### PR TITLE
Admonitions fixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,9 @@ title: Example WYSIWYG site
 ---
 # Welcome
 
+!!! warning "Custom Title"
+    Admonitions with custom titles work too.
+
 This is a test page for the mkdocs-live-wysiwyg-plugin.
 
 Click **Edit** above to try the WYSIWYG editor.
@@ -11,7 +14,7 @@ Click **Edit** above to try the WYSIWYG editor.
 
 The WYSIWYG editor supports MkDocs admonitions. In Markdown mode, use:
 
-!!! note
+!!! note "Note"
     This is a note admonition.
 
 !!! warning "Custom Title"
@@ -19,5 +22,7 @@ The WYSIWYG editor supports MkDocs admonitions. In Markdown mode, use:
 
 This shows you what it's like to be awesome!
 
-!!! note
+# Test
+
+!!! danger "Danger"
     This is a note common in mkdocs.


### PR DESCRIPTION
Bug fixes:

- With a document with frontmatter, and a title, and admonition right under the title, AND you place your cursor in the front... switching across markdown and WYSIWYG would cause a heading render issue because a span element was inserted during rendering.  This would cause the heading to still have its literal `#` when rendered in HTML.
- When toggling from WYSIWYG to markdown for an admonition, the HTML to markdown translation would add in the default titles such as `!!!  note "Note"` instead of just `!!! note`.  It no longer does this for all admonitions.
- If the cursor selection is on an admonition itself such as selected `note` of `!!! note`, then the selection would render a bunch of cursor marker junk in the HTML.
  - This was fixed by double rendering `markdown->html->markdown` and then comparing the markdown within the double render.  If the double render makes the markdown look different than it is assumed corrupted and the selection is cleared.  Instead of creating a matching selection when switching to WYSIWYG the cursor is simply moved to the same line in HTML as it was within the plain text markdown.  This will help protect against any general corruption around selecting text and toggling between modes.
- If the user erased the admonition title entirely and toggled multiple times between editor modes, then it would corrupt the admonition with cursor marker junk data.  Cursor marker data is now stripped from admonition titles when it is doing string comparison for rendering.  Toggling editor modes multiple times no longer corrupts the admonition.