### PR TITLE
Nested elements, emojis, edit behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A WYSIWYG (What-You-See-Is-What-You-Get) editor for [mkdocs-live-edit-plugin](https://github.com/eddyluten/mkdocs-live-edit-plugin), based on [@celsowm/markdown-wysiwyg](https://www.npmjs.com/package/@celsowm/markdown-wysiwyg).
 
+See [shortcuts and behaviors document](docs/shortcuts.md) for how to edit documents.
+
+
 - :rainbow::sparkles: Author quality of life features
   - :white_check_mark: Non-destructive WYSIWYG editing is a top priority.  `git diff` will show changes the author intended.  No extra mess typically associated with WYSIWYG editors.
   - :white_check_mark: Selected text to edit is the fastest flow.  A small context menu pops up around selected text which enables the author to fix the issue right away.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,24 @@ build: techdocs-preview.sh build # (1)
 preview: techdocs-preview.sh # (2)
 ```
 
-1. Build the `site`.
+Another item
+
+1. Foo
+
+   ```
+   some code
+   ```
+
+   1. Build the `site`.
+
+      ```
+      text content
+      ```
+
+      test
+
+   2. Another
+
 2. Launch a server on `http://127.0.0.1:8000/`.
 
 This code block is 4-space indented.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,106 @@
+# Keyboard Shortcuts and Behaviors
+
+## Edit and Save
+
+- Pressing period (`.`) in read mode (before opening the editor) opens the editor, similar to GitHub's keyboard shortcut.
+- **Ctrl+S** (Windows/Linux) / **Cmd+S** (Mac) saves the document.
+
+## Progressive Select All (Ctrl+A / Cmd+A)
+
+Repeated presses expand the selection through a context-aware hierarchy:
+
+1. Inside a **code block or admonition**: selects all code content (excludes UI elements).
+2. Inside a **code block or admonition**: selects all content and title. **Pressing backspace** will delete the entire admonition or code block in this state.
+3. Inside an **inline code** span: selects the inline code, then the containing paragraph.
+4. On a **paragraph or heading**: selects the full element text.
+5. Expands to all content under the **current section** heading.
+6. Continues expanding up through **parent heading levels** (H4 -> H3 -> H2 -> H1).
+7. Finally selects the **entire document**.
+
+## Code Blocks
+
+- Typing **three backticks** automatically inserts a basic code block.
+- Wrapping a word or set of words with a **pair of backticks** converts it into inline code.
+- **Enter** (3×) at the end of a code block exits onto a new paragraph. Trailing blank lines are removed. Pressing Enter in the middle of code content will never trigger an exit.
+- **Backspace** on a completely empty code block deletes it.
+- **Tab** inserts the configured indent (spaces or tab character) at the cursor.
+- **Lang button** (upper-right) sets the code language. Custom languages are supported—type any name and press Enter.
+- **Gear button** (next to lang) configures auto-indent: toggle on/off, choose spaces or tabs, and set indent size (2, 4, or 8). Settings persist across pages via cookie.
+
+### Advanced Code Blocks (with title)
+
+- **Enter** at the beginning of the title inserts a new paragraph before the code block.
+- **Enter** elsewhere in the title (or on an empty title) moves the cursor into the code body.
+- **Backspace** at the beginning of the title with content is a no-op.
+- **Backspace** on an empty title converts the advanced code block to a basic one (no title or language).
+
+## Admonitions
+
+- **Enter** (3×) at the end of admonition body content exits onto a new paragraph. Trailing empty paragraphs are cleaned up.
+- **Backspace** on an admonition with an empty body deletes the entire admonition.
+- Exiting a list inside an admonition requires only a single enter press to exit the admonition if the list is at the end.
+
+### Admonition Titles
+
+- **Enter** at the beginning of the title inserts a new paragraph before the admonition.
+- **Enter** elsewhere in the title moves the cursor into the admonition body. On an empty title, the default type name is restored (e.g., "Note").
+- **Backspace** at the beginning of the title (with or without content) is a no-op.
+
+## Block Quotes
+
+- **Enter** (3×) at the end of a block quote exits onto a new paragraph.
+- Exiting a list or admonition inside a block quote grants credit—only one more Enter is needed to exit the block quote (if the line is blank).
+- Code blocks and admonitions can be inserted inside block quotes and vice versa (indefinite nesting).
+- Content inside block quotes does not inherit block quote italic/color styling.
+
+## Lists
+
+- **Enter** (2×) on an empty list item at the end of the list exits the list. This works for unordered, ordered, and checklists.
+- Items can be added in the middle of a list without triggering the exit behavior.
+
+## Inline Code
+
+- Clicking the **Inline Code** toolbar button toggles inline code off if the cursor is on existing inline code or the selection spans multiple inline code elements.
+
+## Emoji <img alt="😍" class="emojione" src="[https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/svg/1f60d.svg](https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/svg/1f60d.svg)" title=":heart_eyes:" data-emoji-shortcode=":heart_eyes:">
+
+Emoji shortcodes (e.g. `:heart_eyes:`, `:white_check_mark:`) are rendered as images matching MkDocs output. Unicode emoji already present in the document are preserved as-is.
+
+### Shortcode Completion
+
+- Typing `:` followed by at least **2 characters** opens an autocomplete popup with matching emoji. Continue typing to narrow results.
+- Typing the closing `:` of a valid shortcode (e.g. `:fire:`) immediately converts it to the emoji image.
+- **Arrow Up / Arrow Down** navigates the autocomplete list (the focused item scrolls into view).
+- **Enter** or **Tab** inserts the selected emoji.
+- **Escape** dismisses the autocomplete popup.
+- Clicking an item in the popup inserts that emoji.
+
+### Emoji Picker (Ctrl+Space / Cmd+Space)
+
+- **Ctrl+Space** (Windows/Linux) / **Cmd+Space** (Mac) opens the full emoji picker at the cursor position.
+- Type to filter the list by name.
+- **Backspace** removes filter characters; clearing the filter shows all emoji again.
+- **Arrow Up / Arrow Down**, **Enter / Tab**, **Escape**, and click work the same as shortcode completion.
+- If a trailing `:` is present before the cursor (e.g. after typing a colon and then pressing Ctrl+Space), inserting an emoji replaces the colon.
+- The picker is disabled inside code blocks.
+
+### Rendering
+
+- Shortcodes are rendered as `<img>` tags using the Emojione CDN, matching the MkDocs pymdownx.emoji output:
+
+  ```html
+  <img alt="😍" class="emojione" src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/svg/1f60d.svg" title=":heart_eyes:">
+  ```
+
+- Shortcodes inside fenced code blocks, inline code, and `<pre>` / `<code>` elements are not converted.
+- Unicode emoji in the original markdown are left untouched—they are not converted to shortcodes or images and will round-trip through the editor without creating a git diff.
+
+### Mode Switching
+
+- Switching from **WYSIWYG → Markdown** converts emoji images back to their `:shortcode:` text.
+- Switching from **Markdown → WYSIWYG** converts `:shortcode:` text back to emoji images.
+- Selection is preserved across mode switches: selecting an emoji image in WYSIWYG selects the corresponding `:shortcode:` in markdown, and vice versa.
+
+### Read-Mode Selection
+
+- Selecting an emoji in read mode and entering the editor will select the corresponding `:shortcode:` in markdown mode or the emoji image in WYSIWYG mode.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,7 @@ plugins:
 theme:
   features:
     - content.code.annotate
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -78,7 +78,7 @@
     var prevLi = li.previousElementSibling;
     var prevChecked = false;
     if (prevLi && prevLi.nodeName === 'LI') {
-      var prevCb = prevLi.querySelector('input[type="checkbox"]');
+      var prevCb = getDirectCheckboxOfLi(prevLi);
       if (prevCb) prevChecked = prevCb.checked;
     }
     var cb = document.createElement('input');
@@ -108,7 +108,7 @@
     var savedNode = range.startContainer;
     var savedOffset = range.startOffset;
 
-    var space = document.createTextNode('\u00a0');
+    var space = document.createTextNode('\u00a0 ');
     li.insertBefore(space, li.firstChild);
     li.insertBefore(cb, space);
 
@@ -117,16 +117,41 @@
     var newRange = document.createRange();
     try {
       if (cursorBeforeCb) {
-        newRange.setStartAfter(space);
+        newRange.setStart(space, 2);
       } else {
         newRange.setStart(savedNode, savedOffset);
       }
     } catch (ex) {
-      newRange.setStartAfter(space);
+      newRange.setStart(space, 2);
     }
     newRange.collapse(true);
     sel.removeAllRanges();
     sel.addRange(newRange);
+  }
+
+  /**
+   * Fix malformed nested lists: when indent creates UL/OL as sibling of LI instead of
+   * child, move the list into the previous LI so markdown indentation persists.
+   */
+  function fixMalformedNestedLists(editableArea) {
+    if (!editableArea) return;
+    var changed;
+    do {
+      changed = false;
+      var lists = editableArea.querySelectorAll('ul, ol');
+      for (var i = 0; i < lists.length; i++) {
+        var list = lists[i];
+        var parent = list.parentNode;
+        if (!parent || (parent.nodeName !== 'UL' && parent.nodeName !== 'OL')) continue;
+        var prev = list.previousSibling;
+        while (prev && prev.nodeType !== 1) prev = prev.previousSibling;
+        if (prev && prev.nodeName === 'LI') {
+          prev.appendChild(list);
+          changed = true;
+          break;
+        }
+      }
+    } while (changed);
   }
 
   /**
@@ -163,6 +188,372 @@
         checkbox.addEventListener('mousedown', onCheckboxMouseDown, true);
         checkbox.addEventListener('click', onCheckboxClick, true);
       })(cb);
+    }
+  }
+
+  var CODE_LANG_LIST = [
+    'python', 'javascript', 'typescript', 'java', 'c', 'cpp', 'csharp',
+    'go', 'rust', 'ruby', 'php', 'swift', 'kotlin', 'scala', 'bash',
+    'shell', 'sql', 'html', 'css', 'json', 'yaml', 'xml', 'markdown',
+    'dockerfile', 'terraform', 'lua', 'perl', 'r', 'matlab', 'groovy'
+  ];
+
+  var _indentSettingsCache = null;
+  function getIndentSettings() {
+    if (_indentSettingsCache) return _indentSettingsCache;
+    var defaults = { enabled: true, type: 'space', size: 4 };
+    try {
+      var match = document.cookie.match(/(?:^|;\s*)liveWysiwygIndent=([^;]*)/);
+      if (match) {
+        var parsed = JSON.parse(decodeURIComponent(match[1]));
+        defaults.enabled = typeof parsed.enabled === 'boolean' ? parsed.enabled : true;
+        defaults.type = parsed.type === 'tab' ? 'tab' : 'space';
+        defaults.size = [2, 4, 8].indexOf(parsed.size) !== -1 ? parsed.size : 4;
+      }
+    } catch (e) {}
+    _indentSettingsCache = defaults;
+    return defaults;
+  }
+  function setIndentSettings(settings) {
+    _indentSettingsCache = settings;
+    var val = encodeURIComponent(JSON.stringify(settings));
+    document.cookie = 'liveWysiwygIndent=' + val + ';path=/;max-age=31536000;SameSite=Lax';
+  }
+
+  var _activeSettingsDropdown = null;
+  function dismissActiveSettingsDropdown() {
+    if (_activeSettingsDropdown) {
+      if (_activeSettingsDropdown.el.parentNode) _activeSettingsDropdown.el.parentNode.removeChild(_activeSettingsDropdown.el);
+      if (_activeSettingsDropdown.closeHandler) document.removeEventListener('mousedown', _activeSettingsDropdown.closeHandler, true);
+      if (_activeSettingsDropdown.scrollHandler) window.removeEventListener('scroll', _activeSettingsDropdown.scrollHandler, true);
+      _activeSettingsDropdown = null;
+    }
+  }
+
+  var _activeLangDropdown = null;
+
+  function dismissActiveLangDropdown() {
+    if (_activeLangDropdown) {
+      if (_activeLangDropdown.el.parentNode) _activeLangDropdown.el.parentNode.removeChild(_activeLangDropdown.el);
+      if (_activeLangDropdown.closeHandler) document.removeEventListener('mousedown', _activeLangDropdown.closeHandler, true);
+      if (_activeLangDropdown.scrollHandler) window.removeEventListener('scroll', _activeLangDropdown.scrollHandler, true);
+      _activeLangDropdown = null;
+    }
+  }
+
+  function createLangDropdown(anchorBtn, currentLang, onSelect) {
+    dismissActiveLangDropdown();
+    var dropdown = document.createElement('div');
+    dropdown.className = 'md-code-lang-dropdown';
+    dropdown.setAttribute('contenteditable', 'false');
+    var filter = document.createElement('input');
+    filter.className = 'md-code-lang-filter';
+    filter.type = 'text';
+    filter.placeholder = 'Filter...';
+    filter.value = currentLang || '';
+    dropdown.appendChild(filter);
+    var list = document.createElement('div');
+    list.className = 'md-code-lang-list';
+    dropdown.appendChild(list);
+    function render(filterText) {
+      list.innerHTML = '';
+      var ft = (filterText || '').toLowerCase();
+      var langs = CODE_LANG_LIST.filter(function (l) { return !ft || l.indexOf(ft) !== -1; });
+      if (ft && langs.indexOf(ft) === -1 && ft.match(/^[a-z0-9_+#.-]+$/i)) {
+        langs.unshift(ft);
+      }
+      for (var i = 0; i < langs.length; i++) {
+        var item = document.createElement('div');
+        item.className = 'md-code-lang-item';
+        if (langs[i] === currentLang) item.classList.add('md-code-lang-item-active');
+        item.textContent = langs[i];
+        item.setAttribute('data-lang', langs[i]);
+        list.appendChild(item);
+      }
+    }
+    render(filter.value);
+    filter.addEventListener('input', function () { render(filter.value); });
+    function wrappedSelect(chosen) {
+      dismissActiveLangDropdown();
+      onSelect(chosen);
+    }
+    list.addEventListener('mousedown', function (e) {
+      var item = e.target;
+      if (!item.classList || !item.classList.contains('md-code-lang-item')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      wrappedSelect(item.getAttribute('data-lang'));
+    });
+    filter.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        var first = list.querySelector('.md-code-lang-item');
+        if (first) wrappedSelect(first.getAttribute('data-lang'));
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        wrappedSelect(null);
+      }
+    });
+
+    function positionDropdown() {
+      var rect = anchorBtn.getBoundingClientRect();
+      var left = rect.right - 180;
+      if (left < 0) left = rect.left;
+      dropdown.style.top = (rect.bottom + 2) + 'px';
+      dropdown.style.left = left + 'px';
+    }
+
+    document.body.appendChild(dropdown);
+    positionDropdown();
+
+    var closeHandler = function (ev) {
+      if (dropdown.contains(ev.target) || ev.target === anchorBtn) return;
+      dismissActiveLangDropdown();
+    };
+    document.addEventListener('mousedown', closeHandler, true);
+
+    var scrollHandler = function () { positionDropdown(); };
+    window.addEventListener('scroll', scrollHandler, true);
+
+    _activeLangDropdown = { el: dropdown, closeHandler: closeHandler, scrollHandler: scrollHandler };
+
+    return { el: dropdown, focusFilter: function () { requestAnimationFrame(function () { filter.focus(); }); } };
+  }
+
+  function addLangButtonToBasicPre(pre, editableArea) {
+    if (pre.querySelector('.md-code-lang-btn')) return;
+    if (pre.parentNode && pre.parentNode.classList && pre.parentNode.classList.contains('md-code-block')) return;
+    var btn = document.createElement('button');
+    btn.className = 'md-code-lang-btn';
+    btn.setAttribute('contenteditable', 'false');
+    btn.textContent = 'lang';
+    btn.type = 'button';
+    pre.style.position = 'relative';
+    pre.appendChild(btn);
+    btn.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (_activeLangDropdown) return;
+      var dd = createLangDropdown(btn, '', function (chosen) {
+        if (!chosen) return;
+        convertBasicToAdvanced(pre, chosen, editableArea);
+      });
+      dd.focusFilter();
+    });
+    addSettingsButtonToBasicPre(pre);
+  }
+
+  function convertBasicToAdvanced(pre, lang, editableArea) {
+    pre.setAttribute('data-lang', lang);
+    var codeEl = pre.querySelector('code');
+    if (codeEl) codeEl.className = 'language-' + lang;
+    var oldBtn = pre.querySelector('.md-code-lang-btn');
+    if (oldBtn) oldBtn.parentNode.removeChild(oldBtn);
+    var oldDD = pre.querySelector('.md-code-lang-dropdown');
+    if (oldDD) oldDD.parentNode.removeChild(oldDD);
+    var oldSettings = pre.querySelector('.md-code-settings-btn');
+    if (oldSettings) oldSettings.parentNode.removeChild(oldSettings);
+    var oldSettingsDD = pre.querySelector('.md-code-settings-dropdown');
+    if (oldSettingsDD) oldSettingsDD.parentNode.removeChild(oldSettingsDD);
+    enhanceCodeBlocks(editableArea);
+    if (wysiwygEditor && wysiwygEditor._finalizeUpdate) {
+      wysiwygEditor._finalizeUpdate(editableArea.innerHTML);
+    }
+  }
+
+  function addLangButtonToAdvancedBlock(wrapper) {
+    if (wrapper.querySelector('.md-code-lang-btn-advanced')) return;
+    var pre = wrapper.querySelector('pre');
+    if (!pre) return;
+    var currentLang = pre.getAttribute('data-lang') || '';
+    var btn = document.createElement('button');
+    btn.className = 'md-code-lang-btn-advanced';
+    btn.setAttribute('contenteditable', 'false');
+    btn.textContent = currentLang || 'lang';
+    btn.type = 'button';
+    wrapper.style.position = 'relative';
+    wrapper.appendChild(btn);
+    btn.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (_activeLangDropdown) return;
+      var dd = createLangDropdown(btn, pre.getAttribute('data-lang') || '', function (chosen) {
+        if (!chosen) return;
+        pre.setAttribute('data-lang', chosen);
+        var codeEl = pre.querySelector('code');
+        if (codeEl) codeEl.className = 'language-' + chosen;
+        btn.textContent = chosen;
+        var titleBar = wrapper.querySelector('.md-code-title, .md-code-lang');
+        if (titleBar && titleBar.classList.contains('md-code-lang')) {
+          titleBar.textContent = chosen;
+        }
+        if (wysiwygEditor && wysiwygEditor._finalizeUpdate) {
+          var ea = pre.closest('[contenteditable="true"]');
+          if (ea) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+        }
+      });
+      dd.focusFilter();
+    });
+    addSettingsButtonToAdvancedBlock(wrapper);
+  }
+
+  var GEAR_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>';
+
+  function createSettingsDropdown(anchorBtn) {
+    dismissActiveSettingsDropdown();
+    var settings = getIndentSettings();
+    var dropdown = document.createElement('div');
+    dropdown.className = 'md-code-settings-dropdown';
+    dropdown.setAttribute('contenteditable', 'false');
+
+    function buildUI() {
+      dropdown.innerHTML = '';
+      var s = getIndentSettings();
+
+      var row1 = document.createElement('div');
+      row1.className = 'md-code-settings-row';
+      var lbl1 = document.createElement('span');
+      lbl1.className = 'md-code-settings-label';
+      lbl1.textContent = 'Auto-indent';
+      row1.appendChild(lbl1);
+      var toggle = document.createElement('button');
+      toggle.className = 'md-code-settings-toggle' + (s.enabled ? ' active' : '');
+      toggle.type = 'button';
+      toggle.textContent = s.enabled ? 'ON' : 'OFF';
+      toggle.addEventListener('mousedown', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        s.enabled = !s.enabled;
+        setIndentSettings(s);
+        buildUI();
+      });
+      row1.appendChild(toggle);
+      dropdown.appendChild(row1);
+
+      var row2 = document.createElement('div');
+      row2.className = 'md-code-settings-row';
+      var lbl2 = document.createElement('span');
+      lbl2.className = 'md-code-settings-label';
+      lbl2.textContent = 'Type';
+      row2.appendChild(lbl2);
+      var btnGroup1 = document.createElement('div');
+      btnGroup1.className = 'md-code-settings-btn-group';
+      var btnSpaces = document.createElement('button');
+      btnSpaces.type = 'button';
+      btnSpaces.className = 'md-code-settings-opt' + (s.type === 'space' ? ' active' : '');
+      btnSpaces.textContent = 'Spaces';
+      btnSpaces.addEventListener('mousedown', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        s.type = 'space';
+        setIndentSettings(s);
+        buildUI();
+      });
+      btnGroup1.appendChild(btnSpaces);
+      var btnTabs = document.createElement('button');
+      btnTabs.type = 'button';
+      btnTabs.className = 'md-code-settings-opt' + (s.type === 'tab' ? ' active' : '');
+      btnTabs.textContent = 'Tabs';
+      btnTabs.addEventListener('mousedown', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        s.type = 'tab';
+        setIndentSettings(s);
+        buildUI();
+      });
+      btnGroup1.appendChild(btnTabs);
+      row2.appendChild(btnGroup1);
+      dropdown.appendChild(row2);
+
+      if (s.type === 'space') {
+        var row3 = document.createElement('div');
+        row3.className = 'md-code-settings-row';
+        var lbl3 = document.createElement('span');
+        lbl3.className = 'md-code-settings-label';
+        lbl3.textContent = 'Size';
+        row3.appendChild(lbl3);
+        var btnGroup2 = document.createElement('div');
+        btnGroup2.className = 'md-code-settings-btn-group';
+        [2, 4, 8].forEach(function (n) {
+          var b = document.createElement('button');
+          b.type = 'button';
+          b.className = 'md-code-settings-opt' + (s.size === n ? ' active' : '');
+          b.textContent = String(n);
+          b.addEventListener('mousedown', function (ev) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            s.size = n;
+            setIndentSettings(s);
+            buildUI();
+          });
+          btnGroup2.appendChild(b);
+        });
+        row3.appendChild(btnGroup2);
+        dropdown.appendChild(row3);
+      }
+    }
+    buildUI();
+
+    function positionDropdown() {
+      var rect = anchorBtn.getBoundingClientRect();
+      var left = rect.right - 200;
+      if (left < 0) left = rect.left;
+      dropdown.style.top = (rect.bottom + 2) + 'px';
+      dropdown.style.left = left + 'px';
+    }
+    document.body.appendChild(dropdown);
+    positionDropdown();
+
+    var closeHandler = function (ev) {
+      if (dropdown.contains(ev.target) || ev.target === anchorBtn) return;
+      dismissActiveSettingsDropdown();
+    };
+    document.addEventListener('mousedown', closeHandler, true);
+    var scrollHandler = function () { positionDropdown(); };
+    window.addEventListener('scroll', scrollHandler, true);
+    _activeSettingsDropdown = { el: dropdown, closeHandler: closeHandler, scrollHandler: scrollHandler };
+  }
+
+  function addSettingsButtonToBasicPre(pre) {
+    if (pre.querySelector('.md-code-settings-btn')) return;
+    var btn = document.createElement('button');
+    btn.className = 'md-code-settings-btn';
+    btn.setAttribute('contenteditable', 'false');
+    btn.innerHTML = GEAR_SVG;
+    btn.type = 'button';
+    pre.appendChild(btn);
+    btn.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (_activeSettingsDropdown) { dismissActiveSettingsDropdown(); return; }
+      createSettingsDropdown(btn);
+    });
+  }
+
+  function addSettingsButtonToAdvancedBlock(wrapper) {
+    if (wrapper.querySelector('.md-code-settings-btn-advanced')) return;
+    var btn = document.createElement('button');
+    btn.className = 'md-code-settings-btn-advanced';
+    btn.setAttribute('contenteditable', 'false');
+    btn.innerHTML = GEAR_SVG;
+    btn.type = 'button';
+    wrapper.appendChild(btn);
+    btn.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (_activeSettingsDropdown) { dismissActiveSettingsDropdown(); return; }
+      createSettingsDropdown(btn);
+    });
+  }
+
+  function enhanceBasicPreBlocks(editableArea) {
+    if (!editableArea) return;
+    var pres = editableArea.querySelectorAll('pre');
+    for (var i = 0; i < pres.length; i++) {
+      var pre = pres[i];
+      if (pre.parentNode && pre.parentNode.classList && pre.parentNode.classList.contains('md-code-block')) continue;
+      if (pre.hasAttribute('data-title') || pre.hasAttribute('data-linenums') || pre.hasAttribute('data-lang')) continue;
+      addLangButtonToBasicPre(pre, editableArea);
     }
   }
 
@@ -265,6 +656,7 @@
       })(headerBar, pre, lang);
       pre.parentNode.insertBefore(wrapper, pre);
       wrapper.appendChild(pre);
+      addLangButtonToAdvancedBlock(wrapper);
       var linenums = pre.getAttribute('data-linenums');
       if (linenums) {
         var codeEl = pre.querySelector('code');
@@ -310,6 +702,11 @@
         })(gutter, codeEl);
       }
     }
+    enhanceBasicPreBlocks(editableArea);
+    var advancedBlocks = editableArea.querySelectorAll('.md-code-block');
+    for (var j = 0; j < advancedBlocks.length; j++) {
+      addLangButtonToAdvancedBlock(advancedBlocks[j]);
+    }
   }
 
   function createInteractiveCheckbox(checked) {
@@ -340,10 +737,116 @@
     return cb;
   }
 
-  function addCheckboxToLi(li) {
+  /** Get the direct-child checkbox of an LI (not from nested children). */
+  function getDirectCheckboxOfLi(li) {
+    for (var c = li.firstChild; c; c = c.nextSibling) {
+      if (c.nodeName === 'INPUT' && c.type === 'checkbox') return c;
+    }
+    return null;
+  }
+
+  /** Return { node, offset } for the first character of content (first non-whitespace after checkbox). Does not modify DOM. */
+  function getFirstContentPosition(li) {
+    var cb = getDirectCheckboxOfLi(li);
+    if (!cb) return null;
+    function findFirst(node) {
+      if (!node || node === li) return null;
+      if (node.nodeType === 3) {
+        var text = node.textContent || '';
+        for (var i = 0; i < text.length; i++) {
+          var c = text.charAt(i);
+          if (c !== ' ' && c !== '\u00a0' && c !== '\t' && c !== '\n' && c !== '\r') {
+            var code = c.charCodeAt(0);
+            if (code !== 0x200B && code !== 0x200C && code !== 0x200D && code !== 0xFEFF) return { node: node, offset: i };
+          }
+        }
+        return null;
+      }
+      if (node.nodeType === 1) {
+        if (node.nodeName === 'UL' || node.nodeName === 'OL') return null;
+        for (var c = node.firstChild; c; c = c.nextSibling) {
+          var r = findFirst(c);
+          if (r) return r;
+        }
+      }
+      return null;
+    }
+    for (var n = cb.nextSibling; n; n = n.nextSibling) {
+      var r = findFirst(n);
+      if (r) return r;
+    }
+    return getPositionAfterCheckboxSpaces(li);
+  }
+
+  /** Return { node, offset } for position after the space(s) following the checkbox. Does not modify DOM. */
+  function getPositionAfterCheckboxSpaces(li) {
+    var cb = getDirectCheckboxOfLi(li);
+    if (!cb) return null;
+    var n = cb.nextSibling;
+    var totalLen = 0;
+    var lastNode = null;
+    var lastOffset = 0;
+    while (n && n.nodeType === 3 && /^[\s ]*$/.test(n.textContent)) {
+      lastNode = n;
+      lastOffset = n.textContent.length;
+      totalLen += n.textContent.length;
+      n = n.nextSibling;
+    }
+    if (!lastNode) return null;
+    var pos = 0;
+    n = cb.nextSibling;
+    while (n && n.nodeType === 3 && /^[\s\u00a0]*$/.test(n.textContent)) {
+      var len = (n.textContent || '').length;
+      if (pos + len >= 2) return { node: n, offset: 2 - pos };
+      pos += len;
+      n = n.nextSibling;
+    }
+    return { node: lastNode, offset: lastOffset };
+  }
+
+  /** Return { node, offset } for the last character of content before any nested UL/OL. */
+  function getLastContentPositionBeforeNestedList(li) {
+    var cb = getDirectCheckboxOfLi(li);
+    if (!cb) return null;
+    function findLast(node) {
+      if (!node || node === li) return null;
+      if (node.nodeType === 3) {
+        var len = (node.textContent || '').length;
+        return len > 0 ? { node: node, offset: len } : null;
+      }
+      if (node.nodeType === 1) {
+        if (node.nodeName === 'UL' || node.nodeName === 'OL') return null;
+        var last = null;
+        for (var c = node.lastChild; c; c = c.previousSibling) {
+          var r = findLast(c);
+          if (r) return r;
+        }
+      }
+      return null;
+    }
+    var lastPos = null;
+    for (var n = cb.nextSibling; n; n = n.nextSibling) {
+      if (n.nodeType === 1 && (n.nodeName === 'UL' || n.nodeName === 'OL')) break;
+      var r = findLast(n);
+      if (r) lastPos = r;
+    }
+    return lastPos || getPositionAfterCheckboxSpaces(li);
+  }
+
+  /** Return the last (deepest) LI in the subtree, for visual order traversal. */
+  function getLastLeafLi(li) {
+    var nested = null;
+    for (var c = li.firstChild; c; c = c.nextSibling) {
+      if (c.nodeName === 'UL' || c.nodeName === 'OL') { nested = c; break; }
+    }
+    if (!nested || !nested.lastElementChild || nested.lastElementChild.nodeName !== 'LI') return li;
+    return getLastLeafLi(nested.lastElementChild);
+  }
+
+  function addCheckboxToLi(li, checked) {
     if (li.querySelector('input[type="checkbox"]')) return;
-    var cb = createInteractiveCheckbox(false);
-    var space = document.createTextNode('\u00a0');
+    var cb = createInteractiveCheckbox(checked === undefined ? false : !!checked);
+    var space = document.createTextNode('\u00a0 ');
     li.insertBefore(space, li.firstChild);
     li.insertBefore(cb, space);
   }
@@ -375,16 +878,19 @@
           ul = ul.parentNode;
         }
         if (ul && ul.nodeName === 'UL') {
-          var hasCheckbox = ul.querySelector('li > input[type="checkbox"]');
-          if (hasCheckbox) {
-            var lis = ul.children;
-            for (var i = 0; i < lis.length; i++) {
-              if (lis[i].nodeName === 'LI') removeCheckboxFromLi(lis[i]);
+          var hasCheckbox = false;
+          for (var i = 0; i < ul.children.length; i++) {
+            var li = ul.children[i];
+            if (li.nodeName === 'LI') {
+              var cb = li.querySelector('input[type="checkbox"]');
+              if (cb && cb.parentNode === li) { hasCheckbox = true; break; }
             }
-          } else {
-            var lis = ul.children;
-            for (var i = 0; i < lis.length; i++) {
-              if (lis[i].nodeName === 'LI') addCheckboxToLi(lis[i]);
+          }
+          var lis = ul.children;
+          for (var i = 0; i < lis.length; i++) {
+            if (lis[i].nodeName === 'LI') {
+              if (hasCheckbox) removeCheckboxFromLi(lis[i]);
+              else addCheckboxToLi(lis[i]);
             }
           }
         } else {
@@ -474,19 +980,49 @@
     if (origWysiwygActive) {
       proto._updateWysiwygToolbarActiveStates = function () {
         origWysiwygActive.apply(this, arguments);
-        var btn = this.toolbar && this.toolbar.querySelector('.md-toolbar-button-checklist');
-        if (!btn) return;
-        btn.classList.remove('active');
         var sel = window.getSelection();
-        if (!sel || sel.rangeCount === 0) return;
-        var node = sel.getRangeAt(0).commonAncestorContainer;
-        if (node.nodeType === 3) node = node.parentNode;
-        while (node && node !== this.editableArea) {
-          if (node.nodeName === 'UL') break;
-          node = node.parentNode;
+
+        var checklistBtn = this.toolbar && this.toolbar.querySelector('.md-toolbar-button-checklist');
+        if (checklistBtn) {
+          checklistBtn.classList.remove('active');
+          if (sel && sel.rangeCount > 0) {
+            var node = sel.getRangeAt(0).commonAncestorContainer;
+            if (node.nodeType === 3) node = node.parentNode;
+            while (node && node !== this.editableArea) {
+              if (node.nodeName === 'UL') break;
+              node = node.parentNode;
+            }
+            if (node && node.nodeName === 'UL') {
+              var hasDirectCheckbox = false;
+              for (var k = 0; k < node.children.length; k++) {
+                var li = node.children[k];
+                if (li.nodeName === 'LI') {
+                  var cb = li.querySelector('input[type="checkbox"]');
+                  if (cb && cb.parentNode === li) { hasDirectCheckbox = true; break; }
+                }
+              }
+              if (hasDirectCheckbox) checklistBtn.classList.add('active');
+            }
+          }
         }
-        if (node && node.nodeName === 'UL' && node.querySelector('li > input[type="checkbox"]')) {
-          btn.classList.add('active');
+
+        var hBtn = this.headingButton;
+        if (hBtn) {
+          if (!hBtn._originalIcon) hBtn._originalIcon = hBtn.innerHTML;
+          var headingTag = null;
+          if (sel && sel.rangeCount > 0) {
+            var el = sel.getRangeAt(0).commonAncestorContainer;
+            if (el.nodeType === 3) el = el.parentNode;
+            while (el && el !== this.editableArea) {
+              if (/^H[1-6]$/.test(el.nodeName)) { headingTag = el.nodeName; break; }
+              el = el.parentNode;
+            }
+          }
+          if (headingTag) {
+            hBtn.textContent = headingTag;
+          } else {
+            hBtn.innerHTML = hBtn._originalIcon;
+          }
         }
       };
     }
@@ -508,6 +1044,47 @@
         if (/^\s*[-*+]\s+\[[ xX]\]/.test(line)) {
           btn.classList.add('active');
         }
+      };
+    }
+
+    var origHandleToolbarClick = proto._handleToolbarClick;
+    if (origHandleToolbarClick) {
+      proto._handleToolbarClick = function (buttonConfig, buttonElement) {
+        if (buttonConfig.id === 'ol' && this.currentMode === 'wysiwyg') {
+          var sel = window.getSelection();
+          if (sel && sel.rangeCount > 0) {
+            var node = sel.getRangeAt(0).commonAncestorContainer;
+            if (node.nodeType === 3) node = node.parentNode;
+            var list = node;
+            while (list && list !== this.editableArea) {
+              if (list.nodeName === 'UL' || list.nodeName === 'OL') break;
+              list = list.parentNode;
+            }
+            if (list && list.nodeName === 'UL') {
+              var hasDirectCheckbox = false;
+              for (var i = 0; i < list.children.length; i++) {
+                var li = list.children[i];
+                if (li.nodeName === 'LI') {
+                  var cb = li.querySelector('input[type="checkbox"]');
+                  if (cb && cb.parentNode === li) { hasDirectCheckbox = true; break; }
+                }
+              }
+              if (hasDirectCheckbox) {
+                this.editableArea.focus();
+                for (var i = 0; i < list.children.length; i++) {
+                  if (list.children[i].nodeName === 'LI') removeCheckboxFromLi(list.children[i]);
+                }
+                var ol = document.createElement('OL');
+                while (list.firstChild) ol.appendChild(list.firstChild);
+                list.parentNode.replaceChild(ol, list);
+                this._finalizeUpdate(this.editableArea.innerHTML);
+                this._updateToolbarActiveStates();
+                return;
+              }
+            }
+          }
+        }
+        origHandleToolbarClick.apply(this, arguments);
       };
     }
   })();
@@ -603,9 +1180,10 @@
     function insertAdmonition(editor, type) {
       var title = type.charAt(0).toUpperCase() + type.slice(1);
       if (editor.currentMode === 'wysiwyg') {
-        editor.editableArea.focus();
+        var ea = editor.editableArea;
+        ea.focus();
         var sel = window.getSelection();
-        if (editor.savedRangeInfo instanceof Range && editor.editableArea.contains(editor.savedRangeInfo.commonAncestorContainer)) {
+        if (editor.savedRangeInfo instanceof Range && ea.contains(editor.savedRangeInfo.commonAncestorContainer)) {
           sel.removeAllRanges();
           sel.addRange(editor.savedRangeInfo);
         }
@@ -621,20 +1199,53 @@
         adDiv.appendChild(bodyP);
         var range = sel && sel.rangeCount > 0 ? sel.getRangeAt(0) : null;
         if (range) {
-          range.collapse(false);
-          range.insertNode(adDiv);
-          var trailing = document.createElement('p');
-          trailing.innerHTML = '<br>';
-          adDiv.parentNode.insertBefore(trailing, adDiv.nextSibling);
+          var block = range.startContainer;
+          if (block.nodeType === 3) block = block.parentNode;
+          while (block && block !== ea && block.parentNode !== ea) {
+            block = block.parentNode;
+          }
+          var insertParent = ea;
+          var targetBlock = null;
+          var bq = block;
+          while (bq && bq !== ea) {
+            if (bq.nodeName === 'BLOCKQUOTE') break;
+            bq = bq.parentNode;
+          }
+          if (bq && bq.nodeName === 'BLOCKQUOTE') {
+            insertParent = bq;
+            var inner = range.startContainer;
+            if (inner.nodeType === 3) inner = inner.parentNode;
+            while (inner && inner !== bq && inner.parentNode !== bq) {
+              inner = inner.parentNode;
+            }
+            if (inner && inner !== bq && inner.parentNode === bq) {
+              targetBlock = inner;
+            }
+          } else if (block && block !== ea && block.parentNode === ea) {
+            targetBlock = block;
+          }
+          if (targetBlock && targetBlock.parentNode === insertParent) {
+            var blockText = (targetBlock.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            var hasContent = blockText.length > 0;
+            if (hasContent) {
+              insertParent.insertBefore(adDiv, targetBlock.nextSibling);
+            } else {
+              insertParent.insertBefore(adDiv, targetBlock);
+              insertParent.removeChild(targetBlock);
+            }
+          } else {
+            range.collapse(false);
+            range.insertNode(adDiv);
+          }
           var newRange = document.createRange();
           newRange.selectNodeContents(bodyP);
           sel.removeAllRanges();
           sel.addRange(newRange);
         } else {
-          editor.editableArea.appendChild(adDiv);
+          ea.appendChild(adDiv);
         }
         editor.savedRangeInfo = null;
-        editor._finalizeUpdate(editor.editableArea.innerHTML);
+        editor._finalizeUpdate(ea.innerHTML);
       } else {
         var textarea = editor.markdownArea;
         var start, end;
@@ -670,6 +1281,267 @@
     };
   })();
 
+  (function patchBlockquoteInAdmonition() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origWrap = proto._wrapSelectionInBlockquote;
+    if (!origWrap) return;
+    proto._wrapSelectionInBlockquote = function () {
+      var ea = this.editableArea;
+      var sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return origWrap.call(this);
+      var range = sel.getRangeAt(0);
+      var node = range.startContainer;
+      if (node.nodeType === 3) node = node.parentNode;
+      var ad = null;
+      var anc = node;
+      while (anc && anc !== ea) {
+        if (anc.classList && anc.classList.contains('admonition')) {
+          ad = anc;
+          break;
+        }
+        anc = anc.parentNode;
+      }
+      if (!ad) return origWrap.call(this);
+      var topBlockFor = function (n, container) {
+        var cur = n;
+        if (cur.nodeType === 3) cur = cur.parentNode;
+        while (cur && cur.parentNode !== container) cur = cur.parentNode;
+        return cur;
+      };
+      var startBlock = topBlockFor(range.startContainer, ad);
+      var endBlock = topBlockFor(range.endContainer, ad);
+      var titleEl = ad.querySelector('.admonition-title');
+      var bodyBlocks = [];
+      for (var i = 0; i < ad.childNodes.length; i++) {
+        var c = ad.childNodes[i];
+        if (c !== titleEl) bodyBlocks.push(c);
+      }
+      var startIdx = bodyBlocks.indexOf(startBlock);
+      var endIdx = bodyBlocks.indexOf(endBlock);
+      if (startIdx === -1) startIdx = 0;
+      if (endIdx === -1) endIdx = startIdx;
+      if (startIdx > endIdx) { var t = startIdx; startIdx = endIdx; endIdx = t; }
+      var blocks = bodyBlocks.slice(startIdx, endIdx + 1);
+      if (blocks.length === 0) return origWrap.call(this);
+      var isEmptyNode = function (n) {
+        if (n.nodeType === 3) return !n.textContent.replace(/[\s\u00a0]/g, '');
+        if (n.nodeName === 'BR') return true;
+        var text = (n.textContent || '').replace(/[\s\u00a0]/g, '');
+        if (!text && !n.querySelector('img, table, hr')) return true;
+        return false;
+      };
+      var filtered = [];
+      for (var i = 0; i < blocks.length; i++) {
+        if (!isEmptyNode(blocks[i])) filtered.push(blocks[i]);
+      }
+      if (filtered.length === 0) return origWrap.call(this);
+      var bq = document.createElement('blockquote');
+      ad.insertBefore(bq, filtered[0]);
+      for (var j = 0; j < blocks.length; j++) {
+        var block = blocks[j];
+        if (filtered.indexOf(block) === -1) {
+          if (block.parentNode) block.parentNode.removeChild(block);
+        } else {
+          if (this._isBlockElement(block)) {
+            bq.appendChild(block);
+          } else {
+            var p = document.createElement('p');
+            p.appendChild(block);
+            bq.appendChild(p);
+          }
+        }
+      }
+      sel.removeAllRanges();
+      var newRange = document.createRange();
+      newRange.selectNodeContents(bq);
+      sel.addRange(newRange);
+      this._finalizeUpdate(ea.innerHTML);
+    };
+  })();
+
+  (function patchInsertCodeBlock() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origInsertCodeBlock = proto._insertCodeBlock;
+    if (!origInsertCodeBlock) return;
+    proto._insertCodeBlock = function () {
+      if (this.currentMode === 'wysiwyg') {
+        var ea = this.editableArea;
+        ea.focus();
+        var selection = window.getSelection();
+        var initialSelectedText = selection ? selection.toString() : '';
+        var pre = document.createElement('pre');
+        var code = document.createElement('code');
+        code.textContent = initialSelectedText || 'code';
+        pre.appendChild(code);
+        if (selection && selection.rangeCount > 0) {
+          var range = selection.getRangeAt(0);
+          var block = range.startContainer;
+          if (block.nodeType === 3) block = block.parentNode;
+          while (block && block !== ea && block.parentNode !== ea) {
+            block = block.parentNode;
+          }
+          var insertParent = ea;
+          var targetBlock = null;
+          var anc = range.startContainer;
+          if (anc.nodeType === 3) anc = anc.parentNode;
+          while (anc && anc !== ea) {
+            var inLi = anc.nodeName === 'LI' && anc.parentNode && (anc.parentNode.nodeName === 'UL' || anc.parentNode.nodeName === 'OL');
+            if ((anc.classList && anc.classList.contains('admonition')) || anc.nodeName === 'BLOCKQUOTE' || inLi) {
+              insertParent = anc;
+              var inner = range.startContainer;
+              if (inner.nodeType === 3) inner = inner.parentNode;
+              while (inner && inner !== anc && inner.parentNode !== anc) {
+                inner = inner.parentNode;
+              }
+              if (inner && inner !== anc && inner.parentNode === anc) {
+                targetBlock = inner;
+              }
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          if (insertParent === ea && block && block !== ea && block.parentNode === ea) {
+            targetBlock = block;
+          }
+          if (targetBlock && targetBlock.parentNode === insertParent) {
+            var blockText = (targetBlock.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            var hasContent = blockText.length > 0;
+            if (hasContent && !initialSelectedText) {
+              insertParent.insertBefore(pre, targetBlock.nextSibling);
+            } else if (hasContent) {
+              range.deleteContents();
+              var blockTextAfter = (targetBlock.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+              if (blockTextAfter.length === 0) {
+                insertParent.insertBefore(pre, targetBlock);
+                insertParent.removeChild(targetBlock);
+              } else {
+                insertParent.insertBefore(pre, targetBlock.nextSibling);
+              }
+            } else {
+              insertParent.insertBefore(pre, targetBlock);
+              insertParent.removeChild(targetBlock);
+            }
+          } else {
+            range.deleteContents();
+            range.insertNode(pre);
+          }
+          var newRange = document.createRange();
+          newRange.selectNodeContents(code);
+          selection.removeAllRanges();
+          selection.addRange(newRange);
+        } else {
+          ea.appendChild(pre);
+        }
+        enhanceBasicPreBlocks(ea);
+        this._finalizeUpdate(ea.innerHTML);
+      } else {
+        origInsertCodeBlock.call(this);
+      }
+    };
+  })();
+
+  (function patchInsertInlineCode() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origInsertInlineCode = proto._insertInlineCode;
+    if (!origInsertInlineCode) return;
+    proto._insertInlineCode = function () {
+      if (this.currentMode !== 'wysiwyg') {
+        origInsertInlineCode.call(this);
+        return;
+      }
+      var ea = this.editableArea;
+      ea.focus();
+      var sel = window.getSelection();
+      if (!sel || !sel.rangeCount) {
+        origInsertInlineCode.call(this);
+        return;
+      }
+
+      var range = sel.getRangeAt(0);
+      var node = range.commonAncestorContainer;
+      if (node.nodeType === 3) node = node.parentNode;
+
+      var codeAncestor = null;
+      var anc = node;
+      while (anc && anc !== ea) {
+        if (anc.nodeName === 'CODE' && (!anc.parentNode || anc.parentNode.nodeName !== 'PRE')) {
+          codeAncestor = anc;
+          break;
+        }
+        anc = anc.parentNode;
+      }
+
+      if (!sel.isCollapsed) {
+        var codeEls = [];
+        var searchRoot = range.commonAncestorContainer;
+        if (searchRoot.nodeType === 3) searchRoot = searchRoot.parentNode;
+        while (searchRoot && searchRoot !== ea && searchRoot.nodeName !== 'CODE') {
+          if (searchRoot.parentNode === ea || searchRoot.parentNode === null) break;
+          searchRoot = searchRoot.parentNode;
+        }
+        if (!searchRoot || searchRoot.nodeName === 'CODE') searchRoot = ea;
+        var codes = searchRoot.querySelectorAll('code');
+        for (var i = 0; i < codes.length; i++) {
+          if (codes[i].parentNode && codes[i].parentNode.nodeName === 'PRE') continue;
+          var codeRange = document.createRange();
+          codeRange.selectNode(codes[i]);
+          var overlaps = range.compareBoundaryPoints(Range.START_TO_END, codeRange) > 0 &&
+                         range.compareBoundaryPoints(Range.END_TO_START, codeRange) < 0;
+          if (overlaps) codeEls.push(codes[i]);
+        }
+        if (codeAncestor && codeEls.indexOf(codeAncestor) === -1) {
+          codeEls.push(codeAncestor);
+        }
+
+        if (codeEls.length > 0) {
+          var firstText = null;
+          var lastText = null;
+          var totalLen = 0;
+          for (var j = 0; j < codeEls.length; j++) {
+            var ce = codeEls[j];
+            var parent = ce.parentNode;
+            var text = ce.textContent;
+            var textNode = document.createTextNode(text);
+            parent.insertBefore(textNode, ce);
+            parent.removeChild(ce);
+            if (!firstText) firstText = textNode;
+            lastText = textNode;
+            totalLen += text.length;
+          }
+          if (firstText && lastText) {
+            var newRange = document.createRange();
+            newRange.setStart(firstText, 0);
+            newRange.setEnd(lastText, lastText.textContent.length);
+            sel.removeAllRanges();
+            sel.addRange(newRange);
+          }
+          if (this._finalizeUpdate) this._finalizeUpdate(ea.innerHTML);
+          return;
+        }
+
+        origInsertInlineCode.call(this);
+        return;
+      }
+
+      if (codeAncestor) {
+        var text = codeAncestor.textContent;
+        var parent = codeAncestor.parentNode;
+        var textNode = document.createTextNode(text);
+        parent.insertBefore(textNode, codeAncestor);
+        parent.removeChild(codeAncestor);
+        var cursorRange = document.createRange();
+        cursorRange.setStart(textNode, 0);
+        cursorRange.setEnd(textNode, text.length);
+        sel.removeAllRanges();
+        sel.addRange(cursorRange);
+        if (this._finalizeUpdate) this._finalizeUpdate(ea.innerHTML);
+        return;
+      }
+
+      origInsertInlineCode.call(this);
+    };
+  })();
+
   (function patchAdmonitionHtmlToMarkdown() {
     var proto = MarkdownWYSIWYG.prototype;
     var orig = proto._nodeToMarkdownRecursive;
@@ -697,6 +1569,7 @@
         for (var ci = 0; ci < node.childNodes.length; ci++) {
           var cn = node.childNodes[ci];
           if (cn.nodeType === 1 && cn.classList && cn.classList.contains('md-code-line-numbers')) continue;
+          if (cn.nodeType === 1 && cn.classList && (cn.classList.contains('md-code-lang-btn') || cn.classList.contains('md-code-lang-dropdown') || cn.classList.contains('md-code-settings-btn') || cn.classList.contains('md-code-settings-btn-advanced'))) continue;
           if (cn.nodeType === 1 && cn.nodeName === 'CODE') { codeChild = cn; effectiveChildren++; }
           else effectiveChildren++;
         }
@@ -722,6 +1595,7 @@
         for (var k = 0; k < node.childNodes.length; k++) {
           var ch = node.childNodes[k];
           if (ch.nodeType === 1 && ch.classList && ch.classList.contains('md-code-line-numbers')) continue;
+          if (ch.nodeType === 1 && ch.classList && (ch.classList.contains('md-code-lang-btn') || ch.classList.contains('md-code-lang-dropdown') || ch.classList.contains('md-code-settings-btn') || ch.classList.contains('md-code-settings-btn-advanced'))) continue;
           if (ch.nodeType === 3) parts.push(ch.textContent);
           else if (ch.nodeType === 1) parts.push(ch.textContent);
         }
@@ -745,7 +1619,11 @@
         return '';
       }
       if (node.nodeName === 'DIV' && node.classList &&
-          (node.classList.contains('md-code-title') || node.classList.contains('md-code-lang') || node.classList.contains('md-code-line-numbers'))) {
+          (node.classList.contains('md-code-title') || node.classList.contains('md-code-lang') || node.classList.contains('md-code-line-numbers') || node.classList.contains('md-code-lang-dropdown'))) {
+        return '';
+      }
+      if (node.nodeName === 'BUTTON' && node.classList &&
+          (node.classList.contains('md-code-lang-btn') || node.classList.contains('md-code-lang-btn-advanced') || node.classList.contains('md-code-settings-btn') || node.classList.contains('md-code-settings-btn-advanced'))) {
         return '';
       }
       if (node.nodeName === 'DIV' && node.classList && node.classList.contains('admonition')) {
@@ -869,6 +1747,18 @@
     };
   })();
 
+  (function patchNodeToMarkdownForCheckbox() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origNodeToMarkdown = proto._nodeToMarkdownRecursive;
+    if (!origNodeToMarkdown) return;
+    proto._nodeToMarkdownRecursive = function (node, options) {
+      if (node.nodeName === 'INPUT' && node.type === 'checkbox') {
+        return (node.checked ? '[x]' : '[ ]');
+      }
+      return origNodeToMarkdown.apply(this, arguments);
+    };
+  })();
+
   (function patchHtmlToMarkdownPreserveCodeBlockNewlines() {
     var proto = MarkdownWYSIWYG.prototype;
     var origHtmlToMarkdown = proto._htmlToMarkdown;
@@ -921,6 +1811,7 @@
       };
       protected_ = cleanBlockquoteTrailing(protected_);
       for (var j = 0; j < codeBlocks.length; j++) {
+        codeBlocks[j] = codeBlocks[j].replace(/[ \t]+$/gm, '');
         protected_ = protected_.split(placeholderPrefix + j + placeholderSuffix).join(codeBlocks[j]);
       }
       return protected_.trim();
@@ -1089,6 +1980,17 @@
             } else {
               var restoredFence = originals[j].openFence;
               var currentFenceLine = lines[openIdx];
+              var currentLangMatch = currentFenceLine.match(/^(?:`{3,}|~{3,})(\S*)/);
+              var origLangMatch = restoredFence.match(/^(?:`{3,}|~{3,})(\S*)/);
+              var currentLang = (currentLangMatch && currentLangMatch[1]) || '';
+              var origLang = (origLangMatch && origLangMatch[1]) || '';
+              if (currentLang !== origLang) {
+                if (origLang) {
+                  restoredFence = restoredFence.replace(/^(`{3,}|~{3,})\S+/, '$1' + currentLang);
+                } else {
+                  restoredFence = restoredFence.replace(/^(`{3,}|~{3,})/, '$1' + currentLang);
+                }
+              }
               var currentTitleMatch = currentFenceLine.match(/title="([^"]*)"/);
               var origTitleMatch = restoredFence.match(/title="([^"]*)"/);
               if (currentTitleMatch && origTitleMatch && currentTitleMatch[1] !== origTitleMatch[1]) {
@@ -2022,6 +2924,14 @@
     return findSelectedTextInContent(markdown, selectedText, contextBefore, contextAfter);
   }
 
+  function emojiToShortcode(emoji) {
+    var map = typeof liveWysiwygEmojiMap !== 'undefined' ? liveWysiwygEmojiMap : {};
+    for (var key in map) {
+      if (map[key] === emoji) return ':' + key + ':';
+    }
+    return null;
+  }
+
   function applyPendingReadModeSelection(editor) {
     if (!pendingReadModeSelection || !pendingReadModeSelection.selectedText) return false;
     var selectedText = pendingReadModeSelection.selectedText;
@@ -2035,8 +2945,14 @@
     var body = parsed.body || '';
     var frontmatterLen = (md || '').length - body.length;
     var pos = findSelectedTextInMarkdown(body, selectedText, contextBefore, contextAfter);
-    if (!pos) return false;
+    if (!pos) {
+      var sc = emojiToShortcode(selectedText);
+      if (sc) {
+        pos = findSelectedTextInMarkdown(body, sc, contextBefore, contextAfter);
+      }
+    }
     if (editor.currentMode === 'markdown') {
+      if (!pos) return false;
       var ma = editor.markdownArea;
       if (!ma) return false;
       var selStart = pos.start + frontmatterLen;
@@ -2054,13 +2970,28 @@
     }
     var ea = editor.editableArea;
     if (!ea) return false;
+    if (!pos) {
+      var imgs = ea.querySelectorAll('img[data-emoji-shortcode]');
+      for (var i = 0; i < imgs.length; i++) {
+        if (imgs[i].alt === selectedText) {
+          var r = document.createRange();
+          r.selectNode(imgs[i]);
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(r);
+          ea.focus();
+          requestAnimationFrame(function () { scrollToCenterCursor(ea, false); });
+          return true;
+        }
+      }
+    }
     var fullText = '';
     var walker = document.createTreeWalker(ea, NodeFilter.SHOW_TEXT, null, false);
     var node;
     while ((node = walker.nextNode())) fullText += node.textContent;
-    var pos = findSelectedTextInContent(fullText, selectedText, contextBefore, contextAfter);
-    if (pos) {
-      setSelectionInEditable(ea, pos.start, pos.end);
+    var pos2 = findSelectedTextInContent(fullText, selectedText, contextBefore, contextAfter);
+    if (pos2) {
+      setSelectionInEditable(ea, pos2.start, pos2.end);
       ea.focus();
       requestAnimationFrame(function () { scrollToCenterCursor(ea, false); });
       return true;
@@ -2554,16 +3485,64 @@
   var selectionEditPopupHideTimer = null;
 
   function findEditModeTrigger() {
-    var candidates = document.querySelectorAll('.live-edit-controls button, .live-edit-controls a, a, button');
+    var controls = document.querySelector('.live-edit-controls');
+    if (!controls) return null;
+    var candidates = controls.querySelectorAll('button, a');
     for (var i = 0; i < candidates.length; i++) {
       var el = candidates[i];
       if (el.closest && el.closest('.live-edit-wysiwyg-wrapper')) continue;
+      if (el.closest && el.closest('.live-wysiwyg-selection-edit-popup')) continue;
       var text = (el.textContent || '').trim();
       if (text.indexOf('Editor') >= 0) continue;
       if (text.indexOf('Edit') >= 0) return el;
       if (el.getAttribute && (el.getAttribute('title') || '').indexOf('Edit') >= 0) return el;
     }
     return null;
+  }
+
+  function getPagePathFromDOM() {
+    var scripts = document.getElementsByTagName('script');
+    for (var i = scripts.length - 1; i >= 0; i--) {
+      var m = (scripts[i].textContent || '').match(/page_path\s*=\s*['"]([^'"]+)['"]/);
+      if (m) return m[1];
+    }
+    return null;
+  }
+
+  var _pendingEditTriggerObserver = null;
+  function clickEditTriggerOrDefer() {
+    cancelPendingEditTrigger();
+    var trigger = findEditModeTrigger();
+    if (trigger) {
+      trigger.click();
+      return;
+    }
+    var path = getPagePathFromDOM();
+    if (path) {
+      window.dispatchEvent(new CustomEvent('live-edit-request-edit', { detail: { path: path } }));
+      return;
+    }
+    _pendingEditTriggerObserver = new MutationObserver(function () {
+      var t = findEditModeTrigger();
+      if (t) {
+        cancelPendingEditTrigger();
+        t.click();
+      } else {
+        var p = getPagePathFromDOM();
+        if (p) {
+          cancelPendingEditTrigger();
+          window.dispatchEvent(new CustomEvent('live-edit-request-edit', { detail: { path: p } }));
+        }
+      }
+    });
+    _pendingEditTriggerObserver.observe(document.body, { childList: true, subtree: true });
+    setTimeout(function () { cancelPendingEditTrigger(); }, 15000);
+  }
+  function cancelPendingEditTrigger() {
+    if (_pendingEditTriggerObserver) {
+      _pendingEditTriggerObserver.disconnect();
+      _pendingEditTriggerObserver = null;
+    }
   }
 
   function ensureSelectionEditPopup() {
@@ -2578,9 +3557,8 @@
       e.preventDefault();
       e.stopPropagation();
       storeSelectionIfReadMode(window.getSelection());
-      var trigger = findEditModeTrigger();
-      if (trigger) trigger.click();
       hideSelectionEditPopup();
+      clickEditTriggerOrDefer();
     });
     document.body.appendChild(selectionEditPopup);
   }
@@ -2652,6 +3630,21 @@
     document.addEventListener('scroll', hideSelectionEditPopup, true);
   }
   captureReadModeSelectionOnChange();
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== '.') return;
+    if (!isInReadMode()) return;
+    var tag = (document.activeElement || document.body).tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+    if (document.activeElement && document.activeElement.isContentEditable) return;
+    if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    storeSelectionIfReadMode(window.getSelection());
+    hideSelectionEditPopup();
+    clickEditTriggerOrDefer();
+  }, true);
 
   function getControlsElement(textarea) {
     var controls = textarea ? textarea.closest('.live-edit-controls') : null;
@@ -2934,6 +3927,7 @@
         ea.dataset.liveWysiwygChecklistInputAttached = '1';
         ea.addEventListener('input', function () {
           ensureChecklistNewItems(ea);
+          fixMalformedNestedLists(ea);
         });
       }
     })();
@@ -2959,25 +3953,224 @@
           var cb = li.querySelector('input[type="checkbox"]');
           if (!cb) return;
 
-          var atStart = false;
-          if (node === li && offset <= 2) {
-            atStart = true;
-          } else if (node.nodeType === 3) {
-            var spacer = cb.nextSibling;
-            if (node === spacer && offset === 0) {
-              atStart = true;
-            } else if (spacer && node === spacer.nextSibling && offset === 0) {
-              atStart = true;
-            }
-          }
-          if (!atStart) return;
+          var posFirst = getFirstContentPosition(li);
+          if (!posFirst) return;
+          var firstRange = document.createRange();
+          firstRange.setStart(posFirst.node, posFirst.offset);
+          firstRange.collapse(true);
+          var cmp = range.compareBoundaryPoints(Range.START_TO_START, firstRange);
+          if (cmp > 0) return;
+          var text = (li.textContent || '').replace(/[​‌‍﻿]/g, '').replace(/[\s ]/g, '');
+          var isEmpty = text.length === 0;
 
           e.preventDefault();
-          removeCheckboxFromLi(li);
+          if (isEmpty) {
+            var list = li.parentNode;
+            var prevLi = li.previousElementSibling;
+            var nextLi = li.nextElementSibling;
+            list.removeChild(li);
+            if (list.childNodes.length === 0 && list.parentNode && list.parentNode.nodeName === 'LI') {
+              list.parentNode.removeChild(list);
+            }
+            var newRange = document.createRange();
+            if (prevLi && prevLi.nodeName === 'LI') {
+              newRange.selectNodeContents(prevLi);
+              newRange.collapse(false);
+            } else if (nextLi && nextLi.nodeName === 'LI') {
+              var nextPos = getFirstContentPosition(nextLi);
+              if (nextPos) {
+                newRange.setStart(nextPos.node, nextPos.offset);
+                newRange.collapse(true);
+              } else {
+                newRange.selectNodeContents(nextLi);
+                newRange.collapse(true);
+              }
+            } else {
+              var p = document.createElement('p');
+              p.innerHTML = '<br>';
+              if (list.nextSibling) {
+                list.parentNode.insertBefore(p, list.nextSibling);
+              } else {
+                list.parentNode.appendChild(p);
+              }
+              list.parentNode.removeChild(list);
+              newRange.setStart(p, 0);
+              newRange.collapse(true);
+            }
+            sel.removeAllRanges();
+            sel.addRange(newRange);
+          } else {
+            removeCheckboxFromLi(li);
+          }
           if (wysiwygEditor._finalizeUpdate) {
             wysiwygEditor._finalizeUpdate(ea.innerHTML);
           }
+        }, true);
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygChecklistCursorNormAttached) {
+        ea.dataset.liveWysiwygChecklistCursorNormAttached = '1';
+        function normalizeChecklistCursor() {
+          if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+          var range = sel.getRangeAt(0);
+          var node = range.startContainer;
+          if (node.nodeType === 3) node = node.parentNode;
+          var li = node;
+          while (li && li !== ea) {
+            if (li.nodeName === 'LI') break;
+            li = li.parentNode;
+          }
+          if (!li || li.nodeName !== 'LI') return;
+          var cb = getDirectCheckboxOfLi(li);
+          if (!cb) return;
+          var pos = getFirstContentPosition(li);
+          if (!pos) return;
+          var firstRange = document.createRange();
+          firstRange.setStart(pos.node, pos.offset);
+          firstRange.collapse(true);
+          var cmp = range.compareBoundaryPoints(Range.START_TO_START, firstRange);
+          if (cmp >= 0) return;
+          var newRange = document.createRange();
+          newRange.setStart(pos.node, pos.offset);
+          newRange.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(newRange);
+        }
+        ea.addEventListener('mouseup', function () {
+          setTimeout(normalizeChecklistCursor, 0);
         });
+        ea.addEventListener('focus', function () {
+          setTimeout(normalizeChecklistCursor, 0);
+        });
+        ea.addEventListener('keydown', function (e) {
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') setTimeout(normalizeChecklistCursor, 0);
+        });
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygChecklistArrowAttached) {
+        ea.dataset.liveWysiwygChecklistArrowAttached = '1';
+        ea.addEventListener('keydown', function (e) {
+          if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+          if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+          var range = sel.getRangeAt(0);
+          var node = range.startContainer;
+          if (node.nodeType === 3) node = node.parentNode;
+          var block = node;
+          while (block && block !== ea) {
+            if (block.nodeName === 'LI' || block.nodeName === 'P' || (block.nodeName.match && block.nodeName.match(/^H[1-6]$/))) break;
+            block = block.parentNode;
+          }
+          if (!block || block === ea) return;
+          if (e.key === 'ArrowLeft') {
+            var atStart = false;
+            var prevBlock = null;
+            var cameFromParent = false;
+            if (block.nodeName === 'LI') {
+              var cb = getDirectCheckboxOfLi(block);
+              if (!cb) return;
+              var pos = getFirstContentPosition(block);
+              if (!pos) return;
+              var firstRange = document.createRange();
+              firstRange.setStart(pos.node, pos.offset);
+              firstRange.collapse(true);
+              var cmp = range.compareBoundaryPoints(Range.START_TO_START, firstRange);
+              if (cmp !== 0) return;
+              atStart = true;
+              var prev = block.previousElementSibling;
+              if (!prev && block.parentNode && (block.parentNode.nodeName === 'UL' || block.parentNode.nodeName === 'OL')) {
+                var listParent = block.parentNode.parentNode;
+                if (listParent && listParent.nodeName === 'LI') {
+                  prev = listParent;
+                  cameFromParent = true;
+                } else {
+                  prev = block.parentNode.previousElementSibling;
+                }
+              }
+              prevBlock = prev;
+              if (prev && (prev.nodeName === 'UL' || prev.nodeName === 'OL') && prev.lastElementChild && prev.lastElementChild.nodeName === 'LI') prevBlock = prev.lastElementChild;
+            } else if (block.nodeName === 'P' || (block.nodeName.match && block.nodeName.match(/^H[1-6]$/))) {
+              var startRange = document.createRange();
+              startRange.selectNodeContents(block);
+              startRange.collapse(true);
+              atStart = range.compareBoundaryPoints(Range.START_TO_START, startRange) === 0;
+              if (!atStart) return;
+              prevBlock = block.previousElementSibling;
+            }
+            if (atStart && prevBlock && (prevBlock.nodeName === 'LI' || prevBlock.nodeName === 'P' || (prevBlock.nodeName.match && prevBlock.nodeName.match(/^H[1-6]$/)))) {
+              e.preventDefault();
+              var newRange = document.createRange();
+              if (prevBlock.nodeName === 'LI' && prevBlock.querySelector('ul, ol')) {
+                if (cameFromParent) {
+                  var lastPos = getLastContentPositionBeforeNestedList(prevBlock);
+                  if (lastPos) {
+                    newRange.setStart(lastPos.node, lastPos.offset);
+                    newRange.collapse(true);
+                  } else {
+                    newRange.selectNodeContents(prevBlock);
+                    newRange.collapse(false);
+                  }
+                } else {
+                  var leaf = getLastLeafLi(prevBlock);
+                  newRange.selectNodeContents(leaf);
+                  newRange.collapse(false);
+                }
+              } else {
+                newRange.selectNodeContents(prevBlock);
+                newRange.collapse(false);
+              }
+              sel.removeAllRanges();
+              sel.addRange(newRange);
+            }
+          } else {
+            var endRange = document.createRange();
+            endRange.selectNodeContents(block);
+            endRange.collapse(false);
+            var atEnd = range.compareBoundaryPoints(Range.START_TO_END, endRange) === 0;
+            var lastBeforeNested = block.nodeName === 'LI' ? getLastContentPositionBeforeNestedList(block) : null;
+            var atEndOfDirectContent = lastBeforeNested && (function() {
+              var r = document.createRange();
+              r.setStart(lastBeforeNested.node, lastBeforeNested.offset);
+              r.collapse(true);
+              return range.compareBoundaryPoints(Range.START_TO_END, r) === 0;
+            })();
+            if (!atEnd && !atEndOfDirectContent) return;
+            var nextLi = null;
+            if (atEndOfDirectContent && block.nodeName === 'LI') {
+              var nested = null;
+            for (var c = block.firstChild; c; c = c.nextSibling) {
+              if (c.nodeName === 'UL' || c.nodeName === 'OL') { nested = c; break; }
+            }
+              if (nested && nested.firstElementChild && nested.firstElementChild.nodeName === 'LI') nextLi = nested.firstElementChild;
+            }
+            if (!nextLi && atEnd) {
+              var next = block.nextElementSibling;
+              if (!next && block.parentNode && (block.parentNode.nodeName === 'UL' || block.parentNode.nodeName === 'OL')) next = block.parentNode.parentNode ? block.parentNode.parentNode.nextElementSibling : null;
+              if (next && next.nodeName === 'LI') nextLi = next;
+              else if (next && (next.nodeName === 'UL' || next.nodeName === 'OL') && next.firstElementChild && next.firstElementChild.nodeName === 'LI') nextLi = next.firstElementChild;
+            }
+            if (nextLi) {
+              var nextPos = getFirstContentPosition(nextLi);
+              if (nextPos) {
+                e.preventDefault();
+                var newRange = document.createRange();
+                newRange.setStart(nextPos.node, nextPos.offset);
+                newRange.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(newRange);
+              }
+            }
+          }
+        }, true);
       }
     })();
 
@@ -2997,7 +4190,7 @@
           if (wysiwygEditor._finalizeUpdate) {
             wysiwygEditor._finalizeUpdate(ea.innerHTML);
           }
-        });
+        }, true);
       }
     })();
 
@@ -3095,7 +4288,2136 @@
       }
     })();
 
-    const observer = new MutationObserver(function () {
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygTripleBacktickAttached) {
+        ea.dataset.liveWysiwygTripleBacktickAttached = '1';
+        ea.addEventListener('input', function (e) {
+          if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+          if (e.inputType !== 'insertText' || e.data !== '`') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+          var anchorNode = sel.anchorNode;
+          var anchorOffset = sel.anchorOffset;
+          if (!anchorNode || anchorNode.nodeType !== 3) return;
+          var anc = anchorNode.parentNode;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === 'PRE' || anc.nodeName === 'CODE') return;
+            anc = anc.parentNode;
+          }
+          var text = anchorNode.textContent;
+          if (anchorOffset < 3) return;
+          var segment = text.substring(anchorOffset - 3, anchorOffset);
+          if (segment !== '```') return;
+          var lineStart = text.lastIndexOf('\n', anchorOffset - 3) + 1;
+          var beforeInLine = text.substring(lineStart, anchorOffset - 3);
+          if (beforeInLine.trim().length > 0) return;
+          e.preventDefault && e.preventDefault();
+          var parentBlock = anchorNode.parentNode;
+          while (parentBlock && parentBlock !== ea && parentBlock.parentNode !== ea) {
+            parentBlock = parentBlock.parentNode;
+          }
+          if (!parentBlock || parentBlock === ea) parentBlock = anchorNode.parentNode;
+          var insertParent = ea;
+          var targetBlock = parentBlock;
+          var anc = anchorNode.parentNode;
+          while (anc && anc !== ea) {
+            var inLi = anc.nodeName === 'LI' && anc.parentNode && (anc.parentNode.nodeName === 'UL' || anc.parentNode.nodeName === 'OL');
+            if ((anc.classList && anc.classList.contains('admonition')) || anc.nodeName === 'BLOCKQUOTE' || inLi) {
+              insertParent = anc;
+              var inner = anchorNode.parentNode;
+              while (inner && inner !== anc && inner.parentNode !== anc) {
+                inner = inner.parentNode;
+              }
+              if (inner && inner !== anc && inner.parentNode === anc) {
+                targetBlock = inner;
+              }
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          var pre = document.createElement('pre');
+          var code = document.createElement('code');
+          code.textContent = '\n';
+          pre.appendChild(code);
+          if (targetBlock && targetBlock.parentNode === insertParent) {
+            insertParent.insertBefore(pre, targetBlock);
+            insertParent.removeChild(targetBlock);
+          } else {
+            ea.appendChild(pre);
+          }
+          enhanceCodeBlocks(ea);
+          enhanceBasicPreBlocks(ea);
+          requestAnimationFrame(function () {
+            var codeEl = pre.querySelector('code') || pre;
+            var textNode = codeEl.firstChild;
+            if (!textNode || textNode.nodeType !== 3) {
+              textNode = document.createTextNode('\n');
+              codeEl.appendChild(textNode);
+            }
+            var range = document.createRange();
+            range.setStart(textNode, 0);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            ea.focus();
+          });
+          if (wysiwygEditor._finalizeUpdate) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          }
+        }, true);
+      }
+
+    (function emojiShortcodeSupport() {
+      var EMOJI_MAP = (typeof liveWysiwygEmojiMap !== "undefined" ? liveWysiwygEmojiMap : {});
+      var shortcodeRe = /:([a-z0-9_+-]+):/g;
+      var EMOJI_KEYS = Object.keys(EMOJI_MAP);
+      var MAX_SUGGESTIONS = 8;
+
+      function getTextBeforeCursor(sel, ea) {
+        if (!sel || !sel.rangeCount) return { text: "", node: null, offset: 0 };
+        var r = sel.getRangeAt(0);
+        var node = r.startContainer;
+        var offset = r.startOffset;
+        if (node.nodeType === 3) {
+          return { text: node.textContent.substring(0, offset), node: node, offset: offset };
+        }
+        return { text: "", node: null, offset: 0 };
+      }
+
+      function replaceRangeWithEmoji(node, startOffset, endOffset, emoji, shortcode) {
+        if (!node || node.nodeType !== 3) return false;
+        var text = node.textContent;
+        var before = text.substring(0, startOffset);
+        var after = text.substring(endOffset);
+        if (!shortcode) {
+          node.textContent = before + emoji + after;
+          return true;
+        }
+        var parent = node.parentNode;
+        if (!parent) return false;
+        var el;
+        if (typeof window.liveWysiwygEmojiToImgHtml === "function") {
+          var tmp = document.createElement("div");
+          tmp.innerHTML = window.liveWysiwygEmojiToImgHtml(shortcode, emoji);
+          el = tmp.firstChild;
+        } else {
+          el = document.createElement("span");
+          el.setAttribute("data-emoji-shortcode", shortcode);
+          el.textContent = emoji;
+        }
+        var beforeNode = document.createTextNode(before);
+        var afterNode = document.createTextNode(after);
+        parent.insertBefore(afterNode, node.nextSibling);
+        parent.insertBefore(el, afterNode);
+        parent.insertBefore(beforeNode, node);
+        parent.removeChild(node);
+        return el;
+      }
+
+      function fuzzyMatch(needle, haystack) {
+        var n = needle.toLowerCase();
+        var h = haystack.toLowerCase();
+        var j = 0;
+        for (var i = 0; i < n.length; i++) {
+          j = h.indexOf(n[i], j);
+          if (j === -1) return false;
+          j++;
+        }
+        return true;
+      }
+      function showEmojiAutocomplete(ea, prefix, anchorRect, onSelect) {
+        var limit = prefix.length === 0 ? EMOJI_KEYS.length : MAX_SUGGESTIONS;
+        var matches = EMOJI_KEYS.filter(function (k) {
+          return prefix.length === 0 || k.indexOf(prefix) >= 0 || fuzzyMatch(prefix, k);
+        }).sort(function (a, b) {
+          if (prefix.length === 0) return 0;
+          var aPrefix = a.indexOf(prefix) === 0 ? 0 : (a.indexOf(prefix) >= 0 ? 100 : 200);
+          var bPrefix = b.indexOf(prefix) === 0 ? 0 : (b.indexOf(prefix) >= 0 ? 100 : 200);
+          if (aPrefix !== bPrefix) return aPrefix - bPrefix;
+          return (a.indexOf(prefix) >= 0 ? a.indexOf(prefix) : 999) - (b.indexOf(prefix) >= 0 ? b.indexOf(prefix) : 999);
+        }).slice(0, limit);
+        if (matches.length === 0 && prefix.length === 0) return null;
+        var pop = document.createElement("div");
+        pop.className = "live-wysiwyg-emoji-autocomplete";
+        pop.style.cssText = "position:fixed;z-index:10000;background:#fff;border:1px solid #ccc;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,0.15);max-height:" + (matches.length > 12 ? "320px" : "240px") + ";overflow-y:auto;font-family:inherit;font-size:14px;";
+        if (matches.length === 0) {
+          var noMatchRow = document.createElement("div");
+          noMatchRow.className = "live-wysiwyg-emoji-no-matches";
+          noMatchRow.style.cssText = "padding:6px 12px;color:#999;";
+          noMatchRow.textContent = "No matches";
+          pop.appendChild(noMatchRow);
+        }
+        matches.forEach(function (key, i) {
+          var row = document.createElement("div");
+          row.className = "live-wysiwyg-emoji-item" + (i === 0 ? " live-wysiwyg-emoji-selected" : "");
+          row.style.cssText = "padding:6px 12px;cursor:pointer;display:flex;align-items:center;gap:8px;white-space:nowrap;";
+          if (i === 0) row.style.background = "#e3f2fd";
+          row.dataset.key = key;
+          row.innerHTML = "<span style=\"font-size:1.2em\">" + EMOJI_MAP[key] + "</span><span style=\"color:#666\">:" + key + ":</span>";
+          row.addEventListener("mouseenter", function () {
+            pop.querySelectorAll(".live-wysiwyg-emoji-selected").forEach(function (el) { el.classList.remove("live-wysiwyg-emoji-selected"); el.style.background = ""; });
+            row.classList.add("live-wysiwyg-emoji-selected");
+            row.style.background = "#e3f2fd";
+          });
+          row.addEventListener("click", function (e) {
+            e.preventDefault();
+            if (pop._closeHandler) document.removeEventListener("mousedown", pop._closeHandler);
+            onSelect(key);
+            if (pop.parentNode) pop.parentNode.removeChild(pop);
+          });
+          pop.appendChild(row);
+        });
+        document.body.appendChild(pop);
+        var rect = anchorRect || { left: 0, bottom: 20 };
+        pop.style.left = rect.left + "px";
+        pop.style.top = (rect.bottom + 4) + "px";
+        var closeHandler = function (e) {
+          if (pop.parentNode && !pop.contains(e.target)) {
+            pop.parentNode.removeChild(pop);
+            document.removeEventListener("mousedown", closeHandler);
+          }
+        };
+        setTimeout(function () { document.addEventListener("mousedown", closeHandler); }, 0);
+        pop._closeHandler = closeHandler;
+        return { pop: pop, matches: matches, onSelect: onSelect };
+      }
+
+      function attachEmojiSupport(ea) {
+        if (!ea || ea.dataset.liveWysiwygEmojiAttached) return;
+        ea.dataset.liveWysiwygEmojiAttached = "1";
+        var autocompleteState = null;
+
+        ea.addEventListener("input", function (e) {
+          if (wysiwygEditor.currentMode !== "wysiwyg") return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+          var anc = sel.anchorNode;
+          if (anc.nodeType === 3) anc = anc.parentNode;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === "PRE" || anc.nodeName === "CODE") return;
+            anc = anc.parentNode;
+          }
+          var info = getTextBeforeCursor(sel, ea);
+          var text = info.text;
+          var node = sel.anchorNode;
+          var offset = sel.anchorOffset;
+          if (node.nodeType !== 3) return;
+
+          var lastColon = text.lastIndexOf(":");
+          if (lastColon >= 0) {
+            var openColon = lastColon > 0 ? text.lastIndexOf(":", lastColon - 1) : -1;
+            var between = openColon >= 0 ? text.substring(openColon + 1, lastColon) : text.substring(lastColon + 1);
+            if (e.inputType === "insertText" && e.data === ":") {
+              var shortcode = between;
+              if (shortcode.indexOf(" ") < 0 && shortcode.indexOf(":") < 0) {
+                var emoji = EMOJI_MAP[shortcode];
+                if (emoji) {
+                  e.preventDefault();
+                  var start = openColon >= 0 ? openColon : lastColon;
+                  replaceRangeWithEmoji(node, start, offset, emoji, ":" + shortcode + ":");
+                  if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+                  return;
+                }
+              }
+            }
+            if (between.length >= 2 && between.indexOf(" ") < 0 && between.indexOf(":") < 0) {
+              var r = node.getBoundingClientRect ? node.getBoundingClientRect() : ea.getBoundingClientRect();
+              var range = sel.getRangeAt(0);
+              try {
+                var cr = range.getBoundingClientRect();
+                if (cr) r = cr;
+              } catch (err) {}
+              var anchorRect = { left: r.left, bottom: r.bottom };
+              if (autocompleteState && autocompleteState.pop.parentNode) {
+                autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+              }
+              autocompleteState = showEmojiAutocomplete(ea, between, anchorRect, function (key) {
+                var emoji = EMOJI_MAP[key];
+                if (emoji) {
+                  var repl = replaceRangeWithEmoji(node, lastColon, offset, emoji, ":" + key + ":");
+                  ea.focus();
+                  sel.removeAllRanges();
+                  var range = document.createRange();
+                  if (repl && repl.nodeType) {
+                    range.setStartAfter(repl);
+                    range.collapse(true);
+                  } else {
+                    range.setStart(node, lastColon + emoji.length);
+                    range.collapse(true);
+                  }
+                  sel.addRange(range);
+                }
+                if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+                autocompleteState = null;
+              });
+            } else if (autocompleteState && autocompleteState.pop.parentNode) {
+              autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+              autocompleteState = null;
+            }
+          }
+        }, true);
+
+        ea.addEventListener("keydown", function (e) {
+          if ((e.ctrlKey || e.metaKey) && e.key === " ") {
+            e.preventDefault();
+            if (wysiwygEditor.currentMode !== "wysiwyg") return;
+            var anc = ea.querySelector("*") || ea;
+            var sel = window.getSelection();
+            if (!sel || !sel.rangeCount) return;
+            var anc2 = sel.anchorNode;
+            if (anc2 && anc2.nodeType === 3) anc2 = anc2.parentNode;
+            while (anc2 && anc2 !== ea) {
+              if (anc2.nodeName === "PRE" || anc2.nodeName === "CODE") return;
+              anc2 = anc2.parentNode;
+            }
+            var r = ea.getBoundingClientRect();
+            try {
+              var cr = sel.getRangeAt(0).getBoundingClientRect();
+              if (cr) r = cr;
+            } catch (err) {}
+            var anchorRect = { left: r.left, bottom: r.bottom };
+            if (autocompleteState && autocompleteState.pop.parentNode) {
+              autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+            }
+            var savedRange = sel.getRangeAt(0).cloneRange();
+            var beforeCursor = getTextBeforeCursor(sel, ea);
+            var removeColonOnly = beforeCursor.text.endsWith(" :") && beforeCursor.node && beforeCursor.node.nodeType === 3 && beforeCursor.offset >= 1;
+            var state = showEmojiAutocomplete(ea, "", anchorRect, function (key) {
+              var emoji = EMOJI_MAP[key];
+              if (emoji) {
+                var node = beforeCursor.node;
+                var insertEnd = beforeCursor.offset;
+                if (removeColonOnly && replaceRangeWithEmoji(node, beforeCursor.offset - 1, beforeCursor.offset, emoji)) {
+                  insertEnd = beforeCursor.offset - 1 + emoji.length;
+                } else {
+                  sel.removeAllRanges();
+                  sel.addRange(savedRange);
+                  var el;
+                  if (typeof window.liveWysiwygEmojiToImgHtml === "function") {
+                    var tmp = document.createElement("div");
+                    tmp.innerHTML = window.liveWysiwygEmojiToImgHtml(":" + key + ":", emoji);
+                    el = tmp.firstChild;
+                  } else {
+                    el = document.createElement("span");
+                    el.setAttribute("data-emoji-shortcode", ":" + key + ":");
+                    el.textContent = emoji;
+                  }
+                  savedRange.deleteContents();
+                  savedRange.insertNode(el);
+                  var r = document.createRange();
+                  r.setStartAfter(el);
+                  r.collapse(true);
+                  node = el.parentNode;
+                  insertEnd = Array.prototype.indexOf.call(node.childNodes, el) + 1;
+                }
+                ea.focus();
+                sel.removeAllRanges();
+                var range = document.createRange();
+                range.setStart(node, insertEnd);
+                range.collapse(true);
+                sel.addRange(range);
+              }
+              if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+              autocompleteState = null;
+            });
+            if (state) {
+              state.ea = ea;
+              state.anchorRect = anchorRect;
+              state.filterPrefix = "";
+              state.openedByCtrlSpace = true;
+            }
+            autocompleteState = state;
+            return;
+          }
+          if (!autocompleteState || !autocompleteState.pop.parentNode) return;
+          if (autocompleteState.openedByCtrlSpace && (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey || e.key === "Backspace")) {
+            e.preventDefault();
+            if (e.key === "Backspace") {
+              autocompleteState.filterPrefix = autocompleteState.filterPrefix.slice(0, -1);
+              if (autocompleteState.filterPrefix.length === 0) {
+                if (autocompleteState.pop._closeHandler) document.removeEventListener("mousedown", autocompleteState.pop._closeHandler);
+                if (autocompleteState.pop.parentNode) autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+                autocompleteState = null;
+                return;
+              }
+            } else {
+              autocompleteState.filterPrefix += e.key;
+            }
+            if (autocompleteState.pop._closeHandler) document.removeEventListener("mousedown", autocompleteState.pop._closeHandler);
+            if (autocompleteState.pop.parentNode) autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+            var newState = showEmojiAutocomplete(autocompleteState.ea, autocompleteState.filterPrefix, autocompleteState.anchorRect, autocompleteState.onSelect);
+            if (newState) {
+              autocompleteState.pop = newState.pop;
+              autocompleteState.matches = newState.matches;
+              setTimeout(function () { document.addEventListener("mousedown", autocompleteState.pop._closeHandler); }, 0);
+            } else {
+              autocompleteState = null;
+            }
+            return;
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            if (autocompleteState.pop._closeHandler) document.removeEventListener("mousedown", autocompleteState.pop._closeHandler);
+            if (autocompleteState.pop.parentNode) autocompleteState.pop.parentNode.removeChild(autocompleteState.pop);
+            autocompleteState = null;
+            return;
+          }
+          if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === "Tab") {
+            var sel = autocompleteState.pop.querySelector(".live-wysiwyg-emoji-selected");
+            var items = autocompleteState.pop.querySelectorAll(".live-wysiwyg-emoji-item");
+            var idx = Array.prototype.indexOf.call(items, sel);
+            if (e.key === "ArrowDown" && idx < items.length - 1) {
+              e.preventDefault();
+              sel.classList.remove("live-wysiwyg-emoji-selected");
+              sel.style.background = "";
+              var next = items[idx + 1];
+              next.classList.add("live-wysiwyg-emoji-selected");
+              next.style.background = "#e3f2fd";
+              next.scrollIntoView({ block: "nearest", behavior: "smooth" });
+              return;
+            }
+            if (e.key === "ArrowUp" && idx > 0) {
+              e.preventDefault();
+              sel.classList.remove("live-wysiwyg-emoji-selected");
+              sel.style.background = "";
+              var prev = items[idx - 1];
+              prev.classList.add("live-wysiwyg-emoji-selected");
+              prev.style.background = "#e3f2fd";
+              prev.scrollIntoView({ block: "nearest", behavior: "smooth" });
+              return;
+            }
+            if ((e.key === "Enter" || e.key === "Tab") && sel) {
+              e.preventDefault();
+              var key = sel.dataset.key;
+              var pop = autocompleteState.pop;
+              var onSelectCb = autocompleteState.onSelect;
+              if (pop._closeHandler) document.removeEventListener("mousedown", pop._closeHandler);
+              if (pop.parentNode) pop.parentNode.removeChild(pop);
+              autocompleteState = null;
+              if (key && onSelectCb) onSelectCb(key);
+            }
+          }
+        }, true);
+      }
+
+      var ea = wysiwygEditor.editableArea;
+      if (ea) attachEmojiSupport(ea);
+    })();
+
+    })();
+
+
+
+    (function patchMarkdownToHtmlShortcodeToEmoji() {
+      var FALLBACK = {"white_check_mark":"\u2705","check_mark":"\u2714","heart_eyes":"\ud83d\ude0d","thumbsup":"\ud83d\udc4d","heart":"\u2764","smile":"\ud83d\ude04","fire":"\ud83d\udd25","star":"\u2b50","warning":"\u26a0","x":"\u274c"};
+      var EMOJI_MAP = (typeof liveWysiwygEmojiMap !== "undefined" && Object.keys(liveWysiwygEmojiMap || {}).length > 0) ? liveWysiwygEmojiMap : FALLBACK;
+      var shortcodeRe = /:([a-z0-9_+-]+):/g;
+      var EMOJIONE_CDN = "https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/svg/";
+      function emojiToEmojionePath(emoji) {
+        var parts = [];
+        for (var i = 0; i < emoji.length; ) {
+          var cp = emoji.codePointAt(i);
+          parts.push(cp.toString(16));
+          i += cp > 0xFFFF ? 2 : 1;
+        }
+        return parts.join("-");
+      }
+      function emojiToImgHtml(shortcode, emoji) {
+        var path = emojiToEmojionePath(emoji);
+        return "<img alt=\"" + emoji + "\" class=\"emojione\" src=\"" + EMOJIONE_CDN + path + ".svg\" title=\"" + shortcode + "\" data-emoji-shortcode=\"" + shortcode + "\">";
+      }
+      if (typeof window !== "undefined") window.liveWysiwygEmojiToImgHtml = emojiToImgHtml;
+      function replaceShortcodeInHtml(html) {
+        var protectedBlocks = [];
+        var ph = "\u0000PB";
+        var protectBlock = function (m) {
+          var idx = protectedBlocks.length;
+          protectedBlocks.push(m);
+          return ph + idx + ph;
+        };
+        var protected_ = html.replace(/<pre[^>]*>[\s\S]*?<\/pre>/gi, protectBlock);
+        protected_ = protected_.replace(/<img[^>]*data-emoji-shortcode[^>]*>/gi, protectBlock);
+        protected_ = protected_.replace(/<code[^>]*>[\s\S]*?<\/code>/gi, protectBlock);
+        protected_ = protected_.replace(shortcodeRe, function (m, key) {
+          var em = EMOJI_MAP[key];
+          return em ? emojiToImgHtml(":" + key + ":", em) : m;
+        });
+        for (var i = 0; i < protectedBlocks.length; i++) {
+          protected_ = protected_.split(ph + i + ph).join(protectedBlocks[i]);
+        }
+        return protected_;
+      }
+      var proto = MarkdownWYSIWYG.prototype;
+      var origMarkdownToHtml = proto._markdownToHtml;
+      if (!origMarkdownToHtml) return;
+      function replaceShortcodeInMarkdown(md) {
+        var codeBlocks = [];
+        var ph = "\u0000CB";
+        var protectBlock = function (m) {
+          var idx = codeBlocks.length;
+          codeBlocks.push(m);
+          return ph + idx + ph;
+        };
+        var protected_ = md.replace(/\`\`\`[\s\S]*?\`\`\`/g, protectBlock);
+        protected_ = protected_.replace(/`[^`\n]+`/g, protectBlock);
+        protected_ = protected_.replace(shortcodeRe, function (m, key) {
+          var em = EMOJI_MAP[key];
+          return em ? emojiToImgHtml(":" + key + ":", em) : m;
+        });
+        for (var i = 0; i < codeBlocks.length; i++) {
+          protected_ = protected_.split(ph + i + ph).join(codeBlocks[i]);
+        }
+        return protected_;
+      }
+      proto._markdownToHtml = function (markdown) {
+        var md = markdown || "";
+        var mdWithEmoji = replaceShortcodeInMarkdown(md);
+        var html = origMarkdownToHtml.call(this, mdWithEmoji);
+        return replaceShortcodeInHtml(html);
+      };
+    })();
+
+
+    (function patchHtmlToMarkdownEmojiToShortcode() {
+      var MARKER = "\uFFFF\uFFFF\uFFFF";
+      var MARKER_END = "\uFFFE\uFFFE\uFFFE";
+      var proto = MarkdownWYSIWYG.prototype;
+      var origNodeToMarkdown = proto._nodeToMarkdownRecursive;
+      if (!origNodeToMarkdown) return;
+      proto._nodeToMarkdownRecursive = function (node, options) {
+        if (node.nodeName === "IMG" && node.getAttribute && node.getAttribute("data-emoji-shortcode")) {
+          return node.getAttribute("data-emoji-shortcode");
+        }
+        if (node.nodeName === "SPAN" && node.getAttribute && node.getAttribute("data-emoji-shortcode")) {
+          var shortcode = node.getAttribute("data-emoji-shortcode");
+          var childContent = "";
+          for (var i = 0; i < node.childNodes.length; i++) {
+            childContent += origNodeToMarkdown.call(this, node.childNodes[i], options || {});
+          }
+          if (childContent.indexOf(MARKER) >= 0 || childContent.indexOf(MARKER_END) >= 0) {
+            var emojiChar = node.textContent.split(MARKER).join("").split(MARKER_END).join("");
+            return childContent.split(emojiChar).join(shortcode);
+          }
+          return shortcode;
+        }
+        return origNodeToMarkdown.apply(this, arguments);
+      };
+    })();
+
+
+    (function patchSwitchToModeSelectionPreservation() {
+      var MARKER = "\uFFFF\uFFFF\uFFFF";
+      var MARKER_END = "\uFFFE\uFFFE\uFFFE";
+      function getPath(node, root) {
+        var path = [];
+        var cur = node;
+        while (cur && cur !== root) {
+          var parent = cur.parentNode;
+          if (!parent) return null;
+          var idx = Array.prototype.indexOf.call(parent.childNodes, cur);
+          path.unshift(idx);
+          cur = parent;
+        }
+        return cur === root ? path : null;
+      }
+      function getNodeByPath(root, path) {
+        var cur = root;
+        for (var i = 0; i < path.length; i++) {
+          cur = cur.childNodes[path[i]];
+          if (!cur) return null;
+        }
+        return cur;
+      }
+      function insertMarkerAtOffset(parent, refNode, offset, markerText) {
+        var markerNode = document.createTextNode(markerText);
+        if (refNode.nodeType === 3) {
+          var before = refNode.textContent.substring(0, offset);
+          var after = refNode.textContent.substring(offset);
+          var beforeNode = document.createTextNode(before);
+          var afterNode = document.createTextNode(after);
+          parent.insertBefore(afterNode, refNode.nextSibling);
+          parent.insertBefore(markerNode, afterNode);
+          parent.insertBefore(beforeNode, refNode);
+          parent.removeChild(refNode);
+        } else if (refNode.nodeType === 1) {
+          refNode.insertBefore(markerNode, refNode.childNodes[offset] || null);
+        }
+      }
+      var proto = MarkdownWYSIWYG.prototype;
+      var origSwitchToMode = proto.switchToMode;
+      if (!origSwitchToMode) return;
+      proto.switchToMode = function (mode, isInitialSetup) {
+        if (this.currentMode === mode && !isInitialSetup) {
+          return origSwitchToMode.apply(this, arguments);
+        }
+        var sel = window.getSelection();
+        var savedMdSel = null;
+        var savedWysiwygRange = null;
+        if (!isInitialSetup && sel && sel.rangeCount > 0) {
+          var r = sel.getRangeAt(0);
+          if (this.currentMode === "wysiwyg" && this.editableArea.contains(r.commonAncestorContainer)) {
+            savedWysiwygRange = r.cloneRange();
+          } else if (this.currentMode === "markdown" && this.markdownArea === document.activeElement) {
+            savedMdSel = { start: this.markdownArea.selectionStart, end: this.markdownArea.selectionEnd };
+          }
+        }
+        origSwitchToMode.apply(this, arguments);
+        if (isInitialSetup || (!savedMdSel && !savedWysiwygRange)) return;
+        if (mode === "markdown" && savedWysiwygRange) {
+          var ea = this.editableArea;
+          var clone = ea.cloneNode(true);
+          var startPath = getPath(savedWysiwygRange.startContainer, ea);
+          var endPath = getPath(savedWysiwygRange.endContainer, ea);
+          if (startPath && endPath) {
+            var endNode = getNodeByPath(clone, endPath);
+            var startNode = getNodeByPath(clone, startPath);
+            if (startNode && endNode) {
+              var startParent = startNode.parentNode;
+              var endParent = endNode.parentNode;
+              var isEmojiSpan = function (n) {
+                return n && n.nodeType === 1 && n.nodeName === "SPAN" && n.getAttribute && n.getAttribute("data-emoji-shortcode");
+              };
+              var isEmojiImg = function (n) {
+                return n && n.nodeType === 1 && n.nodeName === "IMG" && n.getAttribute && n.getAttribute("data-emoji-shortcode");
+              };
+              var sameEmojiSpan = startNode === endNode && startNode.nodeType === 3 && isEmojiSpan(startParent);
+              var sameEmojiImg = startNode === endNode && isEmojiImg(startNode);
+              if (sameEmojiSpan) {
+                var span = startParent;
+                var spanParent = span.parentNode;
+                if (spanParent) {
+                  var markerStart = document.createTextNode(MARKER);
+                  var markerEnd = document.createTextNode(MARKER_END);
+                  spanParent.insertBefore(markerStart, span);
+                  spanParent.insertBefore(markerEnd, span.nextSibling);
+                }
+              } else if (sameEmojiImg) {
+                var imgParent = startNode.parentNode;
+                if (imgParent) {
+                  var markerStart = document.createTextNode(MARKER);
+                  var markerEnd = document.createTextNode(MARKER_END);
+                  imgParent.insertBefore(markerStart, startNode);
+                  imgParent.insertBefore(markerEnd, startNode.nextSibling);
+                }
+              } else {
+                if (endParent) insertMarkerAtOffset(endParent, endNode, savedWysiwygRange.endOffset, MARKER_END);
+                startNode = getNodeByPath(clone, startPath);
+                startParent = startNode ? startNode.parentNode : null;
+                if (startParent) insertMarkerAtOffset(startParent, startNode, savedWysiwygRange.startOffset, MARKER);
+              }
+              var mdWithMarkers = this._htmlToMarkdown(clone);
+              var idx1 = mdWithMarkers.indexOf(MARKER);
+              var idx2 = mdWithMarkers.indexOf(MARKER_END);
+              if (idx1 >= 0 && idx2 >= 0) {
+                var md = this._htmlToMarkdown(ea);
+                this.markdownArea.value = md;
+                this.markdownArea.setSelectionRange(idx1 + MARKER.length, idx2);
+                this.markdownArea.focus();
+                this._updateMarkdownLineNumbers();
+              }
+            }
+          }
+        } else if (mode === "wysiwyg" && savedMdSel) {
+          var md = this.markdownArea.value;
+          var selText = md.substring(savedMdSel.start, savedMdSel.end);
+          var mdWithMarkers = md.substring(0, savedMdSel.start) + MARKER + selText + MARKER_END + md.substring(savedMdSel.end);
+          this.editableArea.innerHTML = this._markdownToHtml(mdWithMarkers);
+          var range = document.createRange();
+          var walker = document.createTreeWalker(this.editableArea, NodeFilter.SHOW_TEXT, null, false);
+          var node;
+          var startPos = null;
+          var endPos = null;
+          while (node = walker.nextNode()) {
+            var idx = node.textContent.indexOf(MARKER);
+            if (idx >= 0 && !startPos) {
+              startPos = { node: node, offset: idx + MARKER.length };
+            }
+            idx = node.textContent.indexOf(MARKER_END);
+            if (idx >= 0 && !endPos) {
+              endPos = { node: node, offset: idx };
+            }
+          }
+          if (startPos && endPos) {
+            range.setStart(startPos.node, startPos.offset);
+            range.setEnd(endPos.node, endPos.offset);
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+          walker = document.createTreeWalker(this.editableArea, NodeFilter.SHOW_TEXT, null, false);
+          while (node = walker.nextNode()) {
+            if (node.textContent.indexOf(MARKER) >= 0) node.textContent = node.textContent.split(MARKER).join("");
+            if (node.textContent.indexOf(MARKER_END) >= 0) node.textContent = node.textContent.split(MARKER_END).join("");
+          }
+          this.editableArea.focus();
+        }
+      };
+    })();
+
+    // Re-render editable area with emoji patches now applied
+    if (wysiwygEditor && wysiwygEditor.editableArea && wysiwygEditor.markdownArea) {
+      var md = wysiwygEditor.markdownArea.value;
+      if (md) {
+        wysiwygEditor.editableArea.innerHTML = wysiwygEditor._markdownToHtml(md);
+      }
+    }
+
+
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygCodeBlockBackspaceAttached) {
+        ea.dataset.liveWysiwygCodeBlockBackspaceAttached = '1';
+        ea.addEventListener('keydown', function (e) {
+          if (e.key !== 'Backspace' && e.key !== 'Delete') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.rangeCount) return;
+          if (!sel.isCollapsed) {
+            var r = sel.getRangeAt(0);
+            var toRemove = [];
+            var allAds = ea.querySelectorAll('.admonition');
+            for (var ai = 0; ai < allAds.length; ai++) {
+              var ad = allAds[ai];
+              if (!r.intersectsNode(ad)) continue;
+              var titleEl = ad.querySelector('.admonition-title');
+              if (!titleEl || !r.intersectsNode(titleEl)) continue;
+              var bodyIntersects = false;
+              for (var bi = 0; bi < ad.childNodes.length; bi++) {
+                var bc = ad.childNodes[bi];
+                if (bc.nodeType === 1 && bc.classList && bc.classList.contains('admonition-title')) continue;
+                if (r.intersectsNode(bc)) { bodyIntersects = true; break; }
+              }
+              if (bodyIntersects) toRemove.push(ad);
+            }
+            var allCodeBlocks = ea.querySelectorAll('.md-code-block');
+            for (var ci = 0; ci < allCodeBlocks.length; ci++) {
+              var cb = allCodeBlocks[ci];
+              if (!r.intersectsNode(cb)) continue;
+              var cbTitle = cb.querySelector('.md-code-title, .md-code-lang');
+              if (!cbTitle || !r.intersectsNode(cbTitle)) continue;
+              var cbPre = cb.querySelector('pre');
+              if (cbPre && r.intersectsNode(cbPre)) toRemove.push(cb);
+            }
+            if (toRemove.length === 0) return;
+            e.preventDefault();
+            var insertionParent = toRemove[0].parentNode;
+            var insertionRef = toRemove[0].nextSibling;
+            for (var ri = 0; ri < toRemove.length; ri++) {
+              var el = toRemove[ri];
+              if (el.parentNode) {
+                if (ri === 0) {
+                  insertionParent = el.parentNode;
+                  insertionRef = el.nextSibling;
+                }
+                el.parentNode.removeChild(el);
+              }
+            }
+            try { r.deleteContents(); } catch (ex) {}
+            var emptyBqs = ea.querySelectorAll('blockquote');
+            for (var qi = emptyBqs.length - 1; qi >= 0; qi--) {
+              var bq = emptyBqs[qi];
+              if (!bq.textContent.replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '') && !bq.querySelector('pre, .md-code-block, .admonition, img')) {
+                bq.parentNode.removeChild(bq);
+              }
+            }
+            var newP = document.createElement('p');
+            newP.innerHTML = '<br>';
+            if (insertionParent && ea.contains(insertionParent)) {
+              if (insertionRef && insertionParent.contains(insertionRef)) {
+                insertionParent.insertBefore(newP, insertionRef);
+              } else {
+                insertionParent.appendChild(newP);
+              }
+            } else {
+              ea.appendChild(newP);
+            }
+            var range = document.createRange();
+            range.setStart(newP, 0);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            if (wysiwygEditor._finalizeUpdate) {
+              wysiwygEditor._finalizeUpdate(ea.innerHTML);
+            }
+            return;
+          }
+          var node = sel.anchorNode;
+          var pre = null;
+          var wrapper = null;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === 'PRE') pre = anc;
+            if (anc.classList && anc.classList.contains('md-code-block')) wrapper = anc;
+            anc = anc.parentNode;
+          }
+          if (!pre) return;
+          var codeEl = pre.querySelector('code') || pre;
+          var content = codeEl.textContent;
+          var blockContainer = wrapper || pre;
+
+          if (content === '' || content === '\n') {
+            e.preventDefault();
+            var nextSib = blockContainer.nextSibling;
+            var parentNode = blockContainer.parentNode;
+            parentNode.removeChild(blockContainer);
+            var p = document.createElement('p');
+            var br = document.createElement('br');
+            p.appendChild(br);
+            if (nextSib) {
+              parentNode.insertBefore(p, nextSib);
+            } else {
+              parentNode.appendChild(p);
+            }
+            var range = document.createRange();
+            range.setStart(p, 0);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            if (wysiwygEditor._finalizeUpdate) {
+              wysiwygEditor._finalizeUpdate(ea.innerHTML);
+            }
+            return;
+          }
+
+        });
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygAdmonitionBackspaceAttached) {
+        ea.dataset.liveWysiwygAdmonitionBackspaceAttached = '1';
+        ea.addEventListener('keydown', function (e) {
+          if (e.key !== 'Backspace') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+          var node = sel.anchorNode;
+          if (node.nodeType === 3) node = node.parentNode;
+          var ad = null;
+          var inTitle = false;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.classList && anc.classList.contains('admonition')) {
+              ad = anc;
+              var titleEl = ad.querySelector('.admonition-title');
+              inTitle = titleEl && (titleEl === node || titleEl.contains(node));
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          if (!ad) return;
+          if (inTitle) {
+            var titleEl = ad.querySelector('.admonition-title');
+            var titleText = (titleEl.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            if (titleText.length === 0) {
+              e.preventDefault();
+              return;
+            }
+            var r = sel.getRangeAt(0);
+            var atStart = false;
+            var sn = r.startContainer;
+            var so = r.startOffset;
+            if (sn === titleEl && so === 0) {
+              atStart = true;
+            } else if (sn.nodeType === 3 && so === 0) {
+              var prev = sn;
+              while (prev && prev !== titleEl) {
+                if (prev.previousSibling) { atStart = false; break; }
+                prev = prev.parentNode;
+                if (prev === titleEl) { atStart = true; break; }
+              }
+            } else if (sn.nodeType === 1 && so === 0 && (sn === titleEl || titleEl.contains(sn))) {
+              var prev = sn;
+              while (prev && prev !== titleEl) {
+                if (prev.previousSibling) { atStart = false; break; }
+                prev = prev.parentNode;
+                if (prev === titleEl) { atStart = true; break; }
+              }
+            }
+            if (atStart) {
+              e.preventDefault();
+            }
+            return;
+          }
+          var bodyContent = '';
+          for (var j = 0; j < ad.childNodes.length; j++) {
+            var c = ad.childNodes[j];
+            if (c.nodeType === 1 && c.classList && c.classList.contains('admonition-title')) continue;
+            bodyContent += (c.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF]/g, '');
+          }
+          bodyContent = bodyContent.replace(/\s/g, '');
+          if (bodyContent.length === 0) {
+            e.preventDefault();
+            var nextSib = ad.nextSibling;
+            var parentNode = ad.parentNode;
+            parentNode.removeChild(ad);
+            var p = document.createElement('p');
+            var br = document.createElement('br');
+            p.appendChild(br);
+            if (nextSib) {
+              parentNode.insertBefore(p, nextSib);
+            } else {
+              parentNode.appendChild(p);
+            }
+            var range = document.createRange();
+            range.setStart(p, 0);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            if (wysiwygEditor._finalizeUpdate) {
+              wysiwygEditor._finalizeUpdate(ea.innerHTML);
+            }
+          }
+        });
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygListEnterExitAttached) {
+        ea.dataset.liveWysiwygListEnterExitAttached = '1';
+        var listConsecutiveEnters = 0;
+        var lastEnterList = null;
+        var stripMarkersList = /[\u200B\u200C\u200D\uFEFF]/g;
+        function isLiEmpty(li) {
+          var t = (li.textContent || '').replace(stripMarkersList, '').replace(/[\s ]/g, '');
+          return t.length === 0;
+        }
+        ea.addEventListener('keydown', function (e) {
+          if (wysiwygEditor.currentMode !== 'wysiwyg' || e.key !== 'Enter') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) {
+            listConsecutiveEnters = 0;
+            lastEnterList = null;
+            return;
+          }
+          var r = sel.getRangeAt(0);
+          var node = r.startContainer;
+          if (node.nodeType === 3) node = node.parentNode;
+          var list = null;
+          var li = null;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === 'LI') li = anc;
+            if (anc.nodeName === 'UL' || anc.nodeName === 'OL') {
+              list = anc;
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          if (!list || !li) {
+            listConsecutiveEnters = 0;
+            lastEnterList = null;
+            return;
+          }
+
+          if (lastEnterList !== list) {
+            listConsecutiveEnters = 0;
+            lastEnterList = list;
+          }
+          if (!isLiEmpty(li)) {
+            listConsecutiveEnters++;
+            if (listConsecutiveEnters < 2) return;
+            return;
+          }
+          listConsecutiveEnters++;
+          if (listConsecutiveEnters < 2) return;
+          var hasLiAfter = false;
+          var nextLi = li.nextSibling;
+          while (nextLi) {
+            if (nextLi.nodeName === 'LI' && !isLiEmpty(nextLi)) {
+              hasLiAfter = true;
+              break;
+            }
+            nextLi = nextLi.nextSibling;
+          }
+          if (hasLiAfter) {
+            listConsecutiveEnters = 0;
+            return;
+          }
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          listConsecutiveEnters = 0;
+          lastEnterList = null;
+          var lis = [];
+          for (var j = 0; j < list.childNodes.length; j++) {
+            if (list.childNodes[j].nodeName === 'LI') lis.push(list.childNodes[j]);
+          }
+          var removed = 0;
+          for (var i = lis.length - 1; i >= 0 && removed < 2; i--) {
+            if (isLiEmpty(lis[i])) {
+              list.removeChild(lis[i]);
+              removed++;
+            } else {
+              break;
+            }
+          }
+          var parentLi = list.parentNode;
+          var isNestedList = parentLi && parentLi.nodeName === 'LI';
+          if (isNestedList) {
+            var parentList = parentLi.parentNode;
+            if (parentList && (parentList.nodeName === 'UL' || parentList.nodeName === 'OL')) {
+              if (list.childNodes.length === 0) {
+                parentLi.removeChild(list);
+              }
+              var newLi = document.createElement('li');
+              var hasCheckbox = false;
+              for (var k = 0; k < parentList.children.length; k++) {
+                var sib = parentList.children[k];
+                if (sib.nodeName === 'LI') {
+                  var cb = sib.querySelector('input[type="checkbox"]');
+                  if (cb && cb.parentNode === sib) { hasCheckbox = true; break; }
+                }
+              }
+              if (hasCheckbox) {
+                var prevCb = getDirectCheckboxOfLi(parentLi);
+                addCheckboxToLi(newLi, prevCb ? prevCb.checked : false);
+              } else newLi.innerHTML = '<br>';
+              var nextSib = parentLi.nextSibling;
+              if (nextSib) {
+                parentList.insertBefore(newLi, nextSib);
+              } else {
+                parentList.appendChild(newLi);
+              }
+              var range = document.createRange();
+              if (hasCheckbox) {
+                var space = newLi.querySelector('input[type="checkbox"]');
+                if (space) space = space.nextSibling;
+                if (space && space.nodeType === 3) range.setStart(space, space.length || 1);
+                else range.setStart(newLi, 0);
+              } else {
+                range.setStart(newLi, 0);
+              }
+              range.collapse(true);
+              sel.removeAllRanges();
+              sel.addRange(range);
+              if (wysiwygEditor._finalizeUpdate) {
+                wysiwygEditor._finalizeUpdate(ea.innerHTML);
+              }
+              return;
+            }
+          }
+          var p = document.createElement('p');
+          p.innerHTML = '<br>';
+          var insertParent, insertBefore;
+          var adFromList = null;
+          if (list.childNodes.length === 0) {
+            var listParent = list.parentNode;
+            var nextSib = list.nextSibling;
+            listParent.removeChild(list);
+            var a = listParent;
+            while (a && a !== ea) {
+              if (a.classList && a.classList.contains('admonition')) { adFromList = a; break; }
+              a = a.parentNode;
+            }
+            if (adFromList && listParent.parentNode === adFromList) {
+              insertParent = adFromList;
+              insertBefore = listParent.nextSibling;
+            } else {
+              insertParent = listParent.parentNode;
+              insertBefore = listParent.nextSibling;
+            }
+          } else {
+            var bodyEl = list.parentNode;
+            var a = bodyEl;
+            while (a && a !== ea) {
+              if (a.classList && a.classList.contains('admonition')) { adFromList = a; break; }
+              a = a.parentNode;
+            }
+            if (adFromList && bodyEl.parentNode === adFromList) {
+              insertParent = adFromList;
+              insertBefore = bodyEl.nextSibling;
+            } else {
+              insertParent = list.parentNode;
+              insertBefore = list.nextSibling;
+            }
+          }
+          if (insertBefore) {
+            insertParent.insertBefore(p, insertBefore);
+          } else {
+            insertParent.appendChild(p);
+          }
+          if (adFromList) {
+            ea.__liveWysiwygAdmonitionEnterCredit = { count: 2, ad: adFromList };
+          }
+          var bqFromList = null;
+          var a = insertParent;
+          while (a && a !== ea) {
+            if (a.nodeName === 'BLOCKQUOTE') { bqFromList = a; break; }
+            a = a.parentNode;
+          }
+          if (bqFromList) {
+            ea.__liveWysiwygBlockquoteEnterCredit = { count: 2, bq: bqFromList };
+          }
+          var range = document.createRange();
+          range.setStart(p, 0);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          if (wysiwygEditor._finalizeUpdate) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          }
+        }, true);
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygAdmonitionEnterExitAttached) {
+        ea.dataset.liveWysiwygAdmonitionEnterExitAttached = '1';
+        var adConsecutiveEnters = 0;
+        var lastEnterAd = null;
+        ea.addEventListener('keydown', function (e) {
+          if (wysiwygEditor.currentMode !== 'wysiwyg' || e.key !== 'Enter') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = null;
+            return;
+          }
+          var node = sel.anchorNode;
+          if (node.nodeType === 3) node = node.parentNode;
+          var ad = null;
+          var inTitle = false;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.classList && anc.classList.contains('admonition')) {
+              ad = anc;
+              var titleEl = ad.querySelector('.admonition-title');
+              inTitle = titleEl && (titleEl === node || titleEl.contains(node));
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          if (!ad) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = null;
+            return;
+          }
+          if (inTitle) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = null;
+            e.preventDefault();
+            var titleEl = ad.querySelector('.admonition-title');
+            var r = sel.getRangeAt(0);
+            var checkRange = document.createRange();
+            checkRange.setStart(titleEl, 0);
+            checkRange.setEnd(r.startContainer, r.startOffset);
+            var atTitleStart = checkRange.toString().length === 0;
+            var titleText = (titleEl.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            if (atTitleStart && titleText.length > 0) {
+              var p = document.createElement('p');
+              p.innerHTML = '<br>';
+              ad.parentNode.insertBefore(p, ad);
+              var range = document.createRange();
+              range.setStart(p, 0);
+              range.collapse(true);
+              sel.removeAllRanges();
+              sel.addRange(range);
+              if (wysiwygEditor._finalizeUpdate) {
+                wysiwygEditor._finalizeUpdate(ea.innerHTML);
+              }
+            } else {
+              if (titleText.length === 0) {
+                var adType = null;
+                var types = ['note', 'warning', 'danger', 'tip', 'hint', 'important', 'caution', 'error', 'attention'];
+                for (var ti = 0; ti < types.length; ti++) {
+                  if (ad.classList.contains(types[ti])) { adType = types[ti]; break; }
+                }
+                if (adType) {
+                  titleEl.textContent = adType.charAt(0).toUpperCase() + adType.slice(1);
+                } else {
+                  titleEl.textContent = 'Note';
+                }
+              }
+              var firstBody = null;
+              for (var ci = 0; ci < ad.childNodes.length; ci++) {
+                var cn = ad.childNodes[ci];
+                if (cn.nodeType === 1 && cn !== titleEl && cn.nodeName !== 'BR') {
+                  firstBody = cn;
+                  break;
+                }
+              }
+              if (!firstBody) {
+                firstBody = document.createElement('p');
+                firstBody.innerHTML = '<br>';
+                ad.appendChild(firstBody);
+              }
+              var range = document.createRange();
+              if (firstBody.firstChild && firstBody.firstChild.nodeType === 3) {
+                range.setStart(firstBody.firstChild, 0);
+              } else {
+                range.setStart(firstBody, 0);
+              }
+              range.collapse(true);
+              sel.removeAllRanges();
+              sel.addRange(range);
+              if (wysiwygEditor._finalizeUpdate) {
+                wysiwygEditor._finalizeUpdate(ea.innerHTML);
+              }
+            }
+            return;
+          }
+          var inListItem = false;
+          var a = node;
+          while (a && a !== ad) {
+            if (a.nodeName === 'LI') { inListItem = true; break; }
+            a = a.parentNode;
+          }
+          if (inListItem) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = null;
+            return;
+          }
+          var directChild = node;
+          while (directChild && directChild.parentNode !== ad) {
+            directChild = directChild.parentNode;
+          }
+          var isBlock = directChild && (directChild.nodeName === 'P' || directChild.nodeName === 'DIV') && (!directChild.classList || !directChild.classList.contains('admonition-title'));
+          if (!isBlock) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = null;
+            return;
+          }
+          var hadCredit = false;
+          var credit = ea.__liveWysiwygAdmonitionEnterCredit;
+          if (credit && credit.ad === ad) {
+            ea.__liveWysiwygAdmonitionEnterCredit = null;
+            var blockTextCheck = (directChild.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            var onlyBr = directChild.childNodes.length === 1 && directChild.firstChild && directChild.firstChild.nodeName === 'BR';
+            var hasContent = blockTextCheck.length > 0 && !onlyBr;
+            if (hasContent) {
+              adConsecutiveEnters = 0;
+              lastEnterAd = ad;
+            } else {
+              adConsecutiveEnters = credit.count;
+              lastEnterAd = ad;
+              hadCredit = true;
+            }
+          } else if (lastEnterAd !== ad) {
+            adConsecutiveEnters = 0;
+            lastEnterAd = ad;
+          }
+          adConsecutiveEnters++;
+          if (adConsecutiveEnters < 3) return;
+          var hasContentAfter = false;
+          var sib = directChild ? directChild.nextSibling : null;
+          while (sib) {
+            if (sib.nodeType === 1) {
+              var sibText = (sib.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+              if (sibText.length > 0) { hasContentAfter = true; break; }
+            } else if (sib.nodeType === 3) {
+              var sibText = (sib.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+              if (sibText.length > 0) { hasContentAfter = true; break; }
+            }
+            sib = sib.nextSibling;
+          }
+          if (hasContentAfter) {
+            adConsecutiveEnters = 0;
+            return;
+          }
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          adConsecutiveEnters = 0;
+          lastEnterAd = null;
+          var stripMarkersAd = /[\u200B\u200C\u200D\uFEFF]/g;
+          function removeTrailingEmptyBlocks(container) {
+            var kids = container.childNodes;
+            for (var i = kids.length - 1; i >= 0; i--) {
+              var k = kids[i];
+              if (k.nodeType !== 1) continue;
+              var tag = k.nodeName;
+              if (tag !== 'P' && tag !== 'DIV') continue;
+              var t = (k.textContent || '').replace(stripMarkersAd, '').replace(/\s/g, '');
+              if (t.length === 0) {
+                container.removeChild(k);
+              } else {
+                break;
+              }
+            }
+          }
+          var bodyEls = [];
+          for (var j = 0; j < ad.childNodes.length; j++) {
+            var c = ad.childNodes[j];
+            if (c.nodeType === 1 && c.classList && c.classList.contains('admonition-title')) continue;
+            removeTrailingEmptyBlocks(c);
+            bodyEls.push(c);
+          }
+          var maxToRemove = hadCredit ? 1 : 999;
+          var removed = 0;
+          while (bodyEls.length > 0 && removed < maxToRemove) {
+            var last = bodyEls[bodyEls.length - 1];
+            var t = (last.textContent || '').replace(stripMarkersAd, '').replace(/\s/g, '');
+            if (t.length === 0) {
+              ad.removeChild(last);
+              bodyEls.pop();
+              removed++;
+            } else {
+              var txt = (last.textContent || '').replace(stripMarkersAd, '');
+              var trimmed = txt.replace(/\n+$/, '');
+              if (trimmed !== txt && last.childNodes.length === 1 && last.firstChild && last.firstChild.nodeType === 3) {
+                last.firstChild.textContent = trimmed;
+              }
+              break;
+            }
+          }
+          var p = document.createElement('p');
+          p.innerHTML = '<br>';
+          if (ad.nextSibling) {
+            ad.parentNode.insertBefore(p, ad.nextSibling);
+          } else {
+            ad.parentNode.appendChild(p);
+          }
+          var range = document.createRange();
+          range.setStart(p, 0);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          var adParent = ad.parentNode;
+          if (adParent && adParent.nodeName === 'BLOCKQUOTE') {
+            ea.__liveWysiwygBlockquoteEnterCredit = { count: 2, bq: adParent };
+          }
+          if (wysiwygEditor._finalizeUpdate) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          }
+        }, true);
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygBlockquoteEnterExitAttached) {
+        ea.dataset.liveWysiwygBlockquoteEnterExitAttached = '1';
+        var bqConsecutiveEnters = 0;
+        var lastEnterBq = null;
+        ea.addEventListener('keydown', function (e) {
+          if (wysiwygEditor.currentMode !== 'wysiwyg' || e.key !== 'Enter') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = null;
+            return;
+          }
+          var node = sel.anchorNode;
+          if (node.nodeType === 3) node = node.parentNode;
+          var bq = null;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === 'BLOCKQUOTE') {
+              bq = anc;
+              break;
+            }
+            anc = anc.parentNode;
+          }
+          if (!bq) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = null;
+            return;
+          }
+          var inAdmonition = false;
+          var a = node;
+          while (a && a !== bq) {
+            if (a.classList && a.classList.contains('admonition')) { inAdmonition = true; break; }
+            a = a.parentNode;
+          }
+          if (inAdmonition) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = null;
+            return;
+          }
+          var inListItem = false;
+          var a = node;
+          while (a && a !== bq) {
+            if (a.nodeName === 'LI') { inListItem = true; break; }
+            a = a.parentNode;
+          }
+          if (inListItem) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = null;
+            return;
+          }
+          var directChild = node;
+          while (directChild && directChild.parentNode !== bq) {
+            directChild = directChild.parentNode;
+          }
+          var isAdmonitionChild = directChild && directChild.classList && directChild.classList.contains('admonition');
+          var isBlock = directChild && (directChild.nodeName === 'P' || directChild.nodeName === 'DIV') && !isAdmonitionChild;
+          if (!isBlock) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = null;
+            return;
+          }
+          var cursorBlock = node;
+          while (cursorBlock && cursorBlock !== bq && cursorBlock.nodeName !== 'P' && cursorBlock.nodeName !== 'DIV') {
+            cursorBlock = cursorBlock.parentNode;
+          }
+          var hadCredit = false;
+          var credit = ea.__liveWysiwygBlockquoteEnterCredit;
+          if (credit && credit.bq === bq) {
+            ea.__liveWysiwygBlockquoteEnterCredit = null;
+            var contentBlock = (cursorBlock && cursorBlock !== bq) ? cursorBlock : directChild;
+            var blockTextCheck = (contentBlock.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+            var onlyBr = contentBlock.childNodes.length === 1 && contentBlock.firstChild && contentBlock.firstChild.nodeName === 'BR';
+            var hasContent = blockTextCheck.length > 0 && !onlyBr;
+            if (hasContent) {
+              bqConsecutiveEnters = 0;
+              lastEnterBq = bq;
+            } else {
+              bqConsecutiveEnters = credit.count;
+              lastEnterBq = bq;
+              hadCredit = true;
+            }
+          } else if (lastEnterBq !== bq) {
+            bqConsecutiveEnters = 0;
+            lastEnterBq = bq;
+          }
+          bqConsecutiveEnters++;
+          if (bqConsecutiveEnters < 3) return;
+          var hasContentAfterBq = false;
+          var sibBq = directChild ? directChild.nextSibling : null;
+          while (sibBq) {
+            if (sibBq.nodeType === 1) {
+              var sibTextBq = (sibBq.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+              if (sibTextBq.length > 0) { hasContentAfterBq = true; break; }
+            } else if (sibBq.nodeType === 3) {
+              var sibTextBq = (sibBq.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '');
+              if (sibTextBq.length > 0) { hasContentAfterBq = true; break; }
+            }
+            sibBq = sibBq.nextSibling;
+          }
+          if (hasContentAfterBq) {
+            bqConsecutiveEnters = 0;
+            return;
+          }
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          bqConsecutiveEnters = 0;
+          lastEnterBq = null;
+          var stripMarkersBq = /[\u200B\u200C\u200D\uFEFF]/g;
+          function removeTrailingEmptyBlocksBq(container) {
+            var kids = container.childNodes;
+            for (var i = kids.length - 1; i >= 0; i--) {
+              var k = kids[i];
+              if (k.nodeType !== 1) continue;
+              var tag = k.nodeName;
+              if (tag !== 'P' && tag !== 'DIV') continue;
+              var t = (k.textContent || '').replace(stripMarkersBq, '').replace(/\s/g, '');
+              if (t.length === 0) {
+                container.removeChild(k);
+              } else {
+                break;
+              }
+            }
+          }
+          var bodyEls = [];
+          for (var j = 0; j < bq.childNodes.length; j++) {
+            var c = bq.childNodes[j];
+            removeTrailingEmptyBlocksBq(c);
+            bodyEls.push(c);
+          }
+          var maxToRemove = hadCredit ? 1 : 999;
+          var removed = 0;
+          while (bodyEls.length > 0 && removed < maxToRemove) {
+            var last = bodyEls[bodyEls.length - 1];
+            var t = (last.textContent || '').replace(stripMarkersBq, '').replace(/\s/g, '');
+            if (t.length === 0) {
+              bq.removeChild(last);
+              bodyEls.pop();
+              removed++;
+            } else {
+              var txt = (last.textContent || '').replace(stripMarkersBq, '');
+              var trimmed = txt.replace(/\n+$/, '');
+              if (trimmed !== txt && last.childNodes.length === 1 && last.firstChild && last.firstChild.nodeType === 3) {
+                last.firstChild.textContent = trimmed;
+              }
+              break;
+            }
+          }
+          var p = document.createElement('p');
+          p.innerHTML = '<br>';
+          if (bq.nextSibling) {
+            bq.parentNode.insertBefore(p, bq.nextSibling);
+          } else {
+            bq.parentNode.appendChild(p);
+          }
+          var range = document.createRange();
+          range.setStart(p, 0);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          if (wysiwygEditor._finalizeUpdate) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          }
+        }, true);
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygCodeBlockEnterExitAttached) {
+        ea.dataset.liveWysiwygCodeBlockEnterExitAttached = '1';
+        var stripMarkers = /[\u200B\u200C\u200D\uFEFF]/g;
+        var consecutiveEnters = 0;
+        var lastEnterPre = null;
+
+        ea.addEventListener('keydown', function (e) {
+          if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+
+          var sel = window.getSelection();
+          if (!sel || !sel.isCollapsed || !sel.rangeCount) {
+            consecutiveEnters = 0;
+            lastEnterPre = null;
+            return;
+          }
+
+          var node = sel.anchorNode;
+          var pre = null;
+          var wrapper = null;
+          var title = null;
+          var anc = node;
+          while (anc && anc !== ea) {
+            if (anc.nodeName === 'PRE') pre = anc;
+            if (anc.classList && anc.classList.contains('md-code-block')) wrapper = anc;
+            if (anc.classList && anc.classList.contains('md-code-title')) title = anc;
+            anc = anc.parentNode;
+          }
+
+          if (title && !pre && (e.key === 'Enter' || e.key === 'Backspace')) {
+            var titleStripMarkers = /[​‌‍﻿]/g;
+            var atTitleStart = false;
+            var r = sel.getRangeAt(0);
+            var sn = r.startContainer;
+            var so = r.startOffset;
+            if (sn === title && so === 0) {
+              atTitleStart = true;
+            } else if (sn.nodeType === 3 && so === 0) {
+              var prev = sn;
+              while (prev && prev !== title) {
+                if (prev.previousSibling) { atTitleStart = false; break; }
+                prev = prev.parentNode;
+                if (prev === title) { atTitleStart = true; break; }
+              }
+            } else if (sn.nodeType === 1 && so === 0 && (sn === title || title.contains(sn))) {
+              var prev = sn;
+              while (prev && prev !== title) {
+                if (prev.previousSibling) { atTitleStart = false; break; }
+                prev = prev.parentNode;
+                if (prev === title) { atTitleStart = true; break; }
+              }
+            }
+
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.stopImmediatePropagation();
+              var titleText = (title.textContent || '').replace(titleStripMarkers, '').trim();
+              if (atTitleStart && titleText.length > 0) {
+                var codeBlock = wrapper || title.parentNode;
+                while (codeBlock && codeBlock !== ea && !(codeBlock.classList && codeBlock.classList.contains('md-code-block'))) {
+                  codeBlock = codeBlock.parentNode;
+                }
+                if (!codeBlock || codeBlock === ea) codeBlock = title.parentNode;
+                var p = document.createElement('p');
+                p.innerHTML = '<br>';
+                codeBlock.parentNode.insertBefore(p, codeBlock);
+                var range = document.createRange();
+                range.setStart(p, 0);
+                range.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(range);
+                if (wysiwygEditor._finalizeUpdate) {
+                  wysiwygEditor._finalizeUpdate(ea.innerHTML);
+                }
+              } else {
+                var codeBlock = wrapper || title.parentNode;
+                while (codeBlock && codeBlock !== ea && !(codeBlock.classList && codeBlock.classList.contains('md-code-block'))) {
+                  codeBlock = codeBlock.parentNode;
+                }
+                if (!codeBlock || codeBlock === ea) codeBlock = title.parentNode;
+                var targetPre = codeBlock.querySelector('pre');
+                if (targetPre) {
+                  var codeEl = targetPre.querySelector('code');
+                  var focusTarget = codeEl || targetPre;
+                  var range = document.createRange();
+                  if (focusTarget.firstChild && focusTarget.firstChild.nodeType === 3) {
+                    range.setStart(focusTarget.firstChild, 0);
+                  } else {
+                    range.setStart(focusTarget, 0);
+                  }
+                  range.collapse(true);
+                  sel.removeAllRanges();
+                  sel.addRange(range);
+                }
+              }
+              title.blur();
+              title.dispatchEvent(new Event('blur'));
+              return;
+            }
+
+            if (e.key === 'Backspace' && atTitleStart) {
+              var titleText = (title.textContent || '').replace(titleStripMarkers, '').trim();
+              if (titleText.length > 0) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return;
+              }
+              e.preventDefault();
+              e.stopImmediatePropagation();
+              var codeBlock = wrapper || title.parentNode;
+              while (codeBlock && codeBlock !== ea && !(codeBlock.classList && codeBlock.classList.contains('md-code-block'))) {
+                codeBlock = codeBlock.parentNode;
+              }
+              if (!codeBlock || codeBlock === ea) return;
+              var targetPre = codeBlock.querySelector('pre');
+              if (!targetPre) return;
+              targetPre.removeAttribute('data-lang');
+              targetPre.removeAttribute('data-title');
+              targetPre.removeAttribute('data-linenums');
+              targetPre.removeAttribute('data-hl-lines');
+              var codeEl = targetPre.querySelector('code');
+              if (codeEl) codeEl.className = '';
+              var parent = codeBlock.parentNode;
+              parent.insertBefore(targetPre, codeBlock);
+              parent.removeChild(codeBlock);
+              targetPre.style.position = 'relative';
+              addLangButtonToBasicPre(targetPre, ea);
+              var focusTarget = codeEl || targetPre;
+              var range = document.createRange();
+              if (focusTarget.firstChild && focusTarget.firstChild.nodeType === 3) {
+                range.setStart(focusTarget.firstChild, 0);
+              } else {
+                range.setStart(focusTarget, 0);
+              }
+              range.collapse(true);
+              sel.removeAllRanges();
+              sel.addRange(range);
+              if (wysiwygEditor._finalizeUpdate) {
+                wysiwygEditor._finalizeUpdate(ea.innerHTML);
+              }
+              return;
+            }
+          }
+
+          function normalizePreTextNodes(preEl, selection) {
+            var codeEl = preEl.querySelector('code');
+            if (!codeEl) return;
+            var stray = [];
+            for (var ci = 0; ci < preEl.childNodes.length; ci++) {
+              var cn = preEl.childNodes[ci];
+              if (cn === codeEl) continue;
+              if (cn.nodeType === 1 && cn.classList && (cn.classList.contains('md-code-lang-btn') || cn.classList.contains('md-code-lang-dropdown') || cn.classList.contains('md-code-settings-btn') || cn.classList.contains('md-code-settings-btn-advanced') || cn.classList.contains('md-code-settings-dropdown') || cn.classList.contains('md-code-line-numbers'))) continue;
+              if (cn.nodeType === 3 || cn.nodeType === 1) stray.push(cn);
+            }
+            if (stray.length === 0) return;
+            var r = (selection && selection.rangeCount) ? selection.getRangeAt(0) : null;
+            var cursorInStray = false;
+            var cursorStrayNode = null;
+            var cursorStrayOffset = 0;
+            if (r) {
+              for (var si = 0; si < stray.length; si++) {
+                if (stray[si] === r.startContainer || stray[si].contains(r.startContainer)) {
+                  cursorInStray = true;
+                  cursorStrayNode = r.startContainer;
+                  cursorStrayOffset = r.startOffset;
+                  break;
+                }
+              }
+            }
+            var offsetInCode = codeEl.textContent.length;
+            for (var si = 0; si < stray.length; si++) {
+              var txt = stray[si].textContent;
+              if (txt) codeEl.appendChild(document.createTextNode(txt));
+              preEl.removeChild(stray[si]);
+            }
+            if (cursorInStray && r) {
+              var newOffset = offsetInCode;
+              var prevStrayText = '';
+              for (var si = 0; si < stray.length; si++) {
+                if (stray[si] === cursorStrayNode || stray[si].contains(cursorStrayNode)) {
+                  newOffset = offsetInCode + prevStrayText.length + cursorStrayOffset;
+                  break;
+                }
+                prevStrayText += stray[si].textContent;
+              }
+              var walker = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT, null, false);
+              var acc = 0;
+              var wn;
+              while ((wn = walker.nextNode())) {
+                if (acc + wn.textContent.length >= newOffset) {
+                  r.setStart(wn, newOffset - acc);
+                  r.collapse(true);
+                  selection.removeAllRanges();
+                  selection.addRange(r);
+                  break;
+                }
+                acc += wn.textContent.length;
+              }
+            }
+          }
+
+          if (pre && e.key === 'Tab') {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            consecutiveEnters = 0;
+            lastEnterPre = null;
+            normalizePreTextNodes(pre, sel);
+            var codeEl = pre.querySelector('code');
+            if (codeEl) {
+              var r = sel.getRangeAt(0);
+              if (codeEl.contains(r.startContainer)) {
+                var indentSettings = getIndentSettings();
+                var tabStr = indentSettings.type === 'tab' ? '\t' : new Array((indentSettings.size || 4) + 1).join(' ');
+                var doc = codeEl.ownerDocument;
+                var tabNode = doc.createTextNode(tabStr);
+                r.insertNode(tabNode);
+                r.setStart(tabNode, tabStr.length);
+                r.setEnd(tabNode, tabStr.length);
+                r.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(r);
+                if (ea.dispatchEvent) {
+                  ea.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+              }
+            }
+            return;
+          }
+
+          if (e.key !== 'Enter') {
+            if (pre && e.key === 'Backspace' && consecutiveEnters > 0) {
+              consecutiveEnters = Math.max(0, consecutiveEnters - 1);
+            } else {
+              consecutiveEnters = 0;
+              lastEnterPre = null;
+            }
+            return;
+          }
+
+          if (!pre) {
+            consecutiveEnters = 0;
+            lastEnterPre = null;
+            return;
+          }
+
+          if (lastEnterPre !== pre) {
+            consecutiveEnters = 0;
+            lastEnterPre = pre;
+          }
+
+          consecutiveEnters++;
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          normalizePreTextNodes(pre, sel);
+
+          if (consecutiveEnters < 3) {
+            var codeEl = pre.querySelector('code');
+            if (codeEl) {
+              var r = sel.getRangeAt(0);
+              if (codeEl.contains(r.startContainer)) {
+                var indentStr = '';
+                var indentSettings = getIndentSettings();
+                if (indentSettings.enabled) {
+                  var fullText = codeEl.textContent;
+                  var cursorOffset = 0;
+                  var walker = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT, null, false);
+                  var wn;
+                  while ((wn = walker.nextNode())) {
+                    if (wn === r.startContainer) { cursorOffset += r.startOffset; break; }
+                    cursorOffset += wn.textContent.length;
+                  }
+                  var lineStart = fullText.lastIndexOf('\n', cursorOffset - 1) + 1;
+                  var currentLine = fullText.substring(lineStart, cursorOffset);
+                  var leadingMatch = currentLine.match(/^([ \t]*)/);
+                  indentStr = leadingMatch ? leadingMatch[1] : '';
+                  var trimmedLine = currentLine.trimEnd();
+                  if (/[:{(\[]\s*$/.test(trimmedLine)) {
+                    var unit = indentSettings.type === 'tab' ? '\t' : new Array(indentSettings.size + 1).join(' ');
+                    indentStr += unit;
+                  }
+                }
+                var doc = codeEl.ownerDocument;
+                var nl = doc.createTextNode('\n' + indentStr);
+                r.insertNode(nl);
+                r.setStart(nl, 1 + indentStr.length);
+                r.setEnd(nl, 1 + indentStr.length);
+                r.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(r);
+                if (ea.dispatchEvent) {
+                  ea.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+              }
+            }
+            return;
+          }
+
+          var codeElCheck = pre.querySelector('code');
+          var cursorAtEnd = false;
+          if (codeElCheck) {
+            var rCheck = sel.getRangeAt(0);
+            if (codeElCheck.contains(rCheck.startContainer)) {
+              var fullTextCheck = codeElCheck.textContent;
+              var cursorOffsetCheck = 0;
+              var walkerCheck = document.createTreeWalker(codeElCheck, NodeFilter.SHOW_TEXT, null, false);
+              var wnCheck;
+              while ((wnCheck = walkerCheck.nextNode())) {
+                if (wnCheck === rCheck.startContainer) { cursorOffsetCheck += rCheck.startOffset; break; }
+                cursorOffsetCheck += wnCheck.textContent.length;
+              }
+              var afterCursor = fullTextCheck.substring(cursorOffsetCheck);
+              if (afterCursor.replace(/[\n\r\s\t\u200B\u200C\u200D\uFEFF]/g, '').length === 0) {
+                cursorAtEnd = true;
+              }
+            }
+          }
+          if (!cursorAtEnd) {
+            consecutiveEnters = 0;
+            var codeEl = pre.querySelector('code');
+            if (codeEl) {
+              var r = sel.getRangeAt(0);
+              if (codeEl.contains(r.startContainer)) {
+                var doc = codeEl.ownerDocument;
+                var nl = doc.createTextNode('\n');
+                r.insertNode(nl);
+                r.setStart(nl, 1);
+                r.setEnd(nl, 1);
+                r.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(r);
+                if (ea.dispatchEvent) {
+                  ea.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+              }
+            }
+            return;
+          }
+
+          consecutiveEnters = 0;
+          lastEnterPre = null;
+
+          var blockContainer = wrapper || pre;
+          var el = pre;
+          while (el && el !== ea) {
+            if (el.classList && el.classList.contains('md-code-block')) {
+              blockContainer = el;
+            }
+            el = el.parentNode;
+          }
+          if (pre) {
+            var codeEl = pre.querySelector('code');
+            var codeClass = (codeEl && codeEl.className) ? codeEl.className : '';
+            var effectiveChildren = 0;
+            var singleCode = null;
+            for (var ei = 0; ei < pre.childNodes.length; ei++) {
+              var en = pre.childNodes[ei];
+              if (en.nodeType === 1 && en.classList && (en.classList.contains('md-code-lang-btn') || en.classList.contains('md-code-lang-dropdown') || en.classList.contains('md-code-line-numbers') || en.classList.contains('md-code-settings-btn') || en.classList.contains('md-code-settings-btn-advanced'))) continue;
+              if (en.nodeType === 1 && en.nodeName === 'CODE') { singleCode = en; effectiveChildren++; }
+              else effectiveChildren++;
+            }
+            var rawContent;
+            if (effectiveChildren === 1 && singleCode) {
+              rawContent = singleCode.textContent;
+            } else {
+              var parts = [];
+              for (var ci = 0; ci < pre.childNodes.length; ci++) {
+                var cn = pre.childNodes[ci];
+                if (cn.nodeType === 1 && cn.classList && (cn.classList.contains('md-code-lang-btn') || cn.classList.contains('md-code-lang-dropdown') || cn.classList.contains('md-code-line-numbers') || cn.classList.contains('md-code-settings-btn') || cn.classList.contains('md-code-settings-btn-advanced'))) continue;
+                if (cn.nodeType === 3) parts.push(cn.textContent);
+                else if (cn.nodeType === 1) parts.push(cn.textContent);
+              }
+              rawContent = parts.join('\n');
+            }
+            rawContent = rawContent.replace(stripMarkers, '');
+            var cleaned = rawContent.replace(/(\n[ \t]*)+$/, '');
+            while (pre.firstChild) pre.removeChild(pre.firstChild);
+            var newCode = document.createElement('code');
+            if (codeClass) newCode.className = codeClass;
+            newCode.textContent = cleaned.length > 0 ? cleaned + '\n' : '\n';
+            pre.appendChild(newCode);
+            if (!wrapper) {
+              enhanceBasicPreBlocks(ea);
+            }
+          }
+          var p = document.createElement('p');
+          var br = document.createElement('br');
+          p.appendChild(br);
+          blockContainer.insertAdjacentElement('afterend', p);
+          var codeBlockAncestor = p.parentNode;
+          while (codeBlockAncestor && codeBlockAncestor !== ea) {
+            if (codeBlockAncestor.classList && codeBlockAncestor.classList.contains('md-code-block')) {
+              codeBlockAncestor.parentNode.insertBefore(p, codeBlockAncestor.nextSibling);
+              break;
+            }
+            codeBlockAncestor = codeBlockAncestor.parentNode;
+          }
+          var actualParent = p.parentNode;
+          if (actualParent && actualParent !== ea) {
+            if (actualParent.classList && actualParent.classList.contains('admonition')) {
+              ea.__liveWysiwygAdmonitionEnterCredit = { count: 2, ad: actualParent };
+            } else if (actualParent.nodeName === 'BLOCKQUOTE') {
+              ea.__liveWysiwygBlockquoteEnterCredit = { count: 2, bq: actualParent };
+            }
+          }
+          var range = document.createRange();
+          range.setStart(p, 0);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          if (wysiwygEditor._finalizeUpdate) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          }
+        }, true);
+      }
+    })();
+
+    (function () {
+      var ea = wysiwygEditor.editableArea;
+      if (ea && !ea.dataset.liveWysiwygProgressiveSelectAllAttached) {
+        ea.dataset.liveWysiwygProgressiveSelectAllAttached = '1';
+
+        function isCodeUINode(n) {
+          if (n.nodeType !== 1 || !n.classList) return false;
+          return n.classList.contains('md-code-lang-btn') || n.classList.contains('md-code-lang-btn-advanced') ||
+                 n.classList.contains('md-code-lang-dropdown') || n.classList.contains('md-code-line-numbers') ||
+                 n.classList.contains('md-code-settings-btn') || n.classList.contains('md-code-settings-btn-advanced') ||
+                 n.classList.contains('md-code-settings-dropdown');
+        }
+
+        function isSelectableTarget(node) {
+          if (node === ea) return true;
+          if (node.nodeType !== 1) return false;
+          var name = node.nodeName;
+          var cl = node.classList;
+          if (name === 'CODE' && !node.closest('pre')) return true;
+          if (cl && (cl.contains('md-code-title') || cl.contains('md-code-lang'))) return true;
+          if (name === 'PRE') return true;
+          if (cl && cl.contains('md-code-block')) return true;
+          if (cl && cl.contains('admonition')) return true;
+          if (/^(P|H[1-6]|LI|TD|TH)$/.test(name)) return true;
+          if (/^(UL|OL|TABLE|BLOCKQUOTE)$/.test(name)) return true;
+          return false;
+        }
+
+        function buildTargetRange(target) {
+          var range = document.createRange();
+          if (target.nodeName === 'PRE') {
+            var codeEl = target.querySelector('code');
+            var isSingleCode = false;
+            if (codeEl) {
+              var effectiveCount = 0;
+              for (var si = 0; si < target.childNodes.length; si++) {
+                if (isCodeUINode(target.childNodes[si])) continue;
+                effectiveCount++;
+              }
+              isSingleCode = (effectiveCount === 1 && codeEl.childNodes.length === 1 &&
+                              codeEl.firstChild && codeEl.firstChild.nodeType === 3);
+            }
+            if (isSingleCode) {
+              var textNode = codeEl.firstChild;
+              var len = textNode.textContent.length;
+              if (textNode.textContent.endsWith('\n') && len > 0) len = len - 1;
+              range.setStart(textNode, 0);
+              range.setEnd(textNode, len);
+            } else {
+              var firstContent = null, lastContent = null;
+              for (var ci = 0; ci < target.childNodes.length; ci++) {
+                var cn = target.childNodes[ci];
+                if (isCodeUINode(cn)) continue;
+                if (!firstContent) firstContent = cn;
+                lastContent = cn;
+              }
+              if (firstContent) {
+                range.setStartBefore(firstContent);
+                if (lastContent.nodeType === 3 && lastContent.textContent.endsWith('\n')) {
+                  range.setEnd(lastContent, lastContent.textContent.length - 1);
+                } else {
+                  range.setEndAfter(lastContent);
+                }
+              } else {
+                range.selectNodeContents(target);
+              }
+            }
+          } else {
+            range.selectNodeContents(target);
+          }
+          return range;
+        }
+
+        function buildAdmonitionBodyRange(ad) {
+          var range = document.createRange();
+          var firstBody = null, lastBody = null;
+          for (var ci = 0; ci < ad.childNodes.length; ci++) {
+            var cn = ad.childNodes[ci];
+            if (cn.nodeType === 1 && cn.classList && cn.classList.contains('admonition-title')) continue;
+            if (cn.nodeType === 3 && !cn.textContent.replace(/[​‌‍﻿\s]/g, '')) continue;
+            if (!firstBody) firstBody = cn;
+            lastBody = cn;
+          }
+          if (firstBody && lastBody) {
+            range.setStartBefore(firstBody);
+            range.setEndAfter(lastBody);
+          } else {
+            range.selectNodeContents(ad);
+          }
+          return range;
+        }
+
+        function selectionCoversRange(sel, targetRange) {
+          if (!sel.rangeCount) return false;
+          var cur = sel.getRangeAt(0);
+          try {
+            return cur.compareBoundaryPoints(Range.START_TO_START, targetRange) <= 0 &&
+                   cur.compareBoundaryPoints(Range.END_TO_END, targetRange) >= 0;
+          } catch (ex) { return false; }
+        }
+
+        var HEADING_RE = /^H[1-6]$/;
+
+        function buildHeadingSectionRange(siblings, startIdx, endIdx) {
+          var range = document.createRange();
+          range.setStartBefore(siblings[startIdx]);
+          range.setEndAfter(siblings[endIdx]);
+          return range;
+        }
+
+        ea.addEventListener('keydown', function (e) {
+          if (!(e.key === 'a' && (e.metaKey || e.ctrlKey))) return;
+          if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+          var sel = window.getSelection();
+          if (!sel || !sel.rangeCount) return;
+
+          var targetRanges = [];
+          var node = sel.anchorNode;
+          var r = sel.rangeCount ? sel.getRangeAt(0) : null;
+
+          if (node === ea && r) {
+            if (r.startContainer === ea) {
+              for (var ri = r.startOffset; ri < ea.childNodes.length; ri++) {
+                if (ea.childNodes[ri].nodeType === 1) { node = ea.childNodes[ri]; break; }
+              }
+            } else {
+              node = r.startContainer;
+            }
+          } else if (node && node.nodeType === 3 && r && /^\s*$/.test(node.textContent)) {
+            var sc = r.startContainer;
+            if (sc === ea) {
+              for (var ri = r.startOffset; ri < ea.childNodes.length; ri++) {
+                if (ea.childNodes[ri].nodeType === 1) { node = ea.childNodes[ri]; break; }
+              }
+              if (!node || node.nodeType !== 1) {
+                for (var ri = r.startOffset - 1; ri >= 0; ri--) {
+                  if (ea.childNodes[ri].nodeType === 1) { node = ea.childNodes[ri]; break; }
+                }
+              }
+            } else if (sc && sc.nodeType === 3) {
+              node = sc.parentNode;
+              if (node === ea) {
+                var idx = -1;
+                for (var i = 0; i < ea.childNodes.length; i++) {
+                  if (ea.childNodes[i] === sc) { idx = i; break; }
+                }
+                if (idx >= 0) {
+                  for (var ri = idx + 1; ri < ea.childNodes.length; ri++) {
+                    if (ea.childNodes[ri].nodeType === 1) { node = ea.childNodes[ri]; break; }
+                  }
+                  if (!node || node.nodeType !== 1) {
+                    for (var ri = idx - 1; ri >= 0; ri--) {
+                      if (ea.childNodes[ri].nodeType === 1) { node = ea.childNodes[ri]; break; }
+                    }
+                  }
+                }
+              }
+            } else if (sc && sc.nodeType === 1) {
+              node = sc;
+            }
+          }
+
+          var elCur = (node && node.nodeType === 3) ? node.parentNode : node;
+          while (elCur && elCur !== ea) {
+            if (isSelectableTarget(elCur)) {
+              if (elCur.classList && elCur.classList.contains('admonition')) {
+                var inTitle = false;
+                var titleEl = elCur.querySelector('.admonition-title');
+                var check = (node && node.nodeType === 3) ? node.parentNode : node;
+                while (check && check !== elCur) {
+                  if (check === titleEl) { inTitle = true; break; }
+                  check = check.parentNode;
+                }
+                if (!inTitle) {
+                  targetRanges.push(buildAdmonitionBodyRange(elCur));
+                }
+              }
+              targetRanges.push(buildTargetRange(elCur));
+            }
+            elCur = elCur.parentNode;
+          }
+
+          var topChild = (node && node.nodeType === 3) ? node.parentNode : node;
+          while (topChild && topChild !== ea && topChild.parentNode !== ea) {
+            topChild = topChild.parentNode;
+          }
+          if (topChild && topChild.parentNode === ea) {
+            var siblings = ea.childNodes;
+            var topIdx = -1;
+            for (var ti = 0; ti < siblings.length; ti++) {
+              if (siblings[ti] === topChild) { topIdx = ti; break; }
+            }
+            if (topIdx >= 0) {
+              if (topChild.nodeType === 1 && HEADING_RE.test(topChild.nodeName)) {
+                var ownLevel = parseInt(topChild.nodeName.charAt(1));
+                var ownEnd = siblings.length - 1;
+                for (var oi = topIdx + 1; oi < siblings.length; oi++) {
+                  var os = siblings[oi];
+                  if (os.nodeType === 1 && HEADING_RE.test(os.nodeName) && parseInt(os.nodeName.charAt(1)) <= ownLevel) {
+                    ownEnd = oi - 1;
+                    break;
+                  }
+                }
+                if (ownEnd >= topIdx + 1) {
+                  targetRanges.push(buildHeadingSectionRange(siblings, topIdx, ownEnd));
+                }
+              }
+
+              var curLevel = (topChild.nodeType === 1 && HEADING_RE.test(topChild.nodeName))
+                ? parseInt(topChild.nodeName.charAt(1))
+                : 7;
+
+              for (var hi = topIdx - 1; hi >= 0; hi--) {
+                var sib = siblings[hi];
+                if (sib.nodeType !== 1 || !HEADING_RE.test(sib.nodeName)) continue;
+                var hLevel = parseInt(sib.nodeName.charAt(1));
+                if (hLevel >= curLevel) continue;
+                var secStart = hi + 1;
+                var secEnd = siblings.length - 1;
+                for (var si = hi + 1; si < siblings.length; si++) {
+                  var ss = siblings[si];
+                  if (ss.nodeType === 1 && HEADING_RE.test(ss.nodeName) && parseInt(ss.nodeName.charAt(1)) <= hLevel) {
+                    secEnd = si - 1;
+                    break;
+                  }
+                }
+                if (secStart <= secEnd) {
+                  targetRanges.push(buildHeadingSectionRange(siblings, hi, secEnd));
+                }
+                curLevel = hLevel;
+              }
+            }
+          }
+
+          targetRanges.push(buildTargetRange(ea));
+
+          for (var i = 0; i < targetRanges.length; i++) {
+            if (!selectionCoversRange(sel, targetRanges[i])) {
+              e.preventDefault();
+              sel.removeAllRanges();
+              sel.addRange(targetRanges[i]);
+              return;
+            }
+          }
+        });
+      }
+    })();
+
+        const observer = new MutationObserver(function () {
       if (!textarea.parentNode) return;
       if (textarea.classList.contains('live-edit-hidden')) {
         observer.disconnect();
@@ -3115,6 +6437,33 @@
         }
         return result;
       };
+    })();
+
+    (function attachCtrlSSave() {
+      if (document.__liveWysiwygCtrlSAttached) return;
+      document.__liveWysiwygCtrlSAttached = true;
+      document.addEventListener('keydown', function (e) {
+        if (!((e.metaKey || e.ctrlKey) && e.key === 's')) return;
+        if (!wysiwygEditor) return;
+        var ea = wysiwygEditor.editableArea;
+        var ma = wysiwygEditor.markdownArea;
+        var activeEl = document.activeElement;
+        var isInEditor = (ea && ea.contains(activeEl)) || activeEl === ea ||
+                         (ma && (activeEl === ma || ma.contains(activeEl)));
+        if (!isInEditor) return;
+        e.preventDefault();
+        if (wysiwygEditor._finalizeUpdate) {
+          if (wysiwygEditor.currentMode === 'wysiwyg' && ea) {
+            wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          } else if (wysiwygEditor.currentMode === 'markdown' && ma) {
+            wysiwygEditor._finalizeUpdate(ma.value);
+          }
+        }
+        var saveBtn = document.querySelector('.live-edit-save-button');
+        if (saveBtn && !saveBtn.disabled) {
+          saveBtn.click();
+        }
+      });
     })();
 
     if (wysiwygEditor) {

--- a/mkdocs_live_wysiwyg_plugin/plugin.py
+++ b/mkdocs_live_wysiwyg_plugin/plugin.py
@@ -4,12 +4,108 @@ WYSIWYG editor for mkdocs-live-edit-plugin based on @celsowm/markdown-wysiwyg.
 """
 
 import base64
+import json
 from pathlib import Path
 from typing import Literal
 
 from mkdocs.config import config_options
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin
+
+# Fallback emoji map when pymdownx.gemoji_db is not available (~50 common emoji)
+FALLBACK_EMOJI_MAP = {
+    "white_check_mark": "\u2705",
+    "check_mark": "\u2714",
+    "heavy_check_mark": "\u2714",
+    "x": "\u274c",
+    "smile": "\U0001f604",
+    "heart": "\u2764",
+    "thumbsup": "\U0001f44d",
+    "thumbsdown": "\U0001f44e",
+    "star": "\u2b50",
+    "warning": "\u26a0",
+    "info": "\u2139",
+    "information_source": "\u2139",
+    "+1": "\U0001f44d",
+    "-1": "\U0001f44e",
+    "fire": "\U0001f525",
+    "ok": "\U0001f197",
+    "bulb": "\U0001f4a1",
+    "rocket": "\U0001f680",
+    "tada": "\U0001f389",
+    "see_no_evil": "\U0001f648",
+    "hear_no_evil": "\U0001f649",
+    "speak_no_evil": "\U0001f64a",
+    "eyes": "\U0001f440",
+    "zzz": "\U0001f4a4",
+    "100": "\U0001f4af",
+    "1234": "\U0001f522",
+    "grin": "\U0001f601",
+    "joy": "\U0001f602",
+    "smiley": "\U0001f603",
+    "heart_eyes": "\U0001f60d",
+    "kissing_heart": "\U0001f618",
+    "sweat_smile": "\U0001f605",
+    "laughing": "\U0001f606",
+    "wink": "\U0001f609",
+    "blush": "\U0001f60a",
+    "yum": "\U0001f60b",
+    "thinking": "\U0001f914",
+    "neutral_face": "\U0001f610",
+    "expressionless": "\U0001f611",
+    "no_mouth": "\U0001f636",
+    "smirk": "\U0001f60f",
+    "rolling_eyes": "\U0001f644",
+    "relieved": "\U0001f60c",
+    "heartbeat": "\U0001f493",
+    "broken_heart": "\U0001f494",
+    "two_hearts": "\U0001f495",
+    "sparkles": "\u2728",
+    "dizzy": "\U0001f4ab",
+    "boom": "\U0001f4a5",
+    "anger": "\U0001f4a2",
+    "question": "\u2753",
+    "grey_exclamation": "\u2755",
+    "exclamation": "\u2757",
+    "heavy_plus_sign": "\u2795",
+    "heavy_minus_sign": "\u2796",
+    "heavy_division_sign": "\u2797",
+}
+
+
+def _hex_to_unicode(hex_str: str) -> str:
+    """Convert hex like '1f44d' or '1f1e6-1f1eb' to Unicode character(s)."""
+    parts = hex_str.split("-")
+    return "".join(chr(int(p, 16)) for p in parts)
+
+
+def _build_emoji_map() -> dict[str, str]:
+    """Build shortcode (no colons) -> unicode character mapping.
+    Uses pymdownx.gemoji_db if available, otherwise FALLBACK_EMOJI_MAP.
+    """
+    try:
+        import pymdownx.gemoji_db as gemoji_db
+    except ImportError:
+        return FALLBACK_EMOJI_MAP.copy()
+
+    emoji_map = {}
+
+    # Canonical emoji from gemoji_db.emoji
+    for shortcode_with_colons, data in gemoji_db.emoji.items():
+        shortcode = shortcode_with_colons.strip(":")
+        hex_unicode = data.get("unicode", "")
+        if hex_unicode:
+            emoji_map[shortcode] = _hex_to_unicode(hex_unicode)
+
+    # Aliases: map alias shortcode to same unicode as canonical
+    for alias_with_colons, canonical_with_colons in gemoji_db.aliases.items():
+        alias = alias_with_colons.strip(":")
+        canonical = canonical_with_colons.strip(":")
+        if canonical in emoji_map:
+            emoji_map[alias] = emoji_map[canonical]
+
+    return emoji_map
+
 
 class LiveWysiwygPlugin(BasePlugin):
     """
@@ -65,6 +161,15 @@ class LiveWysiwygPlugin(BasePlugin):
             )
         else:
             preamble_parts.append("const liveWysiwygIconDataUrl = null;\n")
+
+        # Build and inject emoji map (cached on plugin instance)
+        if not hasattr(self, "_emoji_map_cache"):
+            self._emoji_map_cache = _build_emoji_map()
+        emoji_map = self._emoji_map_cache
+        preamble_parts.append(
+            f"const liveWysiwygEmojiMap = {json.dumps(emoji_map, ensure_ascii=True)};\n"
+        )
+
         preamble = "".join(preamble_parts)
 
         admonition_css = parent_dir / "admonition.css"

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.css
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.css
@@ -50,6 +50,12 @@
  vertical-align: middle;
 }
 
+.md-toolbar-button-heading {
+ font-weight: 700;
+ font-size: 13px;
+ letter-spacing: -0.5px;
+}
+
 .md-toolbar-heading-wrapper {
  position: relative;
  display: inline-flex;
@@ -191,6 +197,13 @@
 
 .md-editable-area blockquote p {
  margin-bottom: 0.5em;
+}
+
+.md-editable-area blockquote pre,
+.md-editable-area blockquote .md-code-block,
+.md-editable-area blockquote .admonition {
+ font-style: normal;
+ color: inherit;
 }
 
 .md-editable-area pre {
@@ -582,4 +595,268 @@
  color: inherit;
  display: block;
  line-height: 1.45;
+}
+
+/* Lang button on basic (unwrapped) PRE blocks */
+.md-editable-area pre .md-code-lang-btn {
+ position: absolute;
+ top: 4px;
+ right: 4px;
+ background: rgba(0,0,0,0.35);
+ color: #c9d1d9;
+ border: 1px solid rgba(255,255,255,0.12);
+ border-radius: 3px;
+ font-size: 0.65em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ padding: 2px 8px;
+ cursor: pointer;
+ text-transform: uppercase;
+ letter-spacing: 0.5px;
+ opacity: 0;
+ transition: opacity 0.15s;
+ z-index: 5;
+ line-height: 1.4;
+}
+
+.md-editable-area pre:hover .md-code-lang-btn,
+.md-editable-area pre:focus-within .md-code-lang-btn {
+ opacity: 1;
+}
+
+.md-editable-area pre .md-code-lang-btn:hover {
+ background: rgba(0,0,0,0.55);
+ color: #fff;
+}
+
+/* Lang button on advanced (wrapped) code blocks */
+.md-editable-area .md-code-block .md-code-lang-btn-advanced {
+ position: absolute;
+ top: 4px;
+ right: 4px;
+ background: rgba(0,0,0,0.35);
+ color: #c9d1d9;
+ border: 1px solid rgba(255,255,255,0.12);
+ border-radius: 3px;
+ font-size: 0.65em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ padding: 2px 8px;
+ cursor: pointer;
+ text-transform: uppercase;
+ letter-spacing: 0.5px;
+ opacity: 0;
+ transition: opacity 0.15s;
+ z-index: 5;
+ line-height: 1.4;
+}
+
+.md-editable-area .md-code-block:hover .md-code-lang-btn-advanced,
+.md-editable-area .md-code-block:focus-within .md-code-lang-btn-advanced {
+ opacity: 1;
+}
+
+.md-editable-area .md-code-block .md-code-lang-btn-advanced:hover {
+ background: rgba(0,0,0,0.55);
+ color: #fff;
+}
+
+/* Language dropdown menu — appended to body so it escapes overflow:hidden parents */
+.md-code-lang-dropdown {
+ position: fixed;
+ width: 180px;
+ max-height: 240px;
+ background: #1e1e1e;
+ border: 1px solid #444;
+ border-radius: 4px;
+ box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+ z-index: 10000;
+ display: flex;
+ flex-direction: column;
+ overflow: hidden;
+}
+
+.md-code-lang-filter {
+ width: 100%;
+ padding: 6px 8px;
+ border: none;
+ border-bottom: 1px solid #444;
+ background: #2a2a2a;
+ color: #c9d1d9;
+ font-size: 0.8em;
+ font-family: 'Menlo', 'Consolas', monospace;
+ outline: none;
+ box-sizing: border-box;
+}
+
+.md-code-lang-filter::placeholder {
+ color: #666;
+}
+
+.md-code-lang-list {
+ overflow-y: auto;
+ max-height: 200px;
+}
+
+.md-code-lang-item {
+ padding: 4px 8px;
+ cursor: pointer;
+ color: #c9d1d9;
+ font-size: 0.8em;
+ font-family: 'Menlo', 'Consolas', monospace;
+}
+
+.md-code-lang-item:hover {
+ background: #333;
+}
+
+.md-code-lang-item-active {
+ background: #264f78;
+ color: #fff;
+}
+
+/* Settings gear button on basic (unwrapped) PRE blocks */
+.md-editable-area pre .md-code-settings-btn {
+ position: absolute;
+ top: 4px;
+ right: 52px;
+ background: rgba(0,0,0,0.35);
+ color: #c9d1d9;
+ border: 1px solid rgba(255,255,255,0.12);
+ border-radius: 3px;
+ font-size: 0.65em;
+ padding: 2px 4px;
+ cursor: pointer;
+ opacity: 0;
+ transition: opacity 0.15s;
+ z-index: 5;
+ line-height: 1;
+ display: flex;
+ align-items: center;
+ justify-content: center;
+}
+
+.md-editable-area pre:hover .md-code-settings-btn,
+.md-editable-area pre:focus-within .md-code-settings-btn {
+ opacity: 1;
+}
+
+.md-editable-area pre .md-code-settings-btn:hover {
+ background: rgba(0,0,0,0.55);
+ color: #fff;
+}
+
+/* Settings gear button on advanced (wrapped) code blocks */
+.md-editable-area .md-code-block .md-code-settings-btn-advanced {
+ position: absolute;
+ top: 4px;
+ right: 52px;
+ background: rgba(0,0,0,0.35);
+ color: #c9d1d9;
+ border: 1px solid rgba(255,255,255,0.12);
+ border-radius: 3px;
+ font-size: 0.65em;
+ padding: 2px 4px;
+ cursor: pointer;
+ opacity: 0;
+ transition: opacity 0.15s;
+ z-index: 5;
+ line-height: 1;
+ display: flex;
+ align-items: center;
+ justify-content: center;
+}
+
+.md-editable-area .md-code-block:hover .md-code-settings-btn-advanced,
+.md-editable-area .md-code-block:focus-within .md-code-settings-btn-advanced {
+ opacity: 1;
+}
+
+.md-editable-area .md-code-block .md-code-settings-btn-advanced:hover {
+ background: rgba(0,0,0,0.55);
+ color: #fff;
+}
+
+/* Settings dropdown menu */
+.md-code-settings-dropdown {
+ position: fixed;
+ width: 200px;
+ background: #1e1e1e;
+ border: 1px solid #444;
+ border-radius: 4px;
+ box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+ z-index: 10000;
+ padding: 6px 0;
+ font-family: 'Menlo', 'Consolas', monospace;
+ font-size: 0.75em;
+ color: #c9d1d9;
+}
+
+.md-code-settings-row {
+ display: flex;
+ align-items: center;
+ justify-content: space-between;
+ padding: 5px 10px;
+}
+
+.md-code-settings-label {
+ flex-shrink: 0;
+ margin-right: 8px;
+}
+
+.md-code-settings-toggle {
+ background: #333;
+ color: #888;
+ border: 1px solid #555;
+ border-radius: 3px;
+ padding: 2px 10px;
+ cursor: pointer;
+ font-family: inherit;
+ font-size: inherit;
+ transition: background 0.1s, color 0.1s;
+}
+
+.md-code-settings-toggle.active {
+ background: #264f78;
+ color: #fff;
+ border-color: #3a7bd5;
+}
+
+.md-code-settings-toggle:hover {
+ background: #444;
+ color: #fff;
+}
+
+.md-code-settings-toggle.active:hover {
+ background: #2d5a8a;
+}
+
+.md-code-settings-btn-group {
+ display: flex;
+ gap: 2px;
+}
+
+.md-code-settings-opt {
+ background: #333;
+ color: #888;
+ border: 1px solid #555;
+ border-radius: 3px;
+ padding: 2px 8px;
+ cursor: pointer;
+ font-family: inherit;
+ font-size: inherit;
+ transition: background 0.1s, color 0.1s;
+}
+
+.md-code-settings-opt.active {
+ background: #264f78;
+ color: #fff;
+ border-color: #3a7bd5;
+}
+
+.md-code-settings-opt:hover {
+ background: #444;
+ color: #fff;
+}
+
+.md-code-settings-opt.active:hover {
+ background: #2d5a8a;
 }

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.js
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.js
@@ -1338,16 +1338,118 @@ class MarkdownWYSIWYG {
         this.markdownArea.addEventListener('scroll', this._boundListeners.syncScrollMarkdown);
     }
 
+    _listIndentOutdentByDOM(outdent) {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return false;
+        const range = sel.getRangeAt(0);
+        let commonAncestor = range.commonAncestorContainer;
+        if (commonAncestor.nodeType === Node.TEXT_NODE) commonAncestor = commonAncestor.parentNode;
+        const startLI = this._findParentElement(range.startContainer, 'LI');
+        const endLI = this._findParentElement(range.endContainer, 'LI');
+        if (!startLI || !endLI) return true;
+        let list, items;
+        if (startLI.parentNode === endLI.parentNode) {
+            list = startLI.parentNode;
+            const directLis = Array.from(list.children).filter(c => c.nodeName === 'LI');
+            const startIdx = directLis.indexOf(startLI);
+            const endIdx = directLis.indexOf(endLI);
+            if (startIdx < 0 || endIdx < 0) return true;
+            const lo = Math.min(startIdx, endIdx);
+            const hi = Math.max(startIdx, endIdx);
+            items = directLis.slice(lo, hi + 1);
+        } else if (startLI.contains && startLI.contains(endLI)) {
+            list = startLI.parentNode;
+            items = [startLI];
+        } else if (endLI.contains && endLI.contains(startLI)) {
+            list = endLI.parentNode;
+            items = [endLI];
+        } else {
+            return true;
+        }
+        if (!list || (list.nodeName !== 'UL' && list.nodeName !== 'OL')) return true;
+        const savedStart = range.startContainer;
+        const savedStartOffset = range.startOffset;
+        const savedEnd = range.endContainer;
+        const savedEndOffset = range.endOffset;
+        if (outdent) {
+            const listParent = list.parentNode;
+            if (listParent.nodeName === 'LI') {
+                const grandparentList = listParent.parentNode;
+                if (!grandparentList || (grandparentList.nodeName !== 'UL' && grandparentList.nodeName !== 'OL')) return true;
+                let ref = listParent;
+                for (let i = 0; i < items.length; i++) {
+                    const it = items[i];
+                    list.removeChild(it);
+                    const nextRef = ref.nextSibling;
+                    if (nextRef) {
+                        grandparentList.insertBefore(it, nextRef);
+                    } else {
+                        grandparentList.appendChild(it);
+                    }
+                    ref = it;
+                }
+                if (list.childNodes.length === 0) listParent.removeChild(list);
+            } else {
+                return true;
+            }
+        } else {
+            const firstItem = items[0];
+            let prev = firstItem.previousElementSibling;
+            while (prev && prev.nodeName !== 'LI') prev = prev.previousElementSibling;
+            if (!prev) return true;
+            let nestedList = null;
+            for (let n = prev.firstChild; n; n = n.nextSibling) {
+                if (n.nodeName === 'UL' || n.nodeName === 'OL') { nestedList = n; break; }
+            }
+            if (!nestedList) {
+                nestedList = document.createElement(list.nodeName);
+                prev.appendChild(nestedList);
+            }
+            for (let i = 0; i < items.length; i++) {
+                const it = items[i];
+                list.removeChild(it);
+                nestedList.appendChild(it);
+            }
+        }
+        const firstMoved = items[0];
+        const lastMoved = items[items.length - 1];
+        const newRange = document.createRange();
+        try {
+            newRange.setStart(savedStart, savedStartOffset);
+            newRange.setEnd(savedEnd, savedEndOffset);
+        } catch (err) {
+            newRange.setStart(firstMoved, 0);
+            if (firstMoved !== lastMoved) {
+                const lastLen = lastMoved.childNodes.length;
+                newRange.setEnd(lastMoved, lastLen > 0 ? lastLen : 1);
+            } else {
+                newRange.collapse(true);
+            }
+        }
+        sel.removeAllRanges();
+        sel.addRange(newRange);
+        return true;
+    }
+
     _handleKeyDownShared(e, targetArea) {
         if (e.key === 'Tab') {
             e.preventDefault();
             if (targetArea === this.editableArea) {
                 const sel = window.getSelection();
                 if (sel && sel.rangeCount > 0) {
-                    const listItem = this._findParentElement(sel.getRangeAt(0).commonAncestorContainer, 'LI');
-                    const tableCell = this._findParentElement(sel.getRangeAt(0).commonAncestorContainer, ['TD', 'TH']);
-                    if (listItem) {
-                        document.execCommand(e.shiftKey ? 'outdent' : 'indent');
+                    const range = sel.getRangeAt(0);
+                    let commonAncestor = range.commonAncestorContainer;
+                    if (commonAncestor.nodeType === Node.TEXT_NODE) commonAncestor = commonAncestor.parentNode;
+                    const listItem = this._findParentElement(commonAncestor, 'LI');
+                    const list = this._findParentElement(commonAncestor, ['UL', 'OL']);
+                    const inList = !!(listItem || (list && (list.nodeName === 'UL' || list.nodeName === 'OL')));
+                    const tableCell = this._findParentElement(commonAncestor, ['TD', 'TH']);
+                    if (inList) {
+                        if (this._listIndentOutdentByDOM(e.shiftKey)) {
+                            this._finalizeUpdate(this.editableArea.innerHTML);
+                        } else {
+                            document.execCommand(e.shiftKey ? 'outdent' : 'indent');
+                        }
                     } else if (tableCell) {
                         const table = this._findParentElement(tableCell, 'TABLE');
                         if (table) {
@@ -1766,7 +1868,9 @@ class MarkdownWYSIWYG {
     _handleIndent() {
         if (this.currentMode === 'wysiwyg') {
             this.editableArea.focus();
-            document.execCommand('indent', false, null);
+            if (!this._listIndentOutdentByDOM(false)) {
+                document.execCommand('indent', false, null);
+            }
             this._finalizeUpdate(this.editableArea.innerHTML);
         } else {
             this.markdownArea.focus();
@@ -1778,7 +1882,9 @@ class MarkdownWYSIWYG {
     _handleOutdent() {
         if (this.currentMode === 'wysiwyg') {
             this.editableArea.focus();
-            document.execCommand('outdent', false, null);
+            if (!this._listIndentOutdentByDOM(true)) {
+                document.execCommand('outdent', false, null);
+            }
             this._finalizeUpdate(this.editableArea.innerHTML);
         } else {
             this.markdownArea.focus();
@@ -2319,6 +2425,10 @@ class MarkdownWYSIWYG {
                         }
                         listItemContent += this._listToMarkdownRecursive(childNode, indent + contIndent, childNode.nodeName, 1, options);
                     } else {
+                        const isBlock = ['PRE', 'P', 'DIV', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE'].includes(childNode.nodeName);
+                        if (isBlock && listItemContent.trim().length > 0 && !listItemContent.endsWith('\n\n')) {
+                            listItemContent += '\n\n';
+                        }
                         listItemContent += this._nodeToMarkdownRecursive(childNode, options);
                     }
                 });
@@ -2330,15 +2440,20 @@ class MarkdownWYSIWYG {
 
                 // If there are subsequent lines (e.g. from <p> inside <li> or multiple blocks)
                 if (lines.length > 0) {
+                    const baseIndent = indent + contIndent;
                     lines.forEach(line => {
                         if (line.trim().length > 0) { // Only add non-empty lines
-                            processedContent += '\n' + indent + contIndent + line.trimStart(); // Indent subsequent lines
-                        } else if (processedContent.length > 0 || hasNestedList) { // Add empty line if needed for structure
-                            processedContent += '\n' + indent + contIndent;
+                            // Lines with leading whitespace are from nested list (already indented); others (e.g. PRE) need baseIndent
+                            const lineIndent = (hasNestedList && (line.startsWith(' ') || line.startsWith('\t'))) ? '' : baseIndent;
+                            processedContent += '\n' + lineIndent + line;
+                        } else if (processedContent.length > 0 || hasNestedList) { // Blank line - no indent to avoid 4-space code block interpretation
+                            processedContent += '\n';
                         }
                     });
                 }
-                markdown += `${indent}${itemMarker}${processedContent.trimEnd()}\n`; // Ensure no trailing space on the item line
+                const itemEnd = processedContent.trimEnd();
+                const isMultiLine = itemEnd.indexOf('\n') >= 0;
+                markdown += `${indent}${itemMarker}${itemEnd}\n${isMultiLine ? '\n' : ''}`; // Blank line after multi-line items for proper rendering
                 if (isOrdered) listCounter++;
             }
         });


### PR DESCRIPTION
New UI behavior
---------------

- New code block menus (for advanced and basic code blocks)
  - Code blocks now have a LANG button in the upper-right corner.  Configures language.
  - Gear icon next to lang button.  Configures auto-indent settings.
- Clicking on inline code block button will now toggle inline code block off if the cursor rests on in inline code block or a selection covers multiple inline code blocks.
- Heading button now displays the heading level as its icon when the cursor is placed on a heading.
- Admonitions and code blocks can be inserted within block quotes.  Indefinite nesting.
- Block quotes and code blocks can be inserted within admonitions.  Indefinite nesting.
- :heart_eyes: Emoji support via `:shortcode:` or Ctrl+Spacebar on all platforms to bring up emoji menu.
  - Editor prefers shortcode emoji for maximum compatibility.
  - Unicode emoji are preserved if the document already contains them to minimize diff changes.
  - `pymdownx.emoji` preferred, falling back to more limited set of unicode emoji if not available.

New keyboard shortcut behavior
------------------------------

- Document saves on CTRL+S will save the document.
- Adding three backticks to content in a row, then a code block is added.
- Advanced title behaviors within admonition title and code block title (the element refers to either).
  - If the cursor is at the beginning of the title, then pressing enter will insert a new paragraph before the element.
  - If a title is being erased on admonition, then pressing backspace on an empty title is a no-op.
  - If a title is being erased on code block, then pressing backspace on an empty title converts the advanced code block to a basic code block.
- Pressing ENTER two or three times.
  - Three: On a code block, pressing enter three times will exit the code block onto a new paragraph.
  - Three: On a block quote, pressing enter three times will exit the block quote onto a new paragraph.
  - Three: Within an admonition, pressing enter three times will exit the admonition
  - Three: On a block quote, pressing enter three times will exit the block quote.
  - Two: On a list-type, pressing enter a second time on an emty list will exit the list.
  - One: On an admonition, exiting a list requires only a single enter press to exit the admonition.
  - One: On a block quote, exiting a list or admonition requires only a single enter press to exit the block quote.
- BACKSPACE behavior
  - On an empty code block, erases the code block.
  - On an admonition with an empty content body, erases the admonition.
- Progressive selection expansion via CTRL+A.  Repeating CTRL+A expands the selection to more of the document.
  - If the cursor or selection is inside of a code block and the user presses CTRL+A, then only the content inside of the code block will be fully selected.
  - Within admonitions and advanced code blocks, selection will first expand to content body, then to include the title.  If the delete key is pressed in the selection state then the entire admonition or code block is deleted.
  - Smart section handling: selection will expand on the current paragraph, to then multiple paragraphs under current section.  Repeated presses will exexpand the selection to include the heading parent.  Ultimately until the entire document is selected.

Bugs fixes
----------

- Inserting a code block on a line with content now inserts code block after the content line.
- Inserting a code block on an empty line now replaces the line with the code block instead of adding extra lines.
- Inserting an admonition on a line with content now inserts it after content line.
- Inserting an admonition on an empty line now replaces the line with an admonition.
- Backspace on admonition titles erase the entire title and title icon destroying the underlying admonition HTML.
- List indenting now works.  It did not work at all previously/was never tested.
  - Lists have been overhauled to support N-depth children list of lists.
  - Button toggling from the three types (checklist, list, numbers) have been updated to handle N-depth children.
  - Checklists take their state from previous sibling now.
  - Checklists force user cursor after checkbox.  If a user clicks before checkbox, the cursor is moved.
  - Erasing (backspace behavior) now supports N-depth child lists.
  - Double enter, now de-indents across child lists as the user presses enter multiple times.
  - Arrow key handling and click handling prevent cursor in wrong place on checklist item.
  - Superfences support (nested list items getting code blocks and other elements).