### PR TITLE
WYSIWYG bug fixes in rendering

### DIFF
--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -3,6 +3,13 @@
  * Runs after mkdocs-live-edit-plugin. Uses MutationObserver to detect when
  * the .live-edit-source textarea appears, then replaces it with the WYSIWYG editor.
  * Patches the editor to support MkDocs admonitions (!!! note) in HTML mode.
+ * Patches PRE/code block handling to prevent text loss when contenteditable
+ * splits blocks (e.g. DIV children) during editing before switching to markdown mode.
+ * Patches _htmlToMarkdown to preserve extra newlines inside code blocks when collapsing
+ * multiple blank lines in the final output.
+ * Patches text node handling to preserve multiple spaces (e.g. "Foo.  Bar", leading spaces).
+ * Uses a preprocessor/postprocessor to preserve all markdown link styles (inline, reference,
+ * shortcut) exactly as the original author intended when loading, saving, and switching modes.
  */
 (function () {
   if (typeof MarkdownWYSIWYG === 'undefined') {
@@ -15,6 +22,35 @@
     var orig = proto._nodeToMarkdownRecursive;
     if (!orig) return;
     proto._nodeToMarkdownRecursive = function (node, options) {
+      // #text: preserve multiple spaces (upstream collapses with /  +/g)
+      if (node.nodeName === '#text') {
+        var text = node.textContent;
+        if (options && options.inTableCell) {
+          text = text.replace(/\|/g, '\\|');
+          if (!this._findParentElement(node, 'PRE') && !this._findParentElement(node, 'CODE')) {
+            text = text.replace(/\n/g, '<br>');
+          }
+        }
+        return text;
+      }
+      // PRE: robust handling when contenteditable splits code blocks (e.g. DIV children, multiple PRE)
+      if (node.nodeName === 'PRE' && !(options && options.inTableCell)) {
+        var hasSingleCodeChild = node.firstChild && node.firstChild.nodeName === 'CODE' && node.childNodes.length === 1;
+        if (!hasSingleCodeChild) {
+          var parts = [];
+          for (var k = 0; k < node.childNodes.length; k++) {
+            var ch = node.childNodes[k];
+            if (ch.nodeType === 3) parts.push(ch.textContent);
+            else if (ch.nodeType === 1) parts.push(ch.textContent);
+          }
+          var preContent = parts.join('\n');
+          if (preContent.length > 0 && !preContent.endsWith('\n')) preContent += '\n';
+          var codeEl = node.querySelector && node.querySelector('code');
+          var langMatch = codeEl && codeEl.className && codeEl.className.match(/language-(\S+)/);
+          var lang = langMatch ? langMatch[1] : '';
+          return '```' + lang + '\n' + preContent + '```\n\n';
+        }
+      }
       if (node.nodeName === 'DIV' && node.classList && node.classList.contains('admonition')) {
         var type = null;
         var types = ['note', 'warning', 'danger', 'tip', 'hint', 'important', 'caution', 'error', 'attention'];
@@ -42,6 +78,192 @@
         }
       }
       return orig.apply(this, arguments);
+    };
+  })();
+
+  (function patchHtmlToMarkdownPreserveCodeBlockNewlines() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origHtmlToMarkdown = proto._htmlToMarkdown;
+    if (!origHtmlToMarkdown) return;
+    proto._htmlToMarkdown = function (elementOrHtml) {
+      var tempDiv;
+      if (typeof elementOrHtml === 'string') {
+        tempDiv = document.createElement('div');
+        tempDiv.innerHTML = elementOrHtml;
+      } else {
+        tempDiv = elementOrHtml.cloneNode(true);
+      }
+      tempDiv.innerHTML = tempDiv.innerHTML.replace(/\u200B/g, '');
+      var markdown = '';
+      this._normalizeNodes(tempDiv);
+      for (var i = 0; i < tempDiv.childNodes.length; i++) {
+        markdown += this._nodeToMarkdownRecursive(tempDiv.childNodes[i]);
+      }
+      var codeBlockRe = /(```[^\n]*\n[\s\S]*?```)/g;
+      var codeBlocks = [];
+      var placeholderPrefix = '\u0000__CODEBLOCK_';
+      var placeholderSuffix = '__\u0000';
+      var protected_ = markdown.replace(codeBlockRe, function (m) {
+        var idx = codeBlocks.length;
+        codeBlocks.push(m);
+        return placeholderPrefix + idx + placeholderSuffix;
+      });
+      protected_ = protected_.replace(/\n\s*\n\s*\n+/g, '\n\n');
+      protected_ = protected_.replace(/ +\n/g, '\n');
+      for (var j = 0; j < codeBlocks.length; j++) {
+        protected_ = protected_.split(placeholderPrefix + j + placeholderSuffix).join(codeBlocks[j]);
+      }
+      return protected_.trim();
+    };
+  })();
+
+  function normalizeUrl(url) {
+    if (!url || typeof url !== 'string') return '';
+    url = url.replace(/^<|>$/g, '').trim();
+    try {
+      url = decodeURIComponent(url);
+    } catch (e) {}
+    return url.replace(/\/+$/, '') || url;
+  }
+
+  function preprocessMarkdownLinks(markdown) {
+    if (!markdown || typeof markdown !== 'string') {
+      return { linkOriginals: [], refDefinitions: '' };
+    }
+    var linkOriginals = [];
+    var refs = {};
+    var refDefLines = [];
+    var lines = markdown.split('\n');
+    var i, m, refId, url, text;
+
+    for (i = 0; i < lines.length; i++) {
+      m = lines[i].match(/^\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))/);
+      if (m) {
+        refId = m[1];
+        url = (m[2] || m[3] || '').trim();
+        refs[refId.toLowerCase()] = url;
+        refDefLines.push(lines[i]);
+      }
+    }
+    var refDefinitions = refDefLines.length ? refDefLines.join('\n') : '';
+
+    var pos = 0;
+    var inlineLinkRe = /\[([^\]]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+    var inlineImgRe = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+    var fullRefRe = /\[([^\]]*)\]\[([^\]]*)\]/g;
+    var fullImgRefRe = /!\[([^\]]*)\]\[([^\]]*)\]/g;
+    var shortcutRe = /\[([^\]]+)\](?!\s*[(\[])/g;
+    var shortcutImgRe = /!\[([^\]]+)\](?!\s*[(\[])/g;
+    var match, best, bestPos;
+
+    while (pos < markdown.length) {
+      best = null;
+      bestPos = markdown.length;
+
+      inlineLinkRe.lastIndex = pos;
+      match = inlineLinkRe.exec(markdown);
+      if (match && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(match[2]), text: match[1], original: match[0] };
+      }
+
+      inlineImgRe.lastIndex = pos;
+      match = inlineImgRe.exec(markdown);
+      if (match && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(match[2]), text: match[1], original: match[0], isImage: true };
+      }
+
+      fullRefRe.lastIndex = pos;
+      match = fullRefRe.exec(markdown);
+      if (match && refs[match[2].toLowerCase()] && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(refs[match[2].toLowerCase()]), text: match[1], original: match[0] };
+      }
+
+      fullImgRefRe.lastIndex = pos;
+      match = fullImgRefRe.exec(markdown);
+      if (match && refs[match[2].toLowerCase()] && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(refs[match[2].toLowerCase()]), text: match[1], original: match[0], isImage: true };
+      }
+
+      shortcutRe.lastIndex = pos;
+      match = shortcutRe.exec(markdown);
+      if (match && refs[match[1].toLowerCase()] && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(refs[match[1].toLowerCase()]), text: match[1], original: match[0] };
+      }
+
+      shortcutImgRe.lastIndex = pos;
+      match = shortcutImgRe.exec(markdown);
+      if (match && refs[match[1].toLowerCase()] && match.index < bestPos) {
+        bestPos = match.index;
+        best = { url: normalizeUrl(refs[match[1].toLowerCase()]), text: match[1], original: match[0], isImage: true };
+      }
+
+      if (!best) break;
+      linkOriginals.push(best);
+      pos = bestPos + best.original.length;
+    }
+
+    return { linkOriginals: linkOriginals, refDefinitions: refDefinitions };
+  }
+
+  function postprocessMarkdownLinks(markdown, linkData) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    if (!linkData || !linkData.linkOriginals || !linkData.linkOriginals.length) return markdown;
+
+    var linkOriginals = linkData.linkOriginals;
+    var refDefinitions = linkData.refDefinitions || '';
+    var inlineLinkRe = /\[([^\]]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+    var inlineImgRe = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+    var used = [];
+
+    function replaceMatch(match, text, url, isImage) {
+      var cleanUrl = normalizeUrl(url);
+      for (var i = 0; i < linkOriginals.length; i++) {
+        if (!used[i] && linkOriginals[i].url === cleanUrl && linkOriginals[i].text === text && !!linkOriginals[i].isImage === !!isImage) {
+          used[i] = true;
+          return linkOriginals[i].original;
+        }
+      }
+      return match;
+    }
+
+    var result = markdown
+      .replace(inlineLinkRe, function (match, text, url) { return replaceMatch(match, text, url, false); })
+      .replace(inlineImgRe, function (match, text, url) { return replaceMatch(match, text, url, true); });
+
+    if (refDefinitions && result.indexOf(refDefinitions) === -1) {
+      result = result + (result ? '\n\n' : '') + refDefinitions;
+    }
+    return result;
+  }
+
+  (function patchSetValueAndSwitchToModeForLinkPrePost() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origSetValue = proto.setValue;
+    var origSwitchToMode = proto.switchToMode;
+    if (!origSetValue || !origSwitchToMode) return;
+    proto.setValue = function (markdown, isInitialSetup) {
+      if (markdown) this._liveWysiwygLinkData = preprocessMarkdownLinks(markdown);
+      return origSetValue.apply(this, arguments);
+    };
+    proto.switchToMode = function (mode, isInitialSetup) {
+      if (mode === 'wysiwyg' && !isInitialSetup && this.markdownArea && this.markdownArea.value) {
+        this._liveWysiwygLinkData = preprocessMarkdownLinks(this.markdownArea.value);
+      }
+      var result = origSwitchToMode.apply(this, arguments);
+      if (mode === 'markdown' && this._liveWysiwygLinkData) {
+        var md = this.markdownArea.value;
+        var post = postprocessMarkdownLinks(md, this._liveWysiwygLinkData);
+        if (post !== md) {
+          this.markdownArea.value = post;
+          if (this.options && this.options.onUpdate) this.options.onUpdate(this.getValue());
+        }
+      }
+      return result;
     };
   })();
 
@@ -112,6 +334,12 @@
         initialMode: 'wysiwyg',
         showToolbar: true,
         onUpdate: function (markdownContent) {
+          if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygLinkData) {
+            markdownContent = postprocessMarkdownLinks(markdownContent, wysiwygEditor._liveWysiwygLinkData);
+          }
+          if (markdownContent && !markdownContent.endsWith('\n')) {
+            markdownContent = markdownContent + '\n';
+          }
           textarea.value = markdownContent;
         },
       });


### PR DESCRIPTION
The WYSIWYG should try to change as little as possible while giving a rendered view to the author to make changes and save.

Fixes included:

- No longer breaks markdown links when they're external references i.e.  `[text][link]` or `[text_as_link]`.
- No longer breaks documents that have consecutive empty newlines (so a document with multiple newlines before will still have newlines after).
- No longer breaks when there's multiple spaces between words.  Multiple spaces between words are assumed intentional and preserved.