### PR TITLE
Bug fixing selection and some mode behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,14 @@ Add both plugins to your `mkdocs.yml`. **Important:** `live-edit` must be listed
 plugins:
   - live-edit
   - live-wysiwyg:
-      article_selector: ".md-content"  # optional, same as mkdocs-live-edit-plugin
-      menu_selector: ".md-content"     # optional, area to add the Enable/Disable Editor button
-      autoload_wysiwyg: true          # optional, if false, start with plain textarea and show "Enable Editor"
+      autoload_wysiwyg: true # optional, if false, start with plain textarea and show "Enable Editor"
 ```
 
 ### Options
 
 | Option | Type | Default | Description |
 |-------|------|---------|-------------|
-| `article_selector` | string | `null` | CSS selector for the article element where controls appear. Same behavior as mkdocs-live-edit-plugin. Falls back to `[itemprop="articleBody"]`, `div[role="main"]`, or `article` if not specified. |
-| `menu_selector` | string | `null` | CSS selector for the area where the "Enable Editor" / "Disable Editor" button is added. Defaults to `.live-edit-controls` (the live-edit plugin's control bar). The button uses class `live-edit-button` and appears alongside Rename, Delete, New when in edit mode. |
-| `autoload_wysiwyg` | boolean | `true` | If `true`, the WYSIWYG editor loads automatically when entering edit mode. If `false`, the plain textarea is shown initially and the "Enable Editor" button allows switching to WYSIWYG. |
+| `autoload_wysiwyg` | boolean | `true` | Default behavior when no user preference cookie exists. If `true`, the WYSIWYG editor loads automatically when entering edit mode. If `false`, the plain textarea is shown initially with an "Enable Editor" button. Once the user explicitly enables or disables the editor, their preference is stored in a cookie and takes priority over this setting. |
 
 ## Attributions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,5 @@ site_name: WYSIWYG Test
 plugins:
   - live-edit
   - live-wysiwyg:
-      menu_selector: ".md-content"  # area for Enable/Disable Editor button
       autoload_wysiwyg: true         # set to false to start with plain textarea
   - mkdocs-nav-weight

--- a/mkdocs_live_wysiwyg_plugin/plugin.py
+++ b/mkdocs_live_wysiwyg_plugin/plugin.py
@@ -18,8 +18,6 @@ class LiveWysiwygPlugin(BasePlugin):
     """
 
     config_scheme = (
-        ("article_selector", config_options.Type(str, default=None)),
-        ("menu_selector", config_options.Type(str, default=None)),
         ("autoload_wysiwyg", config_options.Type(bool, default=True)),
     )
 
@@ -53,16 +51,8 @@ class LiveWysiwygPlugin(BasePlugin):
         with open(admonition_extension_js, "r", encoding="utf-8") as f:
             admonition_extension_script = f.read()
 
-        article_selector = self.config.get("article_selector")
-        menu_selector = self.config.get("menu_selector")
         autoload_wysiwyg = self.config.get("autoload_wysiwyg")
         preamble_parts = []
-        preamble_parts.append(
-            f"const liveWysiwygArticleSelector = {repr(article_selector) if article_selector else 'null'};\n"
-        )
-        preamble_parts.append(
-            f"const liveWysiwygMenuSelector = {repr(menu_selector) if menu_selector else 'null'};\n"
-        )
         preamble_parts.append(
             f"const liveWysiwygAutoload = {str(autoload_wysiwyg).lower()};\n"
         )


### PR DESCRIPTION
- Removed unused and unlikely to be used options from plugin.
- Fixed the local user preference cookie being ignored if plugin option `autoload_wysiwyg: false`.
- Fixed a few rendering issues:
  - If you're in the frontmatter switching from markdown to WYSIWYG, then the first heading doesn't render properly.
  - If selected text spans the frontmatter and switching from markdown to WYSIWYG, then the first heading doesn't render properly.