### PR TITLE
Option to autoload WYSIWYG or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A WYSIWYG (What-You-See-Is-What-You-Get) editor for [mkdocs-live-edit-plugin](https://github.com/eddyluten/mkdocs-live-edit-plugin), based on [@celsowm/markdown-wysiwyg](https://www.npmjs.com/package/@celsowm/markdown-wysiwyg).
 
+- :white_check_mark: Non-destructive WYSIWYG editing is a top priority.  Only changes the user makes applies to documents.  If the WYSIWYG makes unrelated changes to documents, then it is likely a bug.
 - :white_check_mark: Dual-mode editing (WYSIWYG and Markdown) with toolbar formatting
 - :white_check_mark: MkDocs admonitions (`!!! note`, `!!! warning`, etc.)
 - :white_check_mark: YAML frontmatter preserved when editing and switching modes
@@ -56,6 +57,8 @@ plugins:
   - live-edit
   - live-wysiwyg:
       article_selector: ".md-content"  # optional, same as mkdocs-live-edit-plugin
+      menu_selector: ".md-content"     # optional, area to add the Enable/Disable Editor button
+      autoload_wysiwyg: true          # optional, if false, start with plain textarea and show "Enable Editor"
 ```
 
 ### Options
@@ -63,6 +66,8 @@ plugins:
 | Option | Type | Default | Description |
 |-------|------|---------|-------------|
 | `article_selector` | string | `null` | CSS selector for the article element where controls appear. Same behavior as mkdocs-live-edit-plugin. Falls back to `[itemprop="articleBody"]`, `div[role="main"]`, or `article` if not specified. |
+| `menu_selector` | string | `null` | CSS selector for the area where the "Enable Editor" / "Disable Editor" button is added. Defaults to `.live-edit-controls` (the live-edit plugin's control bar). The button uses class `live-edit-button` and appears alongside Rename, Delete, New when in edit mode. |
+| `autoload_wysiwyg` | boolean | `true` | If `true`, the WYSIWYG editor loads automatically when entering edit mode. If `false`, the plain textarea is shown initially and the "Enable Editor" button allows switching to WYSIWYG. |
 
 ## MkDocs Theme Support
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: WYSIWYG Test
 plugins:
   - live-edit
-  - live-wysiwyg
+  - live-wysiwyg:
+      menu_selector: ".md-content"  # area for Enable/Disable Editor button
+      autoload_wysiwyg: true         # set to false to start with plain textarea
   - mkdocs-nav-weight

--- a/mkdocs_live_wysiwyg_plugin/admonition.css
+++ b/mkdocs_live_wysiwyg_plugin/admonition.css
@@ -76,3 +76,11 @@
   border-left-color: #5cb85c;
   background-color: #f0fff4;
 }
+
+/* WYSIWYG toggle button icon */
+.live-wysiwyg-btn-icon {
+  width: 1.2em;
+  height: 1.2em;
+  vertical-align: middle;
+  margin-right: 0.25em;
+}

--- a/mkdocs_live_wysiwyg_plugin/wysiwyg.svg
+++ b/mkdocs_live_wysiwyg_plugin/wysiwyg.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
+  <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,4 @@ packages = ["mkdocs_live_wysiwyg_plugin"]
 "mkdocs_live_wysiwyg_plugin/vendor/README.md" = "mkdocs_live_wysiwyg_plugin/vendor/README.md"
 "mkdocs_live_wysiwyg_plugin/vendor/LICENSE.marked" = "mkdocs_live_wysiwyg_plugin/vendor/LICENSE.marked"
 "mkdocs_live_wysiwyg_plugin/vendor/LICENSE.editor" = "mkdocs_live_wysiwyg_plugin/vendor/LICENSE.editor"
+"mkdocs_live_wysiwyg_plugin/wysiwyg.svg" = "mkdocs_live_wysiwyg_plugin/wysiwyg.svg"


### PR DESCRIPTION
- A couple of options for autoloading the WYSIWYG.
- The mkdocs-live-edit-plugin menu gets a new option for the user to request enable or disable the plugin.