### PR TITLE
Support for mkdocs code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A WYSIWYG (What-You-See-Is-What-You-Get) editor for [mkdocs-live-edit-plugin](ht
   - :white_check_mark: YAML frontmatter preserved when editing and switching modes.
   - :white_check_mark: MkDocs admonitions (`!!! note`, `!!! warning`, etc.)
   - :white_check_mark: Markdown link styles preserved (inline, reference, shortcut)
+  - :white_check_mark: Code blocks with WYSIWYG editable titles.
 - :white_check_mark: No external JavaScript; all assets are bundled locally within the mkdocs plugin.
 
 When you click "Edit" in the live-edit plugin, this plugin replaces the plain textarea with a rich WYSIWYG editor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,14 @@ title: Example WYSIWYG site
 
 This is a test page for the mkdocs-live-wysiwyg-plugin.
 
+```yaml title="Preview Example"
+build: techdocs-preview.sh build # (1)
+preview: techdocs-preview.sh # (2)
+```
+
+1. Build the `site`.
+2. Launch a server on `http://127.0.0.1:8000/`.
+
 Click **Edit** above to try the WYSIWYG editor.
 
 ## Admonition Support

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,3 +4,6 @@ plugins:
   - live-wysiwyg:
       autoload_wysiwyg: true         # set to false to start with plain textarea
   - mkdocs-nav-weight
+theme:
+  features:
+    - content.code.annotate

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.css
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.css
@@ -482,3 +482,102 @@
  background-color: #0056b3;
  border-color: #0056b3;
 }
+
+/* Material-style code blocks */
+.md-editable-area .md-code-block {
+ border-radius: 4px;
+ overflow: hidden;
+ margin-bottom: 1em;
+ background-color: #272822;
+ color: #f8f8f2;
+}
+
+.md-editable-area .md-code-block pre {
+ background-color: transparent;
+ color: inherit;
+ margin-bottom: 0;
+ border-radius: 0;
+ position: relative;
+}
+
+.md-editable-area .md-code-title {
+ background-color: #1e1e1e;
+ color: #fff;
+ font-size: 0.8em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ padding: 6px 12px;
+ border-bottom: 1px solid #3d3d3d;
+ outline: none;
+ cursor: text;
+ min-height: 1.2em;
+}
+
+.md-editable-area .md-code-title:focus {
+ border-bottom-color: #007bff;
+}
+
+.md-editable-area .md-code-title:empty[data-placeholder]::before {
+ content: attr(data-placeholder);
+ color: #666;
+ font-style: italic;
+}
+
+.md-editable-area .md-code-lang {
+ background-color: #1e1e1e;
+ color: #888;
+ font-size: 0.7em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ padding: 4px 12px;
+ border-bottom: 1px solid #3d3d3d;
+ user-select: none;
+ -webkit-user-select: none;
+ text-transform: uppercase;
+ letter-spacing: 0.5px;
+ cursor: pointer;
+}
+
+.md-editable-area .md-code-lang:hover {
+ color: #bbb;
+}
+
+.md-editable-area .md-code-line-numbers {
+ position: absolute;
+ left: 0;
+ top: 0;
+ bottom: 0;
+ display: flex;
+ flex-direction: column;
+ padding: 10px 0;
+ text-align: right;
+ user-select: none;
+ -webkit-user-select: none;
+ color: #6e7681;
+ font-size: 0.85em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ border-right: 1px solid #3d3d3d;
+ background-color: rgba(0,0,0,0.15);
+}
+
+.md-editable-area .md-code-line-numbers span {
+ display: block;
+ padding: 0 10px 0 8px;
+ line-height: 1.45;
+ cursor: pointer;
+ min-width: 2.5em;
+}
+
+.md-editable-area .md-code-line-numbers span:hover {
+ color: #f8f8f2;
+ background-color: rgba(255,255,255,0.08);
+}
+
+.md-editable-area .md-code-block pre[data-linenums] code {
+ padding-left: 3.5em;
+}
+
+.md-editable-area .md-code-block pre code {
+ background-color: transparent;
+ color: inherit;
+ display: block;
+ line-height: 1.45;
+}


### PR DESCRIPTION
- Support for mkdocs code blocks: language and titles
- The titles are editable in WYSIWYG.

Some fixes:

- Frontmatter duplication: Clicking markdown mode while in markdown mode repeatedly caused frontmatter duplication.
- Frontmatter destruction: Clicking WYSIWYG mode while in WYSIWYG mode repeadedly cause frontmatter to be discarded.
- Code selection bug when the text being selected was a title attribute (rendered in the WYSIWYG to be editable by the user but caused issues when markers were set for selection detection).  When the markdown selection is within a title="..." attribute on a code fence line, the code now detects this before attempting span marker injection and uses a direct codeTitleSelection path. On the WYSIWYG side, it finds the corresponding md-code-title element, focuses it, and sets the selection at the precise character offsets. This bypasses the regular marker-based approach which had a bug with nested contenteditables (the selection parent was incorrectly attributed to the main editable area).