### PR TITLE
Raw HTML support

### DIFF
--- a/docs/design/DESIGN-raw-html-preservation.md
+++ b/docs/design/DESIGN-raw-html-preservation.md
@@ -1,0 +1,279 @@
+# Raw HTML & HTML Comment Preservation
+
+## Problem
+
+Markdown documents may contain raw HTML tags and HTML comments that the WYSIWYG editor must preserve perfectly. Current behavior: `marked.parse()` passes raw HTML through to the WYSIWYG DOM, but the `_htmlToMarkdown` serializer does not recognize those elements and reconstructs them incorrectly (losing attributes, indentation, tag structure). HTML comments are stripped entirely by the browser's DOM parser (`innerHTML` discards comments).
+
+A further complication: `marked` processes content inside HTML blocks (started by tags like `<div>`) as markdown after blank lines. This means fenced code blocks, inline code, and other markdown syntax inside a `<div>` get converted to HTML elements by `marked`, then enhanced by the WYSIWYG's JavaScript (adding settings buttons, code block UI, etc.). The serializer then outputs this modified DOM, causing complete page corruption.
+
+## Requirements
+
+1. **Raw HTML tags** (block-level and inline) must round-trip perfectly: open tags, close tags, self-closing tags, attributes, indentation.
+2. **HTML comments** (single-line and multi-line) must be preserved at their exact positions with original indentation.
+3. **Markdown inside raw HTML** should be preserved. Block-level raw HTML elements are treated as opaque blobs to guarantee zero-diff. The WYSIWYG renders the HTML for visual display but marks it non-editable.
+4. **Zero diff on save** when no edits are made to a document containing raw HTML.
+5. **Indentation is sacred** -- original indentation of HTML tags and the markdown content within them must be preserved exactly, even if non-standard (e.g. 7 spaces).
+
+## Architecture
+
+The approach follows the established preprocessor/postprocessor pattern used by code blocks, list markers, table separators, and links. Raw HTML is handled at **two tiers**: block-level elements use whole-block capture, while inline elements use tag-by-tag annotation.
+
+### Phase 1: Preprocessing (markdown -> annotated markdown)
+
+`preprocessRawHtml(markdown)` scans markdown line-by-line, skipping fenced code blocks (including indented fences inside list items) and admonition syntax lines. For each non-protected line it runs three passes in order:
+
+#### 1a. Block-Level Raw HTML Capture (NEW)
+
+When a line starts with a non-markdown, non-void HTML open tag (the first non-whitespace is `<tagname`), the preprocessor captures the **entire block** from the open tag to the matching close tag as a single unit.
+
+**Strategy:** Encode the complete block (all lines from open to close, inclusive) as a single base64 string and replace with an opaque placeholder element.
+
+```
+      <div class="admonition note end">
+      <p class="admonition-title">Note</p>
+      Some **markdown** content with `inline code`.
+      </div>
+```
+becomes:
+```
+      <div data-live-wysiwyg-raw-html-block="BASE64"></div>
+```
+
+The placeholder **preserves the original indentation** from the first line of the block. This is critical when the raw HTML is inside a list item or other indented context -- without the indentation, `marked` would see the placeholder as a top-level element, breaking the list structure.
+
+The depth tracker `_countBlockTagDepth(line, tagName)` counts open/close tags of the same element on each line to handle nesting (e.g., `<div>` inside `<div>`). If the matching close tag is not found (unclosed block), the preprocessor falls through to the tag-by-tag approach.
+
+**Why whole-block capture?** `marked` processes content inside HTML blocks as markdown after blank lines. Without whole-block capture, fenced code blocks and inline code inside a `<div>` get converted to HTML elements, then the WYSIWYG adds settings buttons, code block UI wrappers, etc. The serializer outputs this corrupted DOM. By encoding the entire block as base64, the content never reaches `marked` or the WYSIWYG enhancements.
+
+#### 1b. HTML Comments (`_preprocessLineComments`)
+
+HTML comments are invisible in the DOM (`innerHTML` strips them). Multi-line comments are especially fragile.
+
+**Strategy:** Replace each HTML comment with an invisible placeholder element that survives `marked.parse()` and the DOM.
+
+```
+<!-- single line comment -->
+```
+becomes:
+```
+<span data-live-wysiwyg-html-comment="BASE64" style="display:none"></span>
+```
+
+The `data-live-wysiwyg-html-comment` attribute contains the base64-encoded original comment. For block-level comments (sole content on a line), the base64 includes the leading whitespace, preserving indentation. The `style="display:none"` keeps it invisible in the WYSIWYG.
+
+For multi-line comments, the line-walker accumulates lines from `<!--` to `-->`, joins them, and base64-encodes the full comment (with leading whitespace for block-level) into a single `<span>` placeholder.
+
+#### 1c. Inline Raw HTML Tags (`_preprocessLineTags`)
+
+Raw HTML tags that are NOT standard markdown elements and appear mid-line (or on lines that didn't trigger block capture) are annotated individually.
+
+**Strategy:** Scan each line for HTML tags using the regex `/<(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b([^>]*?)(\/?)>/g`. For each match:
+
+- Skip tags inside inline code spans (`` `...` ``).
+- Skip tags known to markdown (`_isHtmlTagKnownToMarkdown` checks against: `p`, `br`, `hr`, `em`, `strong`, `del`, `s`, `strike`, `b`, `i`, `u`, `h1`-`h6`, `ul`, `ol`, `li`, `blockquote`, `pre`, `code`, `a`, `img`, `table`, `thead`, `tbody`, `tr`, `th`, `td`, `input`, `sup`, `sub`).
+- **Open tags:** inject `data-live-wysiwyg-raw-html="BASE64"` attribute. The base64 includes leading whitespace if the tag is the first non-whitespace on the line (preserves indentation).
+- **Close tags:** append a sidecar DOM comment `<!--live-wysiwyg-raw-close:BASE64-->` immediately after the close tag.
+- **Self-closing tags:** inject `data-live-wysiwyg-raw-html="BASE64"` attribute (same as open tags).
+
+**Return value:** `{ markdown: annotatedString, comments: [...], tags: [...] }`.
+
+### Phase 2: Marked Parse (no changes needed)
+
+`marked.parse()` passes raw HTML through unchanged. Block-level placeholders (`<div data-live-wysiwyg-raw-html-block>`) survive as empty divs. Comment placeholders and inline tag annotations also survive.
+
+### Phase 3: WYSIWYG Display
+
+After `marked.parse()` and DOM insertion, `populateRawHtmlBlocks(editableArea)` runs **before** all other enhancement functions:
+
+- Finds all `[data-live-wysiwyg-raw-html-block]` elements.
+- Decodes the base64 attribute and sets `innerHTML` to the decoded HTML (rendering it visually).
+- Sets `contenteditable="false"` and `pointer-events: none` to prevent editing and interaction.
+- Adds subtle visual styling (dashed border, reduced opacity) to indicate the block is preserved HTML.
+
+The `enhanceAdmonitions` function skips elements inside raw HTML blocks (via `_isInsideRawHtmlBlock` check) to prevent adding settings buttons to non-interactive content.
+
+Comment placeholders (`<span data-live-wysiwyg-html-comment>`) are hidden via `display:none`. Inline tag annotations render normally.
+
+### Phase 4: Serialization (HTML -> markdown)
+
+The `_nodeToMarkdownRecursive` patch detects annotated elements early in the function, before any other node-type checks:
+
+#### 4a. Block-Level Raw HTML (highest priority)
+
+When encountering any element with `data-live-wysiwyg-raw-html-block`:
+- Base64-decode the attribute value.
+- Return the decoded block verbatim + newline.
+- **Do not recurse into children** -- the base64 blob is the authoritative content.
+
+#### 4b. DOM Comment Nodes (nodeType === 8)
+
+- If the comment has `_liveWysiwygConsumed` flag set, return `''` (already consumed by the open-tag handler).
+- If the comment data starts with `live-wysiwyg-raw-close:`, base64-decode the rest and return the original close tag + newline.
+- Otherwise return `''` (ignore unknown DOM comments).
+
+#### 4c. HTML Comment Placeholders
+
+When encountering any element (nodeType === 1) with `data-live-wysiwyg-html-comment`:
+- Base64-decode the attribute value.
+- Return the decoded comment verbatim + newline.
+
+#### 4d. Inline Raw HTML Open/Self-Closing Tags
+
+When encountering any element with `data-live-wysiwyg-raw-html`:
+- Base64-decode the attribute to get the original tag string (including preserved indentation).
+- Serialize child nodes, with special handling:
+  - **Annotated children** (having `data-live-wysiwyg-raw-html` or `data-live-wysiwyg-html-comment`): handled by the normal recursive serializer path.
+  - **Non-annotated element children**: serialized via `_serializeElementAsHtml`, preserving tag names, attributes, and inner content.
+  - **Text nodes**: output `textContent` directly.
+  - **Sidecar close-tag comments**: skipped (handled by close-tag search below).
+- Search forward through `nextSibling` for the matching `live-wysiwyg-raw-close:` DOM comment. Decode and set `_liveWysiwygConsumed = true`.
+- Return: original open tag + newline + child content + close tag + newline.
+
+**Priority order:** `data-live-wysiwyg-raw-html-block` > `data-live-wysiwyg-html-comment` > `data-live-wysiwyg-raw-html` > all other handlers.
+
+### Phase 5: Postprocessing
+
+`postprocessRawHtml(markdown, rawHtmlData)` runs after `_htmlToMarkdown` and before final output. Currently a passthrough; available for future edge-case corrections.
+
+## Data Flow
+
+```
+Original markdown
+       |
+       v
+preprocessRawHtml()          -- block capture, annotate inline tags, replace comments
+       |
+       v
+_markdownToHtml()            -- marked.parse (block placeholders pass through as empty divs)
+       |
+       v
+populateRawHtmlBlocks()      -- decode & render block HTML as non-editable visual preview
+       |
+       v
+WYSIWYG DOM                  -- user edits markdown content normally (raw HTML blocks locked)
+       |
+       v
+_htmlToMarkdown()            -- patched serializer: blocks→decoded blob, inline→decoded tags
+       |
+       v
+postprocessRawHtml()         -- passthrough (future edge-case fixes)
+       |
+       v
+Final markdown (zero diff)
+```
+
+## Integration Points
+
+All changes are in `live-wysiwyg-integration.js`:
+
+1. **`preprocessRawHtml(markdown)`** -- returns `{ markdown, comments, tags }`.
+2. **`populateRawHtmlBlocks(editableArea)`** -- decodes block placeholders and renders visual preview (called before all enhancement functions).
+3. **`postprocessRawHtml(markdown, rawHtmlData)`** -- currently passthrough.
+4. **`patchMarkdownToHtmlForRawHtml`** -- patches `_markdownToHtml` to run `preprocessRawHtml` before all other markdown-to-HTML patches (emoji, cursor markers). Stores the result as `this._liveWysiwygRawHtmlData`.
+5. **`patchSetValueAndSwitchToModeForLinkPrePost` `switchToMode`** -- calls `postprocessRawHtml` when switching to markdown mode.
+6. **`patchGetValueForListMarkers` `getValue`** -- calls `postprocessRawHtml` before returning final markdown.
+7. **`_nodeToMarkdownRecursive` patch** (in `patchAdmonitionHtmlToMarkdown`) -- handles block-level raw HTML, comment placeholders, inline raw HTML, and sidecar close-tag comments.
+
+### Helper Functions
+
+- **`_b64Encode(str)`** / **`_b64Decode(str)`** -- UTF-8-safe base64 encoding/decoding via `btoa`/`atob` with `encodeURIComponent`/`decodeURIComponent` wrappers.
+- **`_isHtmlTagKnownToMarkdown(tag)`** -- returns `true` for tags that markdown natively generates (should not be annotated).
+- **`_countBlockTagDepth(line, tagName)`** -- counts open/close tags of a specific element on a single line. Open tags increment depth, close tags decrement, self-closing tags are neutral. Used by the block capture to track nesting.
+- **`_isInsideRawHtmlBlock(el)`** -- walks up the DOM tree to check if an element is inside a `data-live-wysiwyg-raw-html-block` container. Used by `enhanceAdmonitions` to skip enhancement of content inside raw HTML blocks.
+- **`_preprocessLineComments(line, lines, idx, comments, result)`** -- handles single-line and multi-line HTML comment detection and replacement. Includes leading whitespace in base64 for block-level comments.
+- **`_preprocessLineTags(line, tags, result)`** -- scans a line for all raw HTML tags (open, close, self-closing) and annotates them. Protects inline code spans from processing. Skips markdown autolinks (`<https://...>`, `<user@example.com>`).
+- **`_serializeElementAsHtml(node)`** -- recursively reconstructs an element's HTML string (tag name, attributes, children). Used by the inline raw HTML serializer to preserve non-annotated child elements inside annotated tags. Strips internal `data-live-wysiwyg-*` attributes from output.
+- **`populateRawHtmlBlocks(editableArea)`** -- post-DOM-insertion function that decodes block placeholders, sets innerHTML, marks as non-editable, and applies visual styling.
+
+### Constants
+
+- `RAW_HTML_ATTR = 'data-live-wysiwyg-raw-html'` -- inline tag annotation
+- `RAW_HTML_CLOSE_PREFIX = 'live-wysiwyg-raw-close:'` -- sidecar close-tag comment prefix
+- `RAW_HTML_COMMENT_ATTR = 'data-live-wysiwyg-html-comment'` -- comment placeholder
+- `RAW_HTML_BLOCK_ATTR = 'data-live-wysiwyg-raw-html-block'` -- whole-block capture placeholder
+
+## Edge Cases
+
+- **Block-level raw HTML with blank lines**: the whole-block capture encodes everything between open and close tags, preventing `marked` from processing content after blank lines as markdown.
+- **Block-level raw HTML containing markdown**: fenced code blocks, inline code, headings etc. inside raw HTML `<div>` elements are preserved verbatim (not processed by marked or WYSIWYG).
+- **Unclosed block-level raw HTML**: if the depth tracker doesn't find the matching close tag, the block capture is abandoned and the line falls through to inline tag annotation.
+- **Self-closing tags** (`<custom-widget/>`): detected and encoded as single units with `data-live-wysiwyg-raw-html`. No close-tag sidecar needed.
+- **Inline HTML within paragraphs** (`<span class="x">text</span>`): both the open `<span>` and close `</span>` are annotated within the same line. The serializer outputs them verbatim around the text content.
+- **HTML comments after reference links**: comments at the end of the document (common for linter directives) are preserved at their exact line positions.
+- **HTML comments within markdown blocks**: e.g., `<!-- TODO -->` between paragraphs. The placeholder `<span>` is a block-level break point.
+- **Nested raw HTML**: e.g., `<div><div>markdown</div></div>`. The depth tracker correctly handles nested tags of the same type.
+- **Raw HTML that matches known elements** (e.g., `<div class="admonition note">`): block capture takes priority; WYSIWYG enhancements are skipped inside raw HTML blocks.
+- **Indented raw HTML**: the preprocessor captures leading whitespace in the base64 encoding. For block capture, the entire block including indentation is encoded.
+- **Tags inside inline code spans**: protected by the code-span detection in `_preprocessLineTags`; they are not annotated.
+- **Tags inside fenced code blocks**: protected by the line-by-line fenced-code tracker in `preprocessRawHtml`; they are not annotated. The fence regex `^(\s*)(\`{3,}|~{3,})` handles indented fences.
+- **WYSIWYG enhancements inside raw HTML blocks**: `enhanceAdmonitions` skips elements inside `[data-live-wysiwyg-raw-html-block]` via `_isInsideRawHtmlBlock`. The block is marked `contenteditable="false"` and `pointer-events: none`.
+
+## Implementation Quirks
+
+### Block-level vs inline: two tiers of raw HTML handling
+
+The preprocessor uses two strategies depending on where the HTML appears:
+
+1. **Block-level** (tag is first non-whitespace on a line, not known to markdown, not void): Entire block from open tag to matching close tag is encoded as a single base64 blob in `data-live-wysiwyg-raw-html-block`. Content is never processed by `marked` or WYSIWYG enhancements. Serializer outputs the decoded blob verbatim.
+
+2. **Inline** (tag appears mid-line, or block detection was skipped): Individual tags are annotated with `data-live-wysiwyg-raw-html` or sidecar comments. Content between tags IS processed by `marked` and editable in the WYSIWYG. Serializer reconstructs the original tags from base64 annotations.
+
+Block capture runs BEFORE comment and inline tag processing. Lines consumed by block capture are not processed by the comment or tag handlers.
+
+### Base64 encoding preserves indentation for both tags and comments
+
+When a raw HTML tag or comment is the first non-whitespace on a line (i.e., it's block-level), the base64-encoded string includes the leading whitespace. For block capture, the ENTIRE block (all lines with original indentation) is encoded as-is.
+
+For inline tags, the logic is in `_preprocessLineTags`:
+
+```javascript
+var onlyWhitespace = /^[ \t]*$/.test(prefixText);
+var originalForEncode = (onlyWhitespace && lastIdx === 0) ? prefixText + fullTag : fullTag;
+```
+
+For comments, the same pattern applies in `_preprocessLineComments`:
+
+```javascript
+var isBlockComment = !before.trim() && !after.trim();
+var originalForEncode = isBlockComment ? before + comment : comment;
+```
+
+### Close tags use sidecar DOM comments because they cannot carry attributes
+
+HTML close tags like `</div>` have no place for a `data-*` attribute. Instead, the preprocessor appends a DOM comment immediately after:
+
+```
+</div><!--live-wysiwyg-raw-close:BASE64-->
+```
+
+### The `_liveWysiwygConsumed` flag prevents double-output of close tags
+
+When the open-tag handler searches forward through siblings for the matching close-tag sidecar, it sets `nextSib._liveWysiwygConsumed = true`.
+
+### UTF-8 base64 encoding uses a URI-component roundtrip
+
+JavaScript's `btoa` only handles Latin1 characters. `_b64Encode` uses `btoa(unescape(encodeURIComponent(str)))` and `_b64Decode` uses `decodeURIComponent(escape(atob(str)))`.
+
+### Markdown autolinks (`<https://...>`) are not raw HTML
+
+The tag regex in `_preprocessLineTags` skips any "tag" whose content starts with `://` (URL autolink) or `@` (email autolink).
+
+### Bare URLs are preserved by the serializer
+
+When `marked` converts a bare URL into `<a href="url">url</a>`, the serializer detects that the link text matches the href and outputs just the bare URL text instead of wrapping it as `[url](url)`.
+
+### Reference link definitions and trailing HTML comments
+
+Reference link definitions are re-appended by `postprocessMarkdownLinks`. When the document ends with HTML comments, ref defs are inserted BEFORE the last trailing HTML comment.
+
+`postprocessMarkdownLinks` checks each ref def individually by name (case-insensitive) against the result, only appending ref defs that are not already present.
+
+`dryDuplicateInlineLinks` skips inline links where the link text matches the URL (bare URL pattern).
+
+### Admonition type names are normalized to lowercase
+
+The `marked.js` admonition tokenizer lowercases the type name (`match[2].toLowerCase()`).
+
+## Testing Criteria
+
+The user's quality check: open a document with HTML, switch between modes, save without editing. There must be **zero diff** on the HTML parts.

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -1536,16 +1536,48 @@
     return null;
   }
 
+  function populateRawHtmlBlocks(editableArea) {
+    if (!editableArea) return;
+    var blocks = editableArea.querySelectorAll('[' + RAW_HTML_BLOCK_ATTR + ']');
+    for (var bi = 0; bi < blocks.length; bi++) {
+      var block = blocks[bi];
+      if (block._rawHtmlPopulated) continue;
+      var b64 = block.getAttribute(RAW_HTML_BLOCK_ATTR);
+      if (!b64) continue;
+      var decoded = _b64Decode(b64);
+      block.innerHTML = decoded;
+      block.setAttribute('contenteditable', 'false');
+      block.style.border = '1px dashed #ccc';
+      block.style.borderRadius = '4px';
+      block.style.padding = '4px';
+      block.style.margin = '4px 0';
+      block.style.opacity = '0.85';
+      block.style.pointerEvents = 'none';
+      block._rawHtmlPopulated = true;
+    }
+  }
+
+  function _isInsideRawHtmlBlock(el) {
+    var p = el.parentNode;
+    while (p && p !== document) {
+      if (p.getAttribute && p.getAttribute(RAW_HTML_BLOCK_ATTR)) return true;
+      p = p.parentNode;
+    }
+    return false;
+  }
+
   function enhanceAdmonitions(editableArea) {
     if (!editableArea) return;
     var admonitions = editableArea.querySelectorAll('.admonition');
     for (var i = 0; i < admonitions.length; i++) {
+      if (_isInsideRawHtmlBlock(admonitions[i])) continue;
       addSettingsButtonToAdmonition(admonitions[i]);
     }
     for (var j = 0; j < ADMONITION_TYPE_IDS.length; j++) {
       var detailsEls = editableArea.querySelectorAll('details.' + ADMONITION_TYPE_IDS[j]);
       for (var k = 0; k < detailsEls.length; k++) {
         var det = detailsEls[k];
+        if (_isInsideRawHtmlBlock(det)) continue;
         det.setAttribute('open', '');
         addSettingsButtonToAdmonition(det);
         var summary = det.querySelector(':scope > summary');
@@ -2015,6 +2047,71 @@
       if (node.nodeName === 'INPUT' && node.type === 'checkbox') {
         return (node.checked ? '[x]' : '[ ]');
       }
+      if (node.nodeType === 8) {
+        if (node._liveWysiwygConsumed) return '';
+        var commentData = (node.data || '').trim();
+        if (commentData.indexOf(RAW_HTML_CLOSE_PREFIX) === 0) {
+          var b64 = commentData.substring(RAW_HTML_CLOSE_PREFIX.length);
+          return _b64Decode(b64) + '\n';
+        }
+        return '';
+      }
+      if (node.nodeType === 1 && node.getAttribute) {
+        var rawBlockB64 = node.getAttribute(RAW_HTML_BLOCK_ATTR);
+        if (rawBlockB64) {
+          var decoded = _b64Decode(rawBlockB64);
+          if (!this._rawHtmlPlaceholders) this._rawHtmlPlaceholders = [];
+          var idx = this._rawHtmlPlaceholders.length;
+          this._rawHtmlPlaceholders.push(decoded);
+          return '\u0000__RAWHTMLBLOCK_' + idx + '__\u0000\n';
+        }
+        var commentB64 = node.getAttribute(RAW_HTML_COMMENT_ATTR);
+        if (commentB64) {
+          var decoded = _b64Decode(commentB64);
+          if (!this._rawHtmlPlaceholders) this._rawHtmlPlaceholders = [];
+          var idx = this._rawHtmlPlaceholders.length;
+          this._rawHtmlPlaceholders.push(decoded);
+          return '\u0000__RAWHTMLBLOCK_' + idx + '__\u0000\n';
+        }
+        var rawTagB64 = node.getAttribute(RAW_HTML_ATTR);
+        if (rawTagB64) {
+          var originalOpenTag = _b64Decode(rawTagB64);
+          var childMd = '';
+          for (var ri = 0; ri < node.childNodes.length; ri++) {
+            var rChild = node.childNodes[ri];
+            if (rChild.nodeType === 8) {
+              var rData = (rChild.data || '').trim();
+              if (rData.indexOf(RAW_HTML_CLOSE_PREFIX) === 0) continue;
+            }
+            if (rChild.nodeType === 1 && rChild.getAttribute) {
+              if (rChild.getAttribute(RAW_HTML_COMMENT_ATTR) || rChild.getAttribute(RAW_HTML_ATTR)) {
+                childMd += this._nodeToMarkdownRecursive(rChild, options || {});
+              } else {
+                childMd += _serializeElementAsHtml(rChild);
+              }
+            } else if (rChild.nodeType === 3) {
+              childMd += rChild.textContent;
+            } else {
+              childMd += this._nodeToMarkdownRecursive(rChild, options || {});
+            }
+          }
+          var closeTag = '';
+          var nextSib = node.nextSibling;
+          while (nextSib) {
+            if (nextSib.nodeType === 8) {
+              var nd = (nextSib.data || '').trim();
+              if (nd.indexOf(RAW_HTML_CLOSE_PREFIX) === 0) {
+                closeTag = _b64Decode(nd.substring(RAW_HTML_CLOSE_PREFIX.length));
+                nextSib._liveWysiwygConsumed = true;
+                break;
+              }
+            }
+            if (nextSib.nodeType === 1 || (nextSib.nodeType === 3 && nextSib.textContent.trim())) break;
+            nextSib = nextSib.nextSibling;
+          }
+          return originalOpenTag + '\n' + childMd + (closeTag ? closeTag + '\n' : '');
+        }
+      }
       // #text: preserve multiple spaces (upstream collapses with /  +/g)
       if (node.nodeName === '#text') {
         var text = node.textContent.replace(/\u00a0/g, ' ');
@@ -2159,6 +2256,9 @@
             var origUrl = normalizeUrl(o.url);
             var origText = (o.text || '').replace(CURSOR_UNICODE_RE, '').replace(/\s+/g, ' ').replace(/\u00a0/g, ' ').trim();
             if (origUrl === cleanUrl && origText === cleanText) {
+              if (o.isAutolink) {
+                return '<' + href + '>';
+              }
               var shortMatch = (o.original || '').match(/^\[([^\]]+)\]$/);
               if (shortMatch) {
                 return '[' + linkText + ']';
@@ -2166,6 +2266,10 @@
               break;
             }
           }
+        }
+        var bareText = (linkText || '').replace(CURSOR_UNICODE_RE, '').trim();
+        if (bareText && href && normalizeUrl(bareText) === normalizeUrl(href)) {
+          return bareText;
         }
       }
       return orig.apply(this, arguments);
@@ -2201,7 +2305,39 @@
     proto._listToMarkdownRecursive = function (listNode, indent, listType, listCounter, options) {
       var result = origListToMarkdown.apply(this, arguments);
       var listData = this._liveWysiwygListMarkerData;
-      if (!listData || !listData.listItems || !listData.listItems.length || listType === 'OL') return result;
+      if (!listData || !listData.listItems || !listData.listItems.length) return result;
+      if (listType === 'OL') {
+        var olOriginals = listData.listItems;
+        var olUsed = listData._olUsed || 0;
+        var olLines = result.split('\n');
+        var olStyle = listData.olStyle;
+        for (var oi = 0; oi < olLines.length; oi++) {
+          var olm = olLines[oi].match(/^(\s*)(\d+)\.\s+(.*)$/);
+          if (!olm) continue;
+          var olIndent = olm[1];
+          var olContent = olm[3];
+          var olNorm = normalizeContentForListMatch(olContent);
+          var matched = false;
+          for (var oj = olUsed; oj < olOriginals.length; oj++) {
+            var oo = olOriginals[oj];
+            if (!oo.isOrdered) continue;
+            if (oo.indent !== olIndent) continue;
+            if (normalizeContentForListMatch(oo.content) === olNorm) {
+              olUsed = oj + 1;
+              olLines[oi] = olIndent + oo.number + '. ' + olContent;
+              matched = true;
+              break;
+            }
+          }
+          if (!matched && olStyle === 'all-ones') {
+            olLines[oi] = olIndent + '1. ' + olContent;
+          }
+        }
+        listData._olUsed = olUsed;
+        var olResult = olLines.join('\n');
+        olResult = _compactOlBlankLines(olResult);
+        return olResult;
+      }
       var originals = listData.listItems;
       var used = 0;
       var lines = result.split('\n');
@@ -2236,7 +2372,9 @@
           }
         }
       }
-      return lines.join('\n');
+      var ulResult = lines.join('\n');
+      ulResult = _compactUlBlankLines(ulResult);
+      return ulResult;
     };
   })();
 
@@ -2307,6 +2445,25 @@
         codeBlocks[j] = codeBlocks[j].replace(/[ \t]+$/gm, '');
         protected_ = protected_.split(placeholderPrefix + j + placeholderSuffix).join(codeBlocks[j]);
       }
+      var rawHtmlBlocks = this._rawHtmlPlaceholders || [];
+      this._rawHtmlPlaceholders = null;
+      var rawPrefix = '\u0000__RAWHTMLBLOCK_';
+      var rawSuffix = '__\u0000';
+      for (var ri = 0; ri < rawHtmlBlocks.length; ri++) {
+        var rawPh = rawPrefix + ri + rawSuffix;
+        var rawIdx = protected_.indexOf(rawPh);
+        if (rawIdx === -1) continue;
+        var lineStart = protected_.lastIndexOf('\n', rawIdx - 1);
+        lineStart = lineStart === -1 ? 0 : lineStart + 1;
+        var beforePh = protected_.substring(lineStart, rawIdx);
+        var lineEnd = protected_.indexOf('\n', rawIdx + rawPh.length);
+        if (lineEnd === -1) lineEnd = protected_.length;
+        if (/^\s*$/.test(beforePh)) {
+          protected_ = protected_.substring(0, lineStart) + rawHtmlBlocks[ri] + protected_.substring(lineEnd);
+        } else {
+          protected_ = protected_.substring(0, rawIdx) + rawHtmlBlocks[ri] + protected_.substring(rawIdx + rawPh.length);
+        }
+      }
       return protected_.trim();
     };
   })();
@@ -2333,11 +2490,13 @@
    * Returns { listItems: [{ indent, marker, content, isChecklist?, checked? }] } for preservation.
    */
   function preprocessListMarkers(markdown) {
-    if (!markdown || typeof markdown !== 'string') return { listItems: [] };
+    if (!markdown || typeof markdown !== 'string') return { listItems: [], olStyle: null };
     var listItems = [];
     var lines = markdown.split('\n');
     var checklistRe = /^(\s*)([-*+])\s+\[([ xX])\]\s+(.*)$/;
     var regularRe = /^(\s*)([-*+])\s+(.*)$/;
+    var orderedRe = /^(\s*)(\d+)(\.)\s+(.*)$/;
+    var olNumbers = [];
     for (var i = 0; i < lines.length; i++) {
       var m = lines[i].match(checklistRe);
       if (m) {
@@ -2350,12 +2509,24 @@
         });
         continue;
       }
+      m = lines[i].match(orderedRe);
+      if (m) {
+        var num = m[2];
+        olNumbers.push(parseInt(num, 10));
+        listItems.push({ indent: m[1], marker: num + '. ', content: m[4], isOrdered: true, number: num });
+        continue;
+      }
       m = lines[i].match(regularRe);
       if (m) {
         listItems.push({ indent: m[1], marker: m[2] + ' ', content: m[3] });
       }
     }
-    return { listItems: listItems };
+    var olStyle = null;
+    if (olNumbers.length > 1) {
+      var allOnes = olNumbers.every(function(n) { return n === 1; });
+      olStyle = allOnes ? 'all-ones' : 'incrementing';
+    }
+    return { listItems: listItems, olStyle: olStyle };
   }
 
   /**
@@ -2373,11 +2544,12 @@
     if (!listData || !listData.listItems || !listData.listItems.length) return markdown;
     var originals = listData.listItems;
     var used = 0;
+    var olUsed = 0;
     function restoreRegular(match, indent, marker, content) {
       var normContent = normalizeContentForListMatch(content);
       for (var i = used; i < originals.length; i++) {
         var o = originals[i];
-        if (!o.isChecklist && o.indent === indent && normalizeContentForListMatch(o.content) === normContent) {
+        if (!o.isChecklist && !o.isOrdered && o.indent === indent && normalizeContentForListMatch(o.content) === normContent) {
           used = i + 1;
           return indent + o.marker + content;
         }
@@ -2396,9 +2568,26 @@
       }
       return match;
     }
+    function restoreOrdered(match, indent, num, content) {
+      var normContent = normalizeContentForListMatch(content);
+      for (var i = olUsed; i < originals.length; i++) {
+        var o = originals[i];
+        if (o.isOrdered && o.indent === indent && normalizeContentForListMatch(o.content) === normContent) {
+          olUsed = i + 1;
+          return indent + o.number + '. ' + content;
+        }
+      }
+      if (listData.olStyle === 'all-ones') {
+        return indent + '1. ' + content;
+      }
+      return match;
+    }
     var result = markdown
       .replace(/^(\s*)(-\s+)\[([ xX])\]\s+(.*)$/gm, restoreChecklist)
-      .replace(/^(\s*)(-\s+)(.*)$/gm, restoreRegular);
+      .replace(/^(\s*)(-\s+)(.*)$/gm, restoreRegular)
+      .replace(/^(\s*)(\d+)\.\s+(.*)$/gm, restoreOrdered);
+    result = _compactOlBlankLines(result);
+    result = _compactUlBlankLines(result);
     return result;
   }
 
@@ -2545,6 +2734,380 @@
       }
     }
     return lines.join('\n');
+  }
+
+  function preprocessHorizontalRules(markdown) {
+    if (!markdown || typeof markdown !== 'string') return { rules: [] };
+    var rules = [];
+    var lines = markdown.split('\n');
+    var inFencedCode = false;
+    var fencePattern = null;
+    var hrRe = /^\s*([-*_])(\s*\1){2,}\s*$/;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (inFencedCode) {
+        if (fencePattern && fencePattern.test(line)) {
+          inFencedCode = false;
+          fencePattern = null;
+        }
+        continue;
+      }
+      var fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        inFencedCode = true;
+        var fc = fenceMatch[2];
+        fencePattern = new RegExp('^\\s*' + fc.charAt(0) + '{' + fc.length + ',}\\s*$');
+        continue;
+      }
+      if (!hrRe.test(line)) continue;
+      if (/^\s*-/.test(line)) {
+        var isSetext = false;
+        for (var j = i - 1; j >= 0; j--) {
+          if (/^\s*$/.test(lines[j])) break;
+          isSetext = true;
+          break;
+        }
+        if (isSetext) continue;
+      }
+      rules.push(line);
+    }
+    return { rules: rules };
+  }
+
+  function postprocessHorizontalRules(markdown, hrData) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    if (!hrData || !hrData.rules || !hrData.rules.length) return markdown;
+    var originals = hrData.rules;
+    var used = 0;
+    var lines = markdown.split('\n');
+    var inFencedCode = false;
+    var fencePattern = null;
+    for (var i = 0; i < lines.length; i++) {
+      if (used >= originals.length) break;
+      var line = lines[i];
+      if (inFencedCode) {
+        if (fencePattern && fencePattern.test(line)) {
+          inFencedCode = false;
+          fencePattern = null;
+        }
+        continue;
+      }
+      var fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        inFencedCode = true;
+        var fc = fenceMatch[2];
+        fencePattern = new RegExp('^\\s*' + fc.charAt(0) + '{' + fc.length + ',}\\s*$');
+        continue;
+      }
+      if (/^\s*---\s*$/.test(line)) {
+        lines[i] = originals[used];
+        used++;
+      }
+    }
+    return lines.join('\n');
+  }
+
+  var RAW_HTML_ATTR = 'data-live-wysiwyg-raw-html';
+  var RAW_HTML_CLOSE_PREFIX = 'live-wysiwyg-raw-close:';
+  var RAW_HTML_COMMENT_ATTR = 'data-live-wysiwyg-html-comment';
+  var RAW_HTML_BLOCK_ATTR = 'data-live-wysiwyg-raw-html-block';
+
+  function _serializeElementAsHtml(node) {
+    if (node.nodeType === 3) return node.textContent;
+    if (node.nodeType !== 1) return '';
+    var tag = node.nodeName.toLowerCase();
+    var attrs = '';
+    if (node.attributes) {
+      for (var ai = 0; ai < node.attributes.length; ai++) {
+        var attr = node.attributes[ai];
+        if (attr.name === RAW_HTML_ATTR || attr.name === RAW_HTML_COMMENT_ATTR || attr.name === RAW_HTML_BLOCK_ATTR) continue;
+        attrs += ' ' + attr.name + '="' + attr.value.replace(/"/g, '&quot;') + '"';
+      }
+    }
+    var voidTags = ['br','hr','img','input','col','area','base','link','meta','source','track','wbr'];
+    if (voidTags.indexOf(tag) >= 0) return '<' + tag + attrs + '>';
+    var inner = '';
+    for (var ci = 0; ci < node.childNodes.length; ci++) {
+      inner += _serializeElementAsHtml(node.childNodes[ci]);
+    }
+    return '<' + tag + attrs + '>' + inner + '</' + tag + '>';
+  }
+
+  function _countBlockTagDepth(line, tagName) {
+    var re = new RegExp('<(/??)\\s*' + tagName + '\\b([^>]*?)(/?)\\s*>', 'gi');
+    var depth = 0;
+    var m;
+    while ((m = re.exec(line)) !== null) {
+      var isClose = m[1] === '/';
+      var isSelfClose = m[3] === '/';
+      if (isClose) depth--;
+      else if (!isSelfClose) depth++;
+    }
+    return depth;
+  }
+
+  var _rawHtmlVoidTags = ['br','hr','img','input','col','area','base','link','meta','source','track','wbr'];
+
+  function _b64Encode(str) {
+    try { return btoa(unescape(encodeURIComponent(str))); }
+    catch (e) { return btoa(str); }
+  }
+
+  function _b64Decode(str) {
+    try { return decodeURIComponent(escape(atob(str))); }
+    catch (e) { try { return atob(str); } catch (e2) { return str; } }
+  }
+
+  function _stripCommonLeadingWhitespace(text) {
+    var lines = text.split('\n');
+    var minIndent = Infinity;
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].trim().length === 0) continue;
+      var leading = lines[i].match(/^(\s*)/)[1].length;
+      if (leading < minIndent) minIndent = leading;
+    }
+    if (minIndent > 0 && minIndent < Infinity) {
+      for (var i = 0; i < lines.length; i++) {
+        if (lines[i].trim().length === 0) continue;
+        lines[i] = lines[i].substring(minIndent);
+      }
+    }
+    return lines.join('\n');
+  }
+
+  var _keepBlankBeforeListRe = /^\s*(`{3,}|~{3,})\s*$|^\s*<|^\s*>|\u0000__RAWHTMLBLOCK_/;
+  var _isListContextLineRe = /^\s|^\d+\.\s|^[-*+]\s/;
+
+  function _compactOlBlankLines(text) {
+    return text.replace(/([^\n]*)\n[ \t]*\n(?=\s*\d+\.\s)/g, function (match, prevLine) {
+      if (_keepBlankBeforeListRe.test(prevLine)) return match;
+      if (!_isListContextLineRe.test(prevLine)) return match;
+      return prevLine + '\n';
+    });
+  }
+
+  function _compactUlBlankLines(text) {
+    return text.replace(/([^\n]*)\n[ \t]*\n(?=\s*[-*+]\s)/g, function (match, prevLine) {
+      if (_keepBlankBeforeListRe.test(prevLine)) return match;
+      if (!_isListContextLineRe.test(prevLine)) return match;
+      return prevLine + '\n';
+    });
+  }
+
+  function _isHtmlTagKnownToMarkdown(tag) {
+    var m = tag.match(/^<\/?([a-zA-Z][a-zA-Z0-9]*)/);
+    if (!m) return false;
+    var name = m[1].toLowerCase();
+    var mdTags = ['p','br','hr','em','strong','del','s','strike','b','i','u',
+      'h1','h2','h3','h4','h5','h6','ul','ol','li','blockquote',
+      'pre','code','a','img','table','thead','tbody','tr','th','td',
+      'input','sup','sub'];
+    return mdTags.indexOf(name) >= 0;
+  }
+
+  function preprocessRawHtml(markdown) {
+    if (!markdown || typeof markdown !== 'string') return { markdown: markdown, comments: [], tags: [] };
+    var comments = [];
+    var tags = [];
+
+    var lines = markdown.split('\n');
+    var inFencedCode = false;
+    var fencePattern = null;
+    var result = [];
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+
+      if (inFencedCode) {
+        if (fencePattern && fencePattern.test(line)) {
+          inFencedCode = false;
+          fencePattern = null;
+        }
+        result.push(line);
+        continue;
+      }
+
+      var fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        inFencedCode = true;
+        var fc = fenceMatch[2];
+        fencePattern = new RegExp('^\\s*' + fc.charAt(0) + '{' + fc.length + ',}\\s*$');
+        result.push(line);
+        continue;
+      }
+
+      var admonitionMatch = line.match(/^(\s*)(\?\?\?\+|\?\?\?|!!!)\s+\w+/);
+      if (admonitionMatch) {
+        result.push(line);
+        continue;
+      }
+
+      var blockOpenMatch = line.match(/^(\s*)<([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/);
+      if (blockOpenMatch && !/\/\s*>$/.test(blockOpenMatch[0])) {
+        var bTagName = blockOpenMatch[2].toLowerCase();
+        if (!_isHtmlTagKnownToMarkdown('<' + bTagName + '>') && _rawHtmlVoidTags.indexOf(bTagName) < 0) {
+          var blockLines = [line];
+          var depth = _countBlockTagDepth(line, bTagName);
+          var blockClosed = (depth <= 0);
+          if (depth > 0) {
+            var j = i + 1;
+            while (j < lines.length && depth > 0) {
+              blockLines.push(lines[j]);
+              depth += _countBlockTagDepth(lines[j], bTagName);
+              j++;
+            }
+            blockClosed = (depth <= 0);
+            if (blockClosed) i = j - 1;
+          }
+          if (blockClosed) {
+            var fullBlock = blockLines.join('\n');
+            var encoded = _b64Encode(fullBlock);
+            var blockIndent = blockOpenMatch[1] || '';
+            result.push(blockIndent + '<div ' + RAW_HTML_BLOCK_ATTR + '="' + encoded + '"></div>');
+            continue;
+          }
+        }
+      }
+
+      var commentProcessed = _preprocessLineComments(line, lines, i, comments, result);
+      if (commentProcessed !== false) {
+        i = commentProcessed;
+        continue;
+      }
+
+      var tagProcessed = _preprocessLineTags(line, tags, result);
+      if (tagProcessed) {
+        continue;
+      }
+
+      result.push(line);
+    }
+
+    return { markdown: result.join('\n'), comments: comments, tags: tags };
+  }
+
+  function _preprocessLineComments(line, lines, idx, comments, result) {
+    var commentStart = line.indexOf('<!--');
+    if (commentStart === -1) return false;
+
+    var commentEnd = line.indexOf('-->', commentStart + 4);
+    if (commentEnd !== -1) {
+      var before = line.substring(0, commentStart);
+      var comment = line.substring(commentStart, commentEnd + 3);
+      var after = line.substring(commentEnd + 3);
+      var isBlockComment = !before.trim() && !after.trim();
+      var originalForEncode = isBlockComment ? before + comment : comment;
+      var encoded = _b64Encode(originalForEncode);
+      var idx_ = comments.length;
+      comments.push({ original: comment, leading: isBlockComment ? before : '', lineIdx: idx });
+      var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" style="display:none"></span>';
+      if (isBlockComment) {
+        result.push(before + placeholder + after);
+      } else {
+        result.push(before + placeholder + after);
+      }
+      return idx;
+    }
+
+    var multiLines = [line];
+    var j = idx + 1;
+    while (j < lines.length) {
+      multiLines.push(lines[j]);
+      if (lines[j].indexOf('-->') !== -1) break;
+      j++;
+    }
+    var fullComment = multiLines.join('\n');
+    var endPos = fullComment.indexOf('-->');
+    if (endPos === -1) {
+      result.push(line);
+      return false;
+    }
+    var leading = line.substring(0, commentStart);
+    var commentText = fullComment.substring(commentStart, endPos + 3);
+    var afterComment = fullComment.substring(endPos + 3);
+    var isBlockComment = !leading.trim();
+    var originalForEncode = isBlockComment ? leading + commentText : commentText;
+
+    var encoded = _b64Encode(originalForEncode);
+    comments.push({ original: commentText, leading: isBlockComment ? leading : '', lineIdx: idx });
+    var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" style="display:none"></span>';
+    var afterLines = afterComment.split('\n');
+    result.push(leading + placeholder + afterLines[0]);
+    for (var k = 1; k < afterLines.length; k++) {
+      result.push(afterLines[k]);
+    }
+    return j;
+  }
+
+  function _preprocessLineTags(line, tags, result) {
+    var tagRe = /<(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b([^>]*?)(\/?)>/g;
+    var out = '';
+    var lastIdx = 0;
+    var changed = false;
+    var m;
+
+    var codeSpans = [];
+    var csRe = /`[^`\n]+`/g;
+    var csm;
+    while ((csm = csRe.exec(line)) !== null) {
+      codeSpans.push({ start: csm.index, end: csm.index + csm[0].length });
+    }
+    function isInsideCodeSpan(pos) {
+      for (var k = 0; k < codeSpans.length; k++) {
+        if (pos >= codeSpans[k].start && pos < codeSpans[k].end) return true;
+      }
+      return false;
+    }
+
+    while ((m = tagRe.exec(line)) !== null) {
+      if (isInsideCodeSpan(m.index)) continue;
+
+      var fullTag = m[0];
+      var tagName = m[2];
+      var isClose = m[1] === '/';
+      var isSelfClose = m[4] === '/';
+
+      if (_isHtmlTagKnownToMarkdown(fullTag)) continue;
+
+      var tagContent = m[3] || '';
+      if (!isClose && /^:\/\//.test(tagContent)) continue;
+      var innerText = tagName + tagContent;
+      if (!isClose && innerText.indexOf('@') >= 0 && innerText.indexOf(' ') === -1) continue;
+
+      changed = true;
+
+      var prefixText = line.substring(lastIdx, m.index);
+      var onlyWhitespace = /^[ \t]*$/.test(prefixText);
+      var originalForEncode = (onlyWhitespace && lastIdx === 0) ? prefixText + fullTag : fullTag;
+
+      out += prefixText;
+
+      if (isSelfClose) {
+        var encoded = _b64Encode(originalForEncode);
+        tags.push({ original: originalForEncode, type: 'selfclose' });
+        out += fullTag.replace(/\/?>$/, ' ' + RAW_HTML_ATTR + '="' + encoded + '"/>');
+      } else if (isClose) {
+        var encoded = _b64Encode(originalForEncode);
+        tags.push({ original: originalForEncode, type: 'close' });
+        out += fullTag + '<!--' + RAW_HTML_CLOSE_PREFIX + encoded + '-->';
+      } else {
+        var encoded = _b64Encode(originalForEncode);
+        tags.push({ original: originalForEncode, type: 'open' });
+        out += fullTag.replace(/>$/, ' ' + RAW_HTML_ATTR + '="' + encoded + '">');
+      }
+      lastIdx = m.index + fullTag.length;
+    }
+
+    if (!changed) return false;
+    out += line.substring(lastIdx);
+    result.push(out);
+    return true;
+  }
+
+  function postprocessRawHtml(markdown, rawHtmlData) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    if (!rawHtmlData) return markdown;
+    return markdown;
   }
 
   var CURSOR_SPAN_HTML_RE = /<span\s+data-live-wysiwyg-cursor(?:-end)?[^>]*>\s*<\/span>/gi;
@@ -2717,10 +3280,43 @@
       .replace(inlineImgRe, function (match, text, url) { return replaceMatch(match, text, url, true); });
 
     if (refDefinitions) {
-      var normResult = result.replace(/\r\n/g, '\n');
-      var normRefDefs = refDefinitions.replace(/\r\n/g, '\n');
-      if (normResult.indexOf(normRefDefs) === -1) {
-        result = result + (result ? '\n\n' : '') + refDefinitions;
+      var refDefNameRe = /^\s{0,3}\[([^\]]+)\]:/;
+      var existingRefNames = {};
+      var resultLines = result.split('\n');
+      for (var ri = 0; ri < resultLines.length; ri++) {
+        var rm = resultLines[ri].match(refDefNameRe);
+        if (rm) existingRefNames[rm[1].toLowerCase()] = true;
+      }
+      var defLines = refDefinitions.split('\n');
+      var missingDefs = [];
+      for (var di = 0; di < defLines.length; di++) {
+        if (!defLines[di].trim()) continue;
+        var dm = defLines[di].match(refDefNameRe);
+        if (dm && existingRefNames[dm[1].toLowerCase()]) continue;
+        missingDefs.push(defLines[di]);
+      }
+      if (missingDefs.length > 0) {
+        var defsToAppend = missingDefs.join('\n');
+        var trimmed = result.replace(/\s+$/, '');
+        var lastOpenIdx = trimmed.lastIndexOf('<!--');
+        var inserted = false;
+        if (lastOpenIdx >= 0) {
+          var afterLastOpen = trimmed.slice(lastOpenIdx);
+          var closingIdx = afterLastOpen.indexOf('-->');
+          if (closingIdx >= 0 && afterLastOpen.slice(closingIdx + 3).trim() === '') {
+            var before = trimmed.slice(0, lastOpenIdx).replace(/\s+$/, '');
+            var after = trimmed.slice(lastOpenIdx);
+            var lastLineBefore = before.slice(before.lastIndexOf('\n') + 1);
+            var endsWithRefDef = refDefNameRe.test(lastLineBefore);
+            result = before + (endsWithRefDef ? '\n' : '\n\n') + defsToAppend + '\n' + after + '\n';
+            inserted = true;
+          }
+        }
+        if (!inserted) {
+          var lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1);
+          var endsWithRefDef = refDefNameRe.test(lastLine);
+          result = trimmed + (endsWithRefDef ? '\n' : '\n\n') + defsToAppend + '\n';
+        }
       }
     }
     return result;
@@ -2772,6 +3368,7 @@
 
     while ((match = inlineLinkRe.exec(body)) !== null) {
       if (insideCodeBlock(match.index)) continue;
+      if (normalizeUrl(match[1]) === normalizeUrl(match[2])) continue;
       var normUrl = normalizeUrl(match[2]);
       if (!urlGroups[normUrl]) urlGroups[normUrl] = [];
       urlGroups[normUrl].push({
@@ -2886,9 +3483,25 @@
 
     if (newDefs.length > 0) {
       var trimmed = result.replace(/\s+$/, '');
-      var lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1);
-      var endsWithRefDef = /^\s{0,3}\[([^\]]+)\]:\s/.test(lastLine);
-      result = trimmed + (endsWithRefDef ? '\n' : '\n\n') + newDefs.join('\n');
+      var lastOpenIdx = trimmed.lastIndexOf('<!--');
+      var insertedDefs = false;
+      if (lastOpenIdx >= 0) {
+        var afterLastOpen = trimmed.slice(lastOpenIdx);
+        var closingIdx = afterLastOpen.indexOf('-->');
+        if (closingIdx >= 0 && afterLastOpen.slice(closingIdx + 3).trim() === '') {
+          var before = trimmed.slice(0, lastOpenIdx).replace(/\s+$/, '');
+          var after = trimmed.slice(lastOpenIdx);
+          var lastLineBefore = before.slice(before.lastIndexOf('\n') + 1);
+          var endsWithRefDef = /^\s{0,3}\[([^\]]+)\]:\s/.test(lastLineBefore);
+          result = before + (endsWithRefDef ? '\n' : '\n\n') + newDefs.join('\n') + '\n' + after;
+          insertedDefs = true;
+        }
+      }
+      if (!insertedDefs) {
+        var lastLine = trimmed.slice(trimmed.lastIndexOf('\n') + 1);
+        var endsWithRefDef = /^\s{0,3}\[([^\]]+)\]:\s/.test(lastLine);
+        result = trimmed + (endsWithRefDef ? '\n' : '\n\n') + newDefs.join('\n');
+      }
     }
 
     return serializeWithFrontmatter(parsed.frontmatter, result);
@@ -2905,6 +3518,7 @@
         this._liveWysiwygListMarkerData = preprocessListMarkers(markdown);
         this._liveWysiwygTableSepData = preprocessTableSeparators(markdown);
         this._liveWysiwygCodeBlockData = preprocessCodeBlocks(markdown);
+        this._liveWysiwygHrData = preprocessHorizontalRules(markdown);
       }
       return origSetValue.apply(this, arguments);
     };
@@ -2916,6 +3530,7 @@
         var newListData = preprocessListMarkers(cleanBody);
         this._liveWysiwygTableSepData = preprocessTableSeparators(cleanBody);
         this._liveWysiwygCodeBlockData = preprocessCodeBlocks(cleanBody);
+        this._liveWysiwygHrData = preprocessHorizontalRules(cleanBody);
         if (newLinkData.refDefinitions) {
           this._liveWysiwygLinkData = newLinkData;
         }
@@ -2937,6 +3552,12 @@
         }
         if (this._liveWysiwygCodeBlockData) {
           md = postprocessCodeBlocks(md, this._liveWysiwygCodeBlockData);
+        }
+        if (this._liveWysiwygRawHtmlData) {
+          md = postprocessRawHtml(md, this._liveWysiwygRawHtmlData);
+        }
+        if (this._liveWysiwygHrData) {
+          md = postprocessHorizontalRules(md, this._liveWysiwygHrData);
         }
         if (this._liveWysiwygLinkData) {
           md = dryDuplicateInlineLinks(md, this._liveWysiwygLinkData);
@@ -2973,6 +3594,12 @@
       }
       if (this._liveWysiwygCodeBlockData) {
         body = postprocessCodeBlocks(body, this._liveWysiwygCodeBlockData);
+      }
+      if (this._liveWysiwygRawHtmlData) {
+        body = postprocessRawHtml(body, this._liveWysiwygRawHtmlData);
+      }
+      if (this._liveWysiwygHrData) {
+        body = postprocessHorizontalRules(body, this._liveWysiwygHrData);
       }
       if (this._liveWysiwygLinkData) {
         body = dryDuplicateInlineLinks(body, this._liveWysiwygLinkData);
@@ -3545,6 +4172,7 @@
                        body.slice(pos.start, pos.end) + spanMarkerEnd +
                        body.slice(pos.end);
       ea.innerHTML = editor._markdownToHtml(markedBody);
+      if (typeof populateRawHtmlBlocks === 'function') populateRawHtmlBlocks(ea);
       if (typeof enhanceCodeBlocks === 'function') enhanceCodeBlocks(ea);
       if (typeof enhanceChecklists === 'function') enhanceChecklists(ea);
       if (typeof enhanceAdmonitions === 'function') enhanceAdmonitions(ea);
@@ -3981,6 +4609,7 @@
                      body.slice(pos.start, pos.end) + spanMarkerEnd +
                      body.slice(pos.end);
     ea.innerHTML = editor._markdownToHtml(markedBody);
+    if (typeof populateRawHtmlBlocks === 'function') populateRawHtmlBlocks(ea);
     if (typeof enhanceCodeBlocks === 'function') enhanceCodeBlocks(ea);
     if (typeof enhanceChecklists === 'function') enhanceChecklists(ea);
     if (typeof enhanceAdmonitions === 'function') enhanceAdmonitions(ea);
@@ -4082,6 +4711,7 @@
       this._liveWysiwygFrontmatter = parsed.frontmatter;
       var ret = origSetValue.call(this, parsed.body, isInitialSetup);
       if (this.editableArea) {
+        populateRawHtmlBlocks(this.editableArea);
         enhanceCodeBlocks(this.editableArea);
         enhanceChecklists(this.editableArea);
         enhanceAdmonitions(this.editableArea);
@@ -4261,6 +4891,7 @@
       if (!isInitialSetup && savedScroll !== null) {
         if (mode === 'wysiwyg') {
           var editableArea = this.editableArea;
+          populateRawHtmlBlocks(editableArea);
           enhanceCodeBlocks(editableArea);
           enhanceChecklists(editableArea);
           enhanceAdmonitions(editableArea);
@@ -4398,6 +5029,7 @@
           if (this.markdownLineNumbersDiv) this.markdownLineNumbersDiv.scrollTop = this.markdownArea.scrollTop;
         }
       } else if (mode === 'wysiwyg' && this.editableArea) {
+        populateRawHtmlBlocks(this.editableArea);
         enhanceCodeBlocks(this.editableArea);
         enhanceChecklists(this.editableArea);
         enhanceAdmonitions(this.editableArea);
@@ -4946,6 +5578,9 @@
           if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygCodeBlockData) {
             markdownContent = postprocessCodeBlocks(markdownContent, wysiwygEditor._liveWysiwygCodeBlockData);
           }
+          if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygHrData) {
+            markdownContent = postprocessHorizontalRules(markdownContent, wysiwygEditor._liveWysiwygHrData);
+          }
           if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygLinkData) {
             markdownContent = dryDuplicateInlineLinks(markdownContent, wysiwygEditor._liveWysiwygLinkData);
             markdownContent = collapseRedundantReferenceToShortcut(markdownContent);
@@ -5421,6 +6056,7 @@
           }
           enhanceCodeBlocks(ea);
           enhanceBasicPreBlocks(ea);
+          populateRawHtmlBlocks(ea);
           enhanceAdmonitions(ea);
           requestAnimationFrame(function () {
             var codeEl = pre.querySelector('code') || pre;
@@ -5871,6 +6507,17 @@
       };
     })();
 
+    (function patchMarkdownToHtmlForRawHtml() {
+      var proto = MarkdownWYSIWYG.prototype;
+      var origMdToHtml = proto._markdownToHtml;
+      if (!origMdToHtml) return;
+      proto._markdownToHtml = function (markdown) {
+        var md = markdown || '';
+        var rawResult = preprocessRawHtml(md);
+        this._liveWysiwygRawHtmlData = rawResult;
+        return origMdToHtml.call(this, rawResult.markdown);
+      };
+    })();
 
     (function patchHtmlToMarkdownEmojiToShortcode() {
       var MARKER = "\uFFFF\uFFFF\uFFFF";
@@ -5917,6 +6564,7 @@
       var md = wysiwygEditor.markdownArea.value;
       if (md) {
         wysiwygEditor.editableArea.innerHTML = wysiwygEditor._markdownToHtml(md);
+        populateRawHtmlBlocks(wysiwygEditor.editableArea);
       }
     }
 


### PR DESCRIPTION
Prioritizing document integrity over ability to edit custom HTML.

Raw HTML is readonly in the WYSIWYG.  The markdown content of raw HTML is not rendered if there's markdown mixed inside of the HTML.  This is a technical limitation to support preserving custom HTML in mixed markdown and HTML content.

Other notable features

- List compacting is the sane default (e.g. no unnecessary newlines).  Multi-line items has strict indenting requirements with exception for raw HTML which is preserved as-is without modification due to its readonly nature.  This is intentional.
- Lists which contain all `1.` are preserved.  If a document contains lists with all `1.` then it is assumed that if the author creates new lists they also want it to be all `1.`.
- Horizontal rule preservation.  However the user provided it, it's preserved.
- Raw `links` are preserved.  Raw `<link>` is also preserved