### PR TITLE
URL menu and fixes

### DIFF
--- a/docs/design/DESIGN-raw-html-preservation.md
+++ b/docs/design/DESIGN-raw-html-preservation.md
@@ -20,7 +20,11 @@ The approach follows the established preprocessor/postprocessor pattern used by 
 
 ### Phase 1: Preprocessing (markdown -> annotated markdown)
 
-`preprocessRawHtml(markdown)` scans markdown line-by-line, skipping fenced code blocks (including indented fences inside list items) and admonition syntax lines. For each non-protected line it runs three passes in order:
+`preprocessRawHtml(markdown)` first runs `extractRefDefsFromCommentBlocks`, then scans markdown line-by-line, skipping fenced code blocks (including indented fences inside list items) and admonition syntax lines. For each non-protected line it runs three passes in order:
+
+#### 0. Reference definitions between HTML comments (`extractRefDefsFromCommentBlocks`)
+
+Reference definitions between HTML comment pairs (e.g. `<!-- prettier-ignore-start -->` ... `<!-- prettier-ignore-end -->`) are not parsed by `marked` because the comment placeholders create a block context where ref defs are ignored. Before comment replacement, ref definitions between such pairs are extracted and moved to the end of the document so `marked` can resolve shortcut links like `[catalog import][catalog-import]`. The non-ref-def content between the comments is preserved; only ref def lines are moved.
 
 #### 1a. Block-Level Raw HTML Capture (NEW)
 
@@ -59,9 +63,11 @@ becomes:
 <span data-live-wysiwyg-html-comment="BASE64" style="display:none"></span>
 ```
 
-The `data-live-wysiwyg-html-comment` attribute contains the base64-encoded original comment. For block-level comments (sole content on a line), the base64 includes the leading whitespace, preserving indentation. The `style="display:none"` keeps it invisible in the WYSIWYG.
+The `data-live-wysiwyg-html-comment` attribute contains the base64-encoded original comment. For block-level comments (sole content on a line), the base64 includes the leading whitespace, preserving indentation. Trailing whitespace (including newlines after `-->`) is trimmed before encoding to avoid newline accumulation. The `style="display:none"` keeps it invisible in the WYSIWYG.
 
-For multi-line comments, the line-walker accumulates lines from `<!--` to `-->`, joins them, and base64-encodes the full comment (with leading whitespace for block-level) into a single `<span>` placeholder.
+**Adjacent comment collapse:** When multiple block-level HTML comments span adjacent lines (with only blank lines between), they are collapsed into a single placeholder. The combined block is base64-encoded as one unit (e.g. `<!-- comment1 -->\n<!-- comment2 -->`). Trailing whitespace (including newlines after the last `-->`) is trimmed before encoding. This avoids extra block-level spacing from the DOM structure and preserves the exact newline layout when serializing back to markdown.
+
+For multi-line comments (one `<!--` spanning to `-->` on a later line), the line-walker accumulates lines from `<!--` to `-->`, joins them, and base64-encodes the full comment (with leading whitespace for block-level) into a single `<span>` placeholder.
 
 #### 1c. Inline Raw HTML Tags (`_preprocessLineTags`)
 
@@ -133,7 +139,7 @@ When encountering any element with `data-live-wysiwyg-raw-html`:
 
 ### Phase 5: Postprocessing
 
-`postprocessRawHtml(markdown, rawHtmlData)` runs after `_htmlToMarkdown` and before final output. Currently a passthrough; available for future edge-case corrections.
+`postprocessRawHtml(markdown, rawHtmlData)` runs after `_htmlToMarkdown` and before final output. It calls `restoreRefDefsToCommentBlocks` to reverse the extraction done in Phase 1: ref definitions that were moved to the end for `marked` parsing are restored between their original HTML comment pairs (e.g. between `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->`), preserving the original document structure and avoiding extra newlines.
 
 ## Data Flow
 
@@ -156,7 +162,7 @@ WYSIWYG DOM                  -- user edits markdown content normally (raw HTML b
 _htmlToMarkdown()            -- patched serializer: blocks→decoded blob, inline→decoded tags
        |
        v
-postprocessRawHtml()         -- passthrough (future edge-case fixes)
+postprocessRawHtml()         -- restore ref defs between comment pairs
        |
        v
 Final markdown (zero diff)
@@ -168,7 +174,7 @@ All changes are in `live-wysiwyg-integration.js`:
 
 1. **`preprocessRawHtml(markdown)`** -- returns `{ markdown, comments, tags }`.
 2. **`populateRawHtmlBlocks(editableArea)`** -- decodes block placeholders and renders visual preview (called before all enhancement functions).
-3. **`postprocessRawHtml(markdown, rawHtmlData)`** -- currently passthrough.
+3. **`postprocessRawHtml(markdown, rawHtmlData)`** -- calls `restoreRefDefsToCommentBlocks` to restore ref defs between HTML comment pairs.
 4. **`patchMarkdownToHtmlForRawHtml`** -- patches `_markdownToHtml` to run `preprocessRawHtml` before all other markdown-to-HTML patches (emoji, cursor markers). Stores the result as `this._liveWysiwygRawHtmlData`.
 5. **`patchSetValueAndSwitchToModeForLinkPrePost` `switchToMode`** -- calls `postprocessRawHtml` when switching to markdown mode.
 6. **`patchGetValueForListMarkers` `getValue`** -- calls `postprocessRawHtml` before returning final markdown.
@@ -180,7 +186,9 @@ All changes are in `live-wysiwyg-integration.js`:
 - **`_isHtmlTagKnownToMarkdown(tag)`** -- returns `true` for tags that markdown natively generates (should not be annotated).
 - **`_countBlockTagDepth(line, tagName)`** -- counts open/close tags of a specific element on a single line. Open tags increment depth, close tags decrement, self-closing tags are neutral. Used by the block capture to track nesting.
 - **`_isInsideRawHtmlBlock(el)`** -- walks up the DOM tree to check if an element is inside a `data-live-wysiwyg-raw-html-block` container. Used by `enhanceAdmonitions` to skip enhancement of content inside raw HTML blocks.
-- **`_preprocessLineComments(line, lines, idx, comments, result)`** -- handles single-line and multi-line HTML comment detection and replacement. Includes leading whitespace in base64 for block-level comments.
+- **`_preprocessLineComments(line, lines, idx, comments, result)`** -- handles single-line and multi-line HTML comment detection and replacement. For block-level comments, collapses adjacent comment lines (with only blank lines between) into one placeholder. Trailing whitespace is trimmed before encoding. Includes leading whitespace in base64 for block-level comments.
+- **`extractRefDefsFromCommentBlocks(markdown)`** -- moves ref definitions from between HTML comment pairs to the end of the document so `marked` can parse shortcut links.
+- **`restoreRefDefsToCommentBlocks(markdown)`** -- restores ref definitions between their original HTML comment pairs when serializing back to markdown.
 - **`_preprocessLineTags(line, tags, result)`** -- scans a line for all raw HTML tags (open, close, self-closing) and annotates them. Protects inline code spans from processing. Skips markdown autolinks (`<https://...>`, `<user@example.com>`).
 - **`_serializeElementAsHtml(node)`** -- recursively reconstructs an element's HTML string (tag name, attributes, children). Used by the inline raw HTML serializer to preserve non-annotated child elements inside annotated tags. Strips internal `data-live-wysiwyg-*` attributes from output.
 - **`populateRawHtmlBlocks(editableArea)`** -- post-DOM-insertion function that decodes block placeholders, sets innerHTML, marks as non-editable, and applies visual styling.
@@ -200,7 +208,9 @@ All changes are in `live-wysiwyg-integration.js`:
 - **Self-closing tags** (`<custom-widget/>`): detected and encoded as single units with `data-live-wysiwyg-raw-html`. No close-tag sidecar needed.
 - **Inline HTML within paragraphs** (`<span class="x">text</span>`): both the open `<span>` and close `</span>` are annotated within the same line. The serializer outputs them verbatim around the text content.
 - **HTML comments after reference links**: comments at the end of the document (common for linter directives) are preserved at their exact line positions.
+- **Reference definitions between HTML comments**: ref defs between pairs like `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` are extracted to the end for `marked` parsing, then restored between the comments during postprocessing. `postprocessMarkdownLinks` uses a single newline (not `\n\n`) when inserting ref defs after an HTML comment line to avoid extra blank lines.
 - **HTML comments within markdown blocks**: e.g., `<!-- TODO -->` between paragraphs. The placeholder `<span>` is a block-level break point.
+- **Adjacent block comments**: All block-level comments (sole content on a line) collapse when adjacent (with only blank lines between). Trailing whitespace after the last `-->` is trimmed before base64 encoding.
 - **Nested raw HTML**: e.g., `<div><div>markdown</div></div>`. The depth tracker correctly handles nested tags of the same type.
 - **Raw HTML that matches known elements** (e.g., `<div class="admonition note">`): block capture takes priority; WYSIWYG enhancements are skipped inside raw HTML blocks.
 - **Indented raw HTML**: the preprocessor captures leading whitespace in the base64 encoding. For block capture, the entire block including indentation is encoded.
@@ -231,10 +241,11 @@ var onlyWhitespace = /^[ \t]*$/.test(prefixText);
 var originalForEncode = (onlyWhitespace && lastIdx === 0) ? prefixText + fullTag : fullTag;
 ```
 
-For comments, the same pattern applies in `_preprocessLineComments`:
+For comments, the same pattern applies in `_preprocessLineComments`. When multiple block-level comments are adjacent (with only blank lines between), they are collapsed into one encoded block. Trailing whitespace (including newlines after the last `-->`) is trimmed before encoding.
 
 ```javascript
 var isBlockComment = !before.trim() && !after.trim();
+// When block-level: collect adjacent comment lines, encode as one, trim trailing newlines
 var originalForEncode = isBlockComment ? before + comment : comment;
 ```
 
@@ -262,9 +273,11 @@ The tag regex in `_preprocessLineTags` skips any "tag" whose content starts with
 
 When `marked` converts a bare URL into `<a href="url">url</a>`, the serializer detects that the link text matches the href and outputs just the bare URL text instead of wrapping it as `[url](url)`.
 
-### Reference link definitions and trailing HTML comments
+### Reference link definitions and HTML comments
 
-Reference link definitions are re-appended by `postprocessMarkdownLinks`. When the document ends with HTML comments, ref defs are inserted BEFORE the last trailing HTML comment.
+Reference definitions between HTML comment pairs (e.g. `<!-- prettier-ignore-start -->` ... `<!-- prettier-ignore-end -->`) are extracted by `extractRefDefsFromCommentBlocks` before `marked` parses, then restored by `restoreRefDefsToCommentBlocks` in `postprocessRawHtml` when serializing. This allows shortcut links to render on initial load.
+
+Reference link definitions are re-appended by `postprocessMarkdownLinks` when missing from the serialized output. When inserting before HTML comments, a single newline is used (not `\n\n`) when the preceding line is an HTML comment, to avoid extra blank lines.
 
 `postprocessMarkdownLinks` checks each ref def individually by name (case-insensitive) against the result, only appending ref defs that are not already present.
 

--- a/docs/design/DESIGN-readonly-selection-heuristics.md
+++ b/docs/design/DESIGN-readonly-selection-heuristics.md
@@ -51,11 +51,21 @@ Read-only selection handling and edit-mode selection handling (WYSIWYG ↔ Markd
 
 ### Step 2: Build Searchable Text
 
-`buildSearchable(text)` takes a markdown string (the actual body or the pseudo-markdown) and produces a whitespace-normalized, formatting-stripped version with a position map back to the original.
+`buildSearchable(text)` takes a markdown string (the actual body or the pseudo-markdown) and produces a whitespace-normalized, formatting-stripped version with a position map back to the original. This allows selections that span across block boundaries (lists, blockquotes, headings, etc.) to match, since `range.toString()` returns plain text without structural markers.
 
-**Stripping rules:**
+**Stripping rules (at line start):**
 
-- Heading markers (`# ` at line start)
+- Heading markers (`# ` through `###### `)
+- Blockquote markers (`> `, including nested `> > `)
+- Unordered list markers (`- `, `+ `, `* `)
+- Ordered list markers (`1. `, `2. `, etc.)
+- Indented list markers (`  - `, `  + `, `  * `, `  N. `, `    - `, etc., for nested lists)
+- Indent (4 spaces, for code blocks / nested content)
+- Admonition lines (`!!! type` or `??? type` / `???+ type` — entire line skipped)
+
+**Stripping rules (anywhere):**
+
+- HTML comments (`<!-- ... -->`) — skipped entirely so invisible content does not block matches
 - Backticks (inline code delimiters)
 - `**` (bold markers)
 - All whitespace collapsed to single spaces
@@ -70,7 +80,13 @@ Read-only selection handling and edit-mode selection handling (WYSIWYG ↔ Markd
 2. Collapse all whitespace to single spaces
 3. Trim
 
-### Step 4: Search and Map Back
+### Step 4: Body Source for Search
+
+**Critical:** Both `applyPendingReadModeSelection` and `readonly_to_edit_mode_text_selection` must use `markdownArea.value` when available, not `editor.getValue()`.
+
+When in WYSIWYG mode, `getValue()` returns `_htmlToMarkdown(editableArea)` — the serialized DOM. The raw HTML handling patches replace raw HTML blocks with placeholders (e.g. `\u0000__RAWHTMLBLOCK_0__\u0000`). Searching for the user's selected text in that serialized output fails because the actual text may be inside a placeholder. `markdownArea.value` holds the source markdown used to render the editor (including raw HTML), so the search runs against the correct content.
+
+### Step 5: Search and Map Back
 
 `readonly_to_edit_mode_text_selection(editor)` orchestrates the search in tiers:
 
@@ -123,6 +139,10 @@ Once positions in the markdown body are determined:
 
 The core insight is that most inline text in rendered HTML is an exact substring of the markdown source — the markdown just has *extra* characters (formatting markers). By stripping those extras from both the markdown body and the pseudo-markdown, and normalizing whitespace, we can match `range.toString()` output against either representation. When we find a match in the pseudo-markdown, we extract the *formatted* substring (with `#`, `**`, `` ` `` intact) and search for it in the actual body — a high-precision match since it includes the formatting.
 
+**Cross-element selection:** When the user selects text spanning multiple blocks (e.g., from the end of one list item to the start of another, or across a heading and paragraph), `range.toString()` returns concatenated plain text without list markers, blockquote prefixes, or other structural syntax. `buildSearchable` strips these block-level markers at line boundaries so the searchable text aligns with what the user selected.
+
+**Raw HTML:** HTML comments (`<!-- ... -->`) are invisible in the rendered page but appear in the markdown source. `buildSearchable` skips them entirely so selections that traverse across comments (e.g., from a heading through a comment to a list item) match correctly.
+
 ## Relationship to Edit-Mode Selection
 
 The **edit-mode selection system** (WYSIWYG ↔ Markdown toggle) is completely separate and must remain so:
@@ -133,3 +153,11 @@ The **edit-mode selection system** (WYSIWYG ↔ Markdown toggle) is completely s
 - Uses `restoreSelectionFromSemantic` as a fallback
 
 None of these mechanisms are used or affected by the read-only selection heuristics.
+
+## Integration with Raw HTML Handling
+
+The raw HTML preservation patches (`preprocessRawHtml`, `_nodeToMarkdownRecursive` placeholders) interact with selection in two ways:
+
+1. **Markdown → WYSIWYG (edit-mode selection):** Cursor span markers (`<span data-live-wysiwyg-cursor></span>`) must be converted to placeholders *before* `preprocessRawHtml` runs. Otherwise `_preprocessLineTags` wraps them as raw HTML, and the cursor marker patch never sees them. The raw HTML patch therefore replaces cursor spans with `LIVEWYSIWYG_CURSOR_9X7K2` / `LIVEWYSIWYG_CURSOR_END_9X7K2` at the start of its `_markdownToHtml` wrapper.
+
+2. **WYSIWYG → Markdown (serialization):** Cursor spans must be stripped during `_nodeToMarkdownRecursive` and `_serializeElementAsHtml`. When a cursor span was wrapped by raw HTML preprocessing, its matching close-tag comment (`<!--live-wysiwyg-raw-close:...-->`) must also be suppressed — otherwise `</span>` leaks into the markdown output.

--- a/docs/diff-quirks.md
+++ b/docs/diff-quirks.md
@@ -1,7 +1,5 @@
 # Known diff quirks
 
-* HTML comments tend to always append a newline.  For now, this is the way it is
-  due to complexity.
 * Inline code blocks will rerender as single line because the mode switching
   can't handle the content conversion while preserving the newline.  This is a
   complex enough bug that I'm leaving it alone for now.

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -2093,6 +2093,199 @@
     };
   })();
 
+  (function patchInsertLink() {
+    var proto = MarkdownWYSIWYG.prototype;
+    var origInsertLink = proto._insertLink;
+    if (!origInsertLink) return;
+
+    var _activeLinkDropdown = null;
+    function dismissLinkDropdown() {
+      if (_activeLinkDropdown) {
+        if (_activeLinkDropdown.el.parentNode) _activeLinkDropdown.el.parentNode.removeChild(_activeLinkDropdown.el);
+        if (_activeLinkDropdown.closeHandler) document.removeEventListener('mousedown', _activeLinkDropdown.closeHandler, true);
+        if (_activeLinkDropdown.scrollHandler) window.removeEventListener('scroll', _activeLinkDropdown.scrollHandler, true);
+        _activeLinkDropdown = null;
+      }
+    }
+
+    function findAnchorInSelection(editableArea) {
+      var sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return null;
+      var node = sel.getRangeAt(0).commonAncestorContainer;
+      if (node.nodeType === 3) node = node.parentNode;
+      while (node && node !== editableArea) {
+        if (node.nodeName === 'A' && node.getAttribute('href')) return node;
+        node = node.parentNode;
+      }
+      return null;
+    }
+
+    function createLinkDropdown(anchorBtn, editor) {
+      dismissLinkDropdown();
+      dismissAdmonitionSettingsDropdown();
+      dismissActiveSettingsDropdown();
+      dismissActiveLangDropdown();
+
+      var ea = editor.editableArea;
+      var ma = editor.markdownArea;
+      var isWysiwyg = editor.currentMode === 'wysiwyg';
+
+      var savedRange = editor.savedRangeInfo;
+      if (isWysiwyg && savedRange instanceof Range && ea.contains(savedRange.commonAncestorContainer)) {
+        var sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(savedRange);
+      } else if (!isWysiwyg && ma && savedRange && typeof savedRange.start === 'number') {
+        ma.setSelectionRange(savedRange.start, savedRange.end);
+      }
+      var existingAnchor = isWysiwyg ? findAnchorInSelection(ea) : null;
+      var initialUrl = existingAnchor ? (existingAnchor.getAttribute('href') || '') : 'https://';
+      var initialText = '';
+      if (existingAnchor) {
+        initialText = (existingAnchor.textContent || '').trim();
+      } else if (isWysiwyg) {
+        var sel = window.getSelection();
+        if (sel && sel.rangeCount > 0) initialText = sel.toString().trim();
+        if (!initialText && savedRange instanceof Range && ea.contains(savedRange.commonAncestorContainer)) {
+          initialText = savedRange.toString().trim();
+        }
+      } else if (ma) {
+        var start = savedRange && typeof savedRange.start === 'number' ? savedRange.start : ma.selectionStart;
+        var end = savedRange && typeof savedRange.end === 'number' ? savedRange.end : ma.selectionEnd;
+        if (start !== end) initialText = ma.value.substring(start, end).trim();
+      }
+
+      var dropdown = document.createElement('div');
+      dropdown.className = 'md-link-settings-dropdown';
+      dropdown.setAttribute('contenteditable', 'false');
+
+      var urlRow = document.createElement('div');
+      urlRow.className = 'md-link-settings-row';
+      var urlLabel = document.createElement('span');
+      urlLabel.className = 'md-link-settings-label';
+      urlLabel.textContent = 'URL';
+      var urlInput = document.createElement('input');
+      urlInput.className = 'md-link-settings-input';
+      urlInput.type = 'text';
+      urlInput.placeholder = 'https://';
+      urlInput.value = initialUrl;
+      urlRow.appendChild(urlLabel);
+      urlRow.appendChild(urlInput);
+      dropdown.appendChild(urlRow);
+
+      var textRow = document.createElement('div');
+      textRow.className = 'md-link-settings-row';
+      var textLabel = document.createElement('span');
+      textLabel.className = 'md-link-settings-label';
+      textLabel.textContent = 'Text';
+      var textInput = document.createElement('input');
+      textInput.className = 'md-link-settings-input';
+      textInput.type = 'text';
+      textInput.placeholder = 'link text';
+      textInput.value = initialText;
+      textRow.appendChild(textLabel);
+      textRow.appendChild(textInput);
+      dropdown.appendChild(textRow);
+
+      var applyRow = document.createElement('div');
+      applyRow.className = 'md-link-settings-row md-link-settings-apply-row';
+      var applyBtn = document.createElement('button');
+      applyBtn.type = 'button';
+      applyBtn.className = 'md-link-settings-apply';
+      applyBtn.textContent = existingAnchor ? 'Update' : 'Insert';
+      applyRow.appendChild(applyBtn);
+      dropdown.appendChild(applyRow);
+
+      function positionDropdown() {
+        var rect = anchorBtn.getBoundingClientRect();
+        var left = rect.right - 220;
+        if (left < 0) left = rect.left;
+        dropdown.style.top = (rect.bottom + 2) + 'px';
+        dropdown.style.left = left + 'px';
+      }
+
+      function doApply() {
+        var url = (urlInput.value || '').trim();
+        if (!url) return;
+        var text = (textInput.value || '').trim();
+        if (!text && !existingAnchor) text = 'link text';
+
+        if (isWysiwyg) {
+          ea.focus();
+          var sel = window.getSelection();
+          if (existingAnchor) {
+            existingAnchor.setAttribute('href', url);
+            if (text && text !== existingAnchor.textContent) {
+              existingAnchor.textContent = text;
+            }
+          } else {
+            var rangeToUse = null;
+            if (savedRange instanceof Range && ea.contains(savedRange.commonAncestorContainer)) {
+              sel.removeAllRanges();
+              sel.addRange(savedRange);
+              rangeToUse = savedRange;
+            } else if (sel && sel.rangeCount > 0 && ea.contains(sel.getRangeAt(0).commonAncestorContainer)) {
+              rangeToUse = sel.getRangeAt(0);
+            }
+            if (rangeToUse) {
+              var linkTextNode = document.createTextNode(text || 'link text');
+              rangeToUse.deleteContents();
+              rangeToUse.insertNode(linkTextNode);
+              rangeToUse.selectNodeContents(linkTextNode);
+              sel.removeAllRanges();
+              sel.addRange(rangeToUse);
+            }
+            document.execCommand('createLink', false, url);
+          }
+          if (editor._finalizeUpdate) editor._finalizeUpdate(ea.innerHTML);
+        } else {
+          ma.focus();
+          var start = savedRange && typeof savedRange.start === 'number' ? savedRange.start : ma.selectionStart;
+          var end = savedRange && typeof savedRange.end === 'number' ? savedRange.end : ma.selectionEnd;
+          var prefix = '[';
+          var suffix = '](' + url + ')';
+          var replacement = prefix + text + suffix;
+          ma.value = ma.value.substring(0, start) + replacement + ma.value.substring(end);
+          ma.setSelectionRange(start + prefix.length, start + prefix.length + text.length);
+          if (editor._finalizeUpdate) editor._finalizeUpdate(ma.value);
+        }
+        dismissLinkDropdown();
+      }
+
+      applyBtn.addEventListener('mousedown', function (ev) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        doApply();
+      });
+
+      urlInput.addEventListener('keydown', function (ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); doApply(); }
+      });
+      textInput.addEventListener('keydown', function (ev) {
+        if (ev.key === 'Enter') { ev.preventDefault(); doApply(); }
+      });
+
+      document.body.appendChild(dropdown);
+      positionDropdown();
+      requestAnimationFrame(function () { urlInput.focus(); urlInput.select(); });
+
+      var closeHandler = function (ev) {
+        if (dropdown.contains(ev.target) || ev.target === anchorBtn) return;
+        dismissLinkDropdown();
+      };
+      var scrollHandler = function () { positionDropdown(); };
+      document.addEventListener('mousedown', closeHandler, true);
+      window.addEventListener('scroll', scrollHandler, true);
+
+      _activeLinkDropdown = { el: dropdown, closeHandler: closeHandler, scrollHandler: scrollHandler };
+    }
+
+    proto._insertLink = function (buttonElement) {
+      if (!buttonElement) buttonElement = this.toolbar && this.toolbar.querySelector('.md-toolbar-button-link');
+      createLinkDropdown(buttonElement || document.body, this);
+    };
+  })();
+
   (function patchAdmonitionHtmlToMarkdown() {
     var proto = MarkdownWYSIWYG.prototype;
     var orig = proto._nodeToMarkdownRecursive;
@@ -2102,12 +2295,27 @@
       if (node.nodeName === 'INPUT' && node.type === 'checkbox') {
         return (node.checked ? '[x]' : '[ ]');
       }
+      if (node.nodeType === 1 && node.hasAttribute && (node.hasAttribute('data-live-wysiwyg-cursor') || node.hasAttribute('data-live-wysiwyg-cursor-end'))) {
+        return '';
+      }
       if (node.nodeType === 8) {
         if (node._liveWysiwygConsumed) return '';
         var commentData = (node.data || '').trim();
         if (commentData.indexOf(RAW_HTML_CLOSE_PREFIX) === 0) {
-          var b64 = commentData.substring(RAW_HTML_CLOSE_PREFIX.length);
-          return _b64Decode(b64) + '\n';
+          var prev = node.previousSibling;
+          if (prev && prev.nodeType === 1 && prev.getAttribute) {
+            var prevRaw = prev.getAttribute(RAW_HTML_ATTR);
+            if (prevRaw) {
+              var prevDecoded = _b64Decode(prevRaw);
+              if (prevDecoded && prevDecoded.indexOf('data-live-wysiwyg-cursor') >= 0) return '';
+            }
+          }
+          var closePayload = commentData.substring(RAW_HTML_CLOSE_PREFIX.length);
+          var pipeIdx = closePayload.indexOf('|');
+          var closeB64 = pipeIdx >= 0 ? closePayload.substring(0, pipeIdx) : closePayload;
+          var closeNewlines = pipeIdx >= 0 ? parseInt(closePayload.substring(pipeIdx + 1), 10) : 1;
+          if (isNaN(closeNewlines) || closeNewlines < 0) closeNewlines = 1;
+          return _b64Decode(closeB64) + '\n'.repeat(closeNewlines);
         }
         return '';
       }
@@ -2115,22 +2323,27 @@
         var rawBlockB64 = node.getAttribute(RAW_HTML_BLOCK_ATTR);
         if (rawBlockB64) {
           var decoded = _b64Decode(rawBlockB64);
+          var blockNewlinesAfter = parseInt(node.getAttribute(RAW_HTML_NEWLINES_AFTER_ATTR), 10);
+          if (isNaN(blockNewlinesAfter) || blockNewlinesAfter < 0) blockNewlinesAfter = 1;
           if (!this._rawHtmlPlaceholders) this._rawHtmlPlaceholders = [];
           var idx = this._rawHtmlPlaceholders.length;
-          this._rawHtmlPlaceholders.push(decoded);
+          this._rawHtmlPlaceholders.push({ content: decoded, newlinesAfter: blockNewlinesAfter });
           return '\u0000__RAWHTMLBLOCK_' + idx + '__\u0000\n';
         }
         var commentB64 = node.getAttribute(RAW_HTML_COMMENT_ATTR);
         if (commentB64) {
           var decoded = _b64Decode(commentB64);
+          var newlinesAfter = parseInt(node.getAttribute(RAW_HTML_NEWLINES_AFTER_ATTR), 10);
+          if (isNaN(newlinesAfter) || newlinesAfter < 1) newlinesAfter = 1;
           if (!this._rawHtmlPlaceholders) this._rawHtmlPlaceholders = [];
           var idx = this._rawHtmlPlaceholders.length;
-          this._rawHtmlPlaceholders.push(decoded);
+          this._rawHtmlPlaceholders.push({ content: decoded, newlinesAfter: newlinesAfter });
           return '\u0000__RAWHTMLBLOCK_' + idx + '__\u0000\n';
         }
         var rawTagB64 = node.getAttribute(RAW_HTML_ATTR);
         if (rawTagB64) {
           var originalOpenTag = _b64Decode(rawTagB64);
+          if (originalOpenTag && originalOpenTag.indexOf('data-live-wysiwyg-cursor') >= 0) return '';
           var childMd = '';
           for (var ri = 0; ri < node.childNodes.length; ri++) {
             var rChild = node.childNodes[ri];
@@ -2156,7 +2369,13 @@
             if (nextSib.nodeType === 8) {
               var nd = (nextSib.data || '').trim();
               if (nd.indexOf(RAW_HTML_CLOSE_PREFIX) === 0) {
-                closeTag = _b64Decode(nd.substring(RAW_HTML_CLOSE_PREFIX.length));
+                var closePayload = nd.substring(RAW_HTML_CLOSE_PREFIX.length);
+                var pipeIdx = closePayload.indexOf('|');
+                var closeB64 = pipeIdx >= 0 ? closePayload.substring(0, pipeIdx) : closePayload;
+                closeTag = _b64Decode(closeB64);
+                var closeNewlines = pipeIdx >= 0 ? parseInt(closePayload.substring(pipeIdx + 1), 10) : 1;
+                if (isNaN(closeNewlines) || closeNewlines < 0) closeNewlines = 1;
+                closeTag = closeTag + '\n'.repeat(closeNewlines);
                 nextSib._liveWysiwygConsumed = true;
                 break;
               }
@@ -2164,7 +2383,7 @@
             if (nextSib.nodeType === 1 || (nextSib.nodeType === 3 && nextSib.textContent.trim())) break;
             nextSib = nextSib.nextSibling;
           }
-          return originalOpenTag + '\n' + childMd + (closeTag ? closeTag + '\n' : '');
+          return originalOpenTag + '\n' + childMd + (closeTag || '');
         }
       }
       // #text: preserve multiple spaces (upstream collapses with /  +/g)
@@ -2514,9 +2733,35 @@
         var lineEnd = protected_.indexOf('\n', rawIdx + rawPh.length);
         if (lineEnd === -1) lineEnd = protected_.length;
         if (/^\s*$/.test(beforePh)) {
-          protected_ = protected_.substring(0, lineStart) + rawHtmlBlocks[ri] + protected_.substring(lineEnd);
+          var ph = rawHtmlBlocks[ri];
+          var decoded = typeof ph === 'object' ? ph.content : ph;
+          var newlinesAfter = typeof ph === 'object' ? ph.newlinesAfter : null;
+          var after = protected_.substring(lineEnd);
+          if (decoded && /^\s*<!--[\s\S]*?-->\s*$/.test(decoded.trim())) {
+            if (newlinesAfter != null && newlinesAfter >= 1) {
+              after = '\n'.repeat(newlinesAfter) + after.replace(/^\n+/, '');
+            } else {
+              after = after.replace(/^\n+/, '\n');
+            }
+            var insertStart = lineStart;
+            if (lineStart >= 2 && protected_.charAt(lineStart - 1) === '\n' && protected_.charAt(lineStart - 2) === '\n') {
+              var prevLineStart = protected_.lastIndexOf('\n', lineStart - 3) + 1;
+              var prevLine = protected_.substring(prevLineStart, lineStart - 2);
+              if (/^(\s*)([-*+]|\d+\.)\s/.test(prevLine)) {
+                insertStart = lineStart - 1;
+              }
+            }
+            protected_ = protected_.substring(0, insertStart) + decoded + after;
+          } else if (newlinesAfter != null) {
+            after = newlinesAfter >= 1 ? '\n'.repeat(newlinesAfter) + after.replace(/^\n+/, '') : after.replace(/^\n+/, '');
+            protected_ = protected_.substring(0, lineStart) + decoded + after;
+          } else {
+            protected_ = protected_.substring(0, lineStart) + decoded + after;
+          }
         } else {
-          protected_ = protected_.substring(0, rawIdx) + rawHtmlBlocks[ri] + protected_.substring(rawIdx + rawPh.length);
+          var phInline = rawHtmlBlocks[ri];
+          var decodedInline = typeof phInline === 'object' ? phInline.content : phInline;
+          protected_ = protected_.substring(0, rawIdx) + decodedInline + protected_.substring(rawIdx + rawPh.length);
         }
       }
       return protected_.trim();
@@ -2865,11 +3110,13 @@
   var RAW_HTML_ATTR = 'data-live-wysiwyg-raw-html';
   var RAW_HTML_CLOSE_PREFIX = 'live-wysiwyg-raw-close:';
   var RAW_HTML_COMMENT_ATTR = 'data-live-wysiwyg-html-comment';
+  var RAW_HTML_NEWLINES_AFTER_ATTR = 'data-live-wysiwyg-newlines-after';
   var RAW_HTML_BLOCK_ATTR = 'data-live-wysiwyg-raw-html-block';
 
   function _serializeElementAsHtml(node) {
     if (node.nodeType === 3) return node.textContent;
     if (node.nodeType !== 1) return '';
+    if (node.hasAttribute && (node.hasAttribute('data-live-wysiwyg-cursor') || node.hasAttribute('data-live-wysiwyg-cursor-end'))) return '';
     var tag = node.nodeName.toLowerCase();
     var attrs = '';
     if (node.attributes) {
@@ -2960,8 +3207,85 @@
     return mdTags.indexOf(name) >= 0;
   }
 
+  /**
+   * Ref definitions between HTML comments (e.g. <!-- prettier-ignore-start --> ... <!-- prettier-ignore-end -->)
+   * are not parsed by marked because the comment placeholders create a block context where ref defs are ignored.
+   * Extract such ref defs and move them to the end of the document so marked can resolve shortcut links.
+   */
+  function extractRefDefsFromCommentBlocks(markdown) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    var refDefRe = /^\s{0,3}\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))/;
+    var commentRe = /^\s*<!--\s*[\s\S]*?-->\s*$/;
+    var lines = markdown.split('\n');
+    var extracted = [];
+    var i = 0;
+    while (i < lines.length) {
+      var line = lines[i];
+      if (commentRe.test(line)) {
+        var blockStart = i;
+        i++;
+        var between = [];
+        while (i < lines.length && !commentRe.test(lines[i])) {
+          between.push(lines[i]);
+          i++;
+        }
+        if (i < lines.length && commentRe.test(lines[i])) {
+          var refDefLines = [];
+          var otherLines = [];
+          for (var j = 0; j < between.length; j++) {
+            if (refDefRe.test(between[j])) {
+              refDefLines.push(between[j]);
+            } else {
+              otherLines.push(between[j]);
+            }
+          }
+          if (refDefLines.length > 0) {
+            extracted = extracted.concat(refDefLines);
+            lines = lines.slice(0, blockStart + 1).concat(otherLines).concat(lines.slice(i));
+            i = blockStart + 1 + otherLines.length;
+          }
+        }
+        i++;
+      } else {
+        i++;
+      }
+    }
+    if (extracted.length === 0) return markdown;
+    var suffix = (lines.length > 0 && lines[lines.length - 1] !== '') ? '\n\n' : '\n';
+    return lines.join('\n') + suffix + extracted.join('\n');
+  }
+
+  /**
+   * Restore ref definitions between HTML comment pairs when serializing to markdown.
+   * extractRefDefsFromCommentBlocks moves ref defs to the end for marked parsing; this
+   * restores the original structure (ref defs between comments) and removes extra newlines.
+   */
+  function restoreRefDefsToCommentBlocks(markdown) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    var refDefRe = /^\s{0,3}\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))/;
+    var commentRe = /^\s*<!--\s*[\s\S]*?-->\s*$/;
+    var lines = markdown.split('\n');
+    var i = lines.length - 1;
+    var refDefLines = [];
+    while (i >= 0 && refDefRe.test(lines[i])) {
+      refDefLines.unshift(lines[i]);
+      i--;
+    }
+    while (i >= 0 && /^\s*$/.test(lines[i])) i--;
+    if (refDefLines.length === 0 || i < 1) return markdown;
+    var endCommentIdx = i;
+    if (!commentRe.test(lines[endCommentIdx])) return markdown;
+    var startCommentIdx = endCommentIdx - 1;
+    while (startCommentIdx >= 0 && /^\s*$/.test(lines[startCommentIdx])) startCommentIdx--;
+    if (startCommentIdx < 0 || !commentRe.test(lines[startCommentIdx])) return markdown;
+    var before = lines.slice(0, startCommentIdx + 1);
+    var restored = before.concat(refDefLines).concat([lines[endCommentIdx]]);
+    return restored.join('\n');
+  }
+
   function preprocessRawHtml(markdown) {
     if (!markdown || typeof markdown !== 'string') return { markdown: markdown, comments: [], tags: [] };
+    markdown = extractRefDefsFromCommentBlocks(markdown);
     var comments = [];
     var tags = [];
 
@@ -3018,7 +3342,22 @@
             var fullBlock = blockLines.join('\n');
             var encoded = _b64Encode(fullBlock);
             var blockIndent = blockOpenMatch[1] || '';
-            result.push(blockIndent + '<div ' + RAW_HTML_BLOCK_ATTR + '="' + encoded + '"></div>');
+            var lastBlockLine = blockLines[blockLines.length - 1];
+            var lastCloseIdx = lastBlockLine.lastIndexOf('>');
+            var afterCloseOnLine = lastCloseIdx >= 0 ? lastBlockLine.substring(lastCloseIdx + 1) : '';
+            var blockNewlinesAfter;
+            if (/[^\s]/.test(afterCloseOnLine)) {
+              blockNewlinesAfter = 0;
+            } else {
+              var jBlock = i + blockLines.length;
+              var blanksBlock = 0;
+              while (jBlock < lines.length && /^\s*$/.test(lines[jBlock])) {
+                blanksBlock++;
+                jBlock++;
+              }
+              blockNewlinesAfter = blanksBlock + 1;
+            }
+            result.push(blockIndent + '<div ' + RAW_HTML_BLOCK_ATTR + '="' + encoded + '" ' + RAW_HTML_NEWLINES_AFTER_ATTR + '="' + blockNewlinesAfter + '"></div>');
             continue;
           }
         }
@@ -3030,7 +3369,7 @@
         continue;
       }
 
-      var tagProcessed = _preprocessLineTags(line, tags, result);
+      var tagProcessed = _preprocessLineTags(line, lines, i, tags, result);
       if (tagProcessed) {
         continue;
       }
@@ -3040,6 +3379,8 @@
 
     return { markdown: result.join('\n'), comments: comments, tags: tags };
   }
+
+  var _blockCommentRe = /^\s*<!--[\s\S]*?-->\s*$/;
 
   function _preprocessLineComments(line, lines, idx, comments, result) {
     var commentStart = line.indexOf('<!--');
@@ -3051,16 +3392,38 @@
       var comment = line.substring(commentStart, commentEnd + 3);
       var after = line.substring(commentEnd + 3);
       var isBlockComment = !before.trim() && !after.trim();
-      var originalForEncode = isBlockComment ? before + comment : comment;
-      var encoded = _b64Encode(originalForEncode);
-      var idx_ = comments.length;
-      comments.push({ original: comment, leading: isBlockComment ? before : '', lineIdx: idx });
-      var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" style="display:none"></span>';
       if (isBlockComment) {
+        var blockLines = [line];
+        var j = idx + 1;
+        while (j < lines.length && _blockCommentRe.test(lines[j])) {
+          blockLines.push(lines[j]);
+          j++;
+        }
+        var blanks = 0;
+        while (j < lines.length && /^\s*$/.test(lines[j])) {
+          blanks++;
+          j++;
+        }
+        var newlinesAfter = blanks + 1;
+        var collapsedBlock = blockLines.join('\n').replace(/\s+$/, '');
+        var encoded = _b64Encode(collapsedBlock);
+        comments.push({ original: collapsedBlock, leading: before, lineIdx: idx });
+        var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" ' + RAW_HTML_NEWLINES_AFTER_ATTR + '="' + newlinesAfter + '" style="display:none"></span>';
         result.push(before + placeholder + after);
-      } else {
-        result.push(before + placeholder + after);
+        return j - 1;
       }
+      var blanks = 0;
+      var k = idx + 1;
+      while (k < lines.length && /^\s*$/.test(lines[k])) {
+        blanks++;
+        k++;
+      }
+      var newlinesAfterInline = blanks + 1;
+      var originalForEncode = comment.replace(/\s+$/, '');
+      var encoded = _b64Encode(originalForEncode);
+      comments.push({ original: comment, leading: '', lineIdx: idx });
+      var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" ' + RAW_HTML_NEWLINES_AFTER_ATTR + '="' + newlinesAfterInline + '" style="display:none"></span>';
+      result.push(before + placeholder + after);
       return idx;
     }
 
@@ -3081,11 +3444,19 @@
     var commentText = fullComment.substring(commentStart, endPos + 3);
     var afterComment = fullComment.substring(endPos + 3);
     var isBlockComment = !leading.trim();
-    var originalForEncode = isBlockComment ? leading + commentText : commentText;
+    var originalForEncode = (isBlockComment ? leading + commentText : commentText).replace(/\s+$/, '');
+
+    var blanksMulti = 0;
+    var kMulti = j + 1;
+    while (kMulti < lines.length && /^\s*$/.test(lines[kMulti])) {
+      blanksMulti++;
+      kMulti++;
+    }
+    var newlinesAfterMulti = blanksMulti + 1;
 
     var encoded = _b64Encode(originalForEncode);
     comments.push({ original: commentText, leading: isBlockComment ? leading : '', lineIdx: idx });
-    var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" style="display:none"></span>';
+    var placeholder = '<span ' + RAW_HTML_COMMENT_ATTR + '="' + encoded + '" ' + RAW_HTML_NEWLINES_AFTER_ATTR + '="' + newlinesAfterMulti + '" style="display:none"></span>';
     var afterLines = afterComment.split('\n');
     result.push(leading + placeholder + afterLines[0]);
     for (var k = 1; k < afterLines.length; k++) {
@@ -3094,7 +3465,7 @@
     return j;
   }
 
-  function _preprocessLineTags(line, tags, result) {
+  function _preprocessLineTags(line, lines, idx, tags, result) {
     var tagRe = /<(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b([^>]*?)(\/?)>/g;
     var out = '';
     var lastIdx = 0;
@@ -3146,9 +3517,16 @@
         tags.push({ original: originalForEncode, type: 'selfclose' });
         out += fullTag.replace(/\/?>$/, ' ' + RAW_HTML_ATTR + '="' + encoded + '"/>');
       } else if (isClose) {
+        var restOfLine = line.substring(m.index + fullTag.length);
+        var newlinesAfterTag = 0;
+        if (/^\s*$/.test(restOfLine)) {
+          var jTag = idx + 1;
+          while (jTag < lines.length && /^\s*$/.test(lines[jTag])) jTag++;
+          newlinesAfterTag = 1 + (jTag - idx - 1);
+        }
         var encoded = _b64Encode(originalForEncode);
         tags.push({ original: originalForEncode, type: 'close' });
-        out += fullTag + '<!--' + RAW_HTML_CLOSE_PREFIX + encoded + '-->';
+        out += fullTag + '<!--' + RAW_HTML_CLOSE_PREFIX + encoded + '|' + newlinesAfterTag + '-->';
       } else {
         var encoded = _b64Encode(originalForEncode);
         tags.push({ original: originalForEncode, type: 'open' });
@@ -3165,6 +3543,7 @@
 
   function postprocessRawHtml(markdown, rawHtmlData) {
     if (!markdown || typeof markdown !== 'string') return markdown;
+    markdown = restoreRefDefsToCommentBlocks(markdown);
     if (!rawHtmlData) return markdown;
     return markdown;
   }
@@ -3367,7 +3746,9 @@
             var after = trimmed.slice(lastOpenIdx);
             var lastLineBefore = before.slice(before.lastIndexOf('\n') + 1);
             var endsWithRefDef = refDefNameRe.test(lastLineBefore);
-            result = before + (endsWithRefDef ? '\n' : '\n\n') + defsToAppend + '\n' + after + '\n';
+            var endsWithHtmlComment = /^\s*<!--[\s\S]*?-->\s*$/.test(lastLineBefore);
+            var sep = endsWithRefDef ? '\n' : (endsWithHtmlComment ? '\n' : '\n\n');
+            result = before + sep + defsToAppend + '\n' + after + '\n';
             inserted = true;
           }
         }
@@ -3604,6 +3985,9 @@
       var result = origSwitchToMode.apply(this, arguments);
       if (mode === 'markdown') {
         var md = this.markdownArea.value;
+        if (this._liveWysiwygRawHtmlData) {
+          md = postprocessRawHtml(md, this._liveWysiwygRawHtmlData);
+        }
         if (this._liveWysiwygLinkData) {
           md = postprocessMarkdownLinks(md, this._liveWysiwygLinkData);
         }
@@ -3615,9 +3999,6 @@
         }
         if (this._liveWysiwygCodeBlockData) {
           md = postprocessCodeBlocks(md, this._liveWysiwygCodeBlockData);
-        }
-        if (this._liveWysiwygRawHtmlData) {
-          md = postprocessRawHtml(md, this._liveWysiwygRawHtmlData);
         }
         if (this._liveWysiwygHrData) {
           md = postprocessHorizontalRules(md, this._liveWysiwygHrData);
@@ -3646,6 +4027,9 @@
         this._liveWysiwygFrontmatter = parsed.frontmatter;
       }
       var body = parsed.body;
+      if (this._liveWysiwygRawHtmlData) {
+        body = postprocessRawHtml(body, this._liveWysiwygRawHtmlData);
+      }
       if (this._liveWysiwygLinkData) {
         body = postprocessMarkdownLinks(body, this._liveWysiwygLinkData);
       }
@@ -3657,9 +4041,6 @@
       }
       if (this._liveWysiwygCodeBlockData) {
         body = postprocessCodeBlocks(body, this._liveWysiwygCodeBlockData);
-      }
-      if (this._liveWysiwygRawHtmlData) {
-        body = postprocessRawHtml(body, this._liveWysiwygRawHtmlData);
       }
       if (this._liveWysiwygHrData) {
         body = postprocessHorizontalRules(body, this._liveWysiwygHrData);
@@ -4190,7 +4571,7 @@
     var contextBefore = pendingReadModeSelection.contextBefore || '';
     var contextAfter = pendingReadModeSelection.contextAfter || '';
     pendingReadModeSelection = null;
-    var md = editor.currentMode === 'markdown'
+    var md = (editor.markdownArea && editor.markdownArea.value)
       ? editor.markdownArea.value
       : (editor.getValue ? editor.getValue() : '');
     var parsed = parseFrontmatter(md || '');
@@ -4560,14 +4941,63 @@
     var len = text.length;
     var lastWasSpace = false;
 
+    function atLineStart() { return i === 0 || text[i - 1] === '\n'; }
+
     while (i < len) {
-      if (i === 0 || text[i - 1] === '\n') {
+      if (atLineStart()) {
         var j = i;
         while (j < len && text[j] === '#') j++;
         if (j > i && j - i <= 6 && j < len && text[j] === ' ') {
           i = j + 1;
           continue;
         }
+        while (i < len && text[i] === '>' && i + 1 < len && text[i + 1] === ' ') { i += 2; }
+        if (i < len && (text[i] === '-' || text[i] === '+' || text[i] === '*') && i + 1 < len && text[i + 1] === ' ') {
+          i += 2;
+          continue;
+        }
+        if (i < len && /\d/.test(text[i])) {
+          var k = i;
+          while (k < len && /\d/.test(text[k])) k++;
+          if (k > i && k < len && text[k] === '.' && k + 1 < len && text[k + 1] === ' ') {
+            i = k + 2;
+            continue;
+          }
+        }
+        if (i + 3 < len && text[i] === ' ' && text[i + 1] === ' ' && (text[i + 2] === '-' || text[i + 2] === '+' || text[i + 2] === '*') && text[i + 3] === ' ') {
+          i += 4;
+          continue;
+        }
+        if (i + 3 < len && text[i] === ' ' && text[i + 1] === ' ' && /\d/.test(text[i + 2])) {
+          var k2 = i + 2;
+          while (k2 < len && /\d/.test(text[k2])) k2++;
+          if (k2 > i + 2 && k2 < len && text[k2] === '.' && k2 + 1 < len && text[k2 + 1] === ' ') {
+            i = k2 + 2;
+            continue;
+          }
+        }
+        if (i + 5 < len && text[i] === ' ' && text[i + 1] === ' ' && text[i + 2] === ' ' && text[i + 3] === ' ' && (text[i + 4] === '-' || text[i + 4] === '+' || text[i + 4] === '*') && text[i + 5] === ' ') {
+          i += 6;
+          continue;
+        }
+        if (i + 3 < len && text[i] === ' ' && text[i + 1] === ' ' && text[i + 2] === ' ' && text[i + 3] === ' ') {
+          i += 4;
+          continue;
+        }
+        if (i + 3 < len && text[i] === '!' && text[i + 1] === '!' && text[i + 2] === '!' && text[i + 3] === ' ') {
+          while (i < len && text[i] !== '\n') i++;
+          continue;
+        }
+        if (i + 3 < len && text[i] === '?' && text[i + 1] === '?' && text[i + 2] === '?' && (text[i + 3] === ' ' || (text[i + 3] === '+' && i + 4 < len && text[i + 4] === ' '))) {
+          while (i < len && text[i] !== '\n') i++;
+          continue;
+        }
+      }
+      if (i + 3 < len && text[i] === '<' && text[i + 1] === '!' && text[i + 2] === '-' && text[i + 3] === '-') {
+        i += 4;
+        while (i + 2 < len && !(text[i] === '-' && text[i + 1] === '-' && text[i + 2] === '>')) i++;
+        if (i + 2 < len) i += 3;
+        continue;
       }
       if (text[i] === '`') { i++; continue; }
       if (text[i] === '*' && i + 1 < len && text[i + 1] === '*') { i += 2; continue; }
@@ -4605,7 +5035,7 @@
     };
     if (applyPendingReadModeSelection(editor)) return true;
 
-    var mdRaw = editor.currentMode === 'markdown'
+    var mdRaw = (editor.markdownArea && editor.markdownArea.value)
       ? editor.markdownArea.value
       : (editor.getValue ? editor.getValue() : '');
     var parsed = parseFrontmatter(mdRaw || '');
@@ -5682,6 +6112,29 @@
         ma.dataset.liveWysiwygBlurAttached = '1';
         ma.addEventListener('blur', function () {
           capturedMarkdownSelection = { start: ma.selectionStart, end: ma.selectionEnd };
+        });
+      }
+    })();
+
+    (function () {
+      var linkBtn = wysiwygEditor.toolbar && wysiwygEditor.toolbar.querySelector('.md-toolbar-button-link');
+      if (linkBtn && !linkBtn.dataset.liveWysiwygLinkMousedownAttached) {
+        linkBtn.dataset.liveWysiwygLinkMousedownAttached = '1';
+        linkBtn.addEventListener('mousedown', function () {
+          if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor.editableArea) {
+            var ea = wysiwygEditor.editableArea;
+            if (document.activeElement === ea) {
+              var sel = window.getSelection();
+              if (sel && sel.rangeCount > 0 && ea.contains(sel.getRangeAt(0).commonAncestorContainer)) {
+                wysiwygEditor.savedRangeInfo = sel.getRangeAt(0).cloneRange();
+              }
+            }
+          } else if (wysiwygEditor.currentMode === 'markdown' && wysiwygEditor.markdownArea) {
+            var ma = wysiwygEditor.markdownArea;
+            if (document.activeElement === ma) {
+              wysiwygEditor.savedRangeInfo = { start: ma.selectionStart, end: ma.selectionEnd };
+            }
+          }
         });
       }
     })();
@@ -7331,8 +7784,11 @@
       var proto = MarkdownWYSIWYG.prototype;
       var origMdToHtml = proto._markdownToHtml;
       if (!origMdToHtml) return;
+      var spanPattern = new RegExp('<span\\s+data-live-wysiwyg-cursor\\s*></span>', 'g');
+      var spanEndPattern = new RegExp('<span\\s+data-live-wysiwyg-cursor-end\\s*></span>', 'g');
       proto._markdownToHtml = function (markdown) {
         var md = markdown || '';
+        md = md.replace(spanPattern, 'LIVEWYSIWYG_CURSOR_9X7K2').replace(spanEndPattern, 'LIVEWYSIWYG_CURSOR_END_9X7K2');
         var rawResult = preprocessRawHtml(md);
         this._liveWysiwygRawHtmlData = rawResult;
         return origMdToHtml.call(this, rawResult.markdown);

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.css
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.css
@@ -1044,3 +1044,72 @@
 .md-admonition-placement-half.active:hover {
  background: #2d5a8a;
 }
+
+/* Link settings dropdown - matches admonition/code settings style */
+.md-link-settings-dropdown {
+ position: fixed;
+ width: 220px;
+ background: #1e1e1e;
+ border: 1px solid #444;
+ border-radius: 4px;
+ box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+ z-index: 10000;
+ padding: 6px 0;
+ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+ font-size: 12px;
+ color: #c9d1d9;
+}
+
+.md-link-settings-row {
+ display: flex;
+ align-items: center;
+ justify-content: space-between;
+ padding: 5px 10px;
+}
+
+.md-link-settings-label {
+ flex-shrink: 0;
+ margin-right: 8px;
+}
+
+.md-link-settings-input {
+ flex: 1;
+ min-width: 0;
+ background: #333;
+ color: #c9d1d9;
+ border: 1px solid #555;
+ border-radius: 3px;
+ padding: 4px 8px;
+ font-family: inherit;
+ font-size: inherit;
+}
+
+.md-link-settings-input:focus {
+ outline: none;
+ border-color: #3a7bd5;
+}
+
+.md-link-settings-input::placeholder {
+ color: #888;
+}
+
+.md-link-settings-apply-row {
+ justify-content: flex-end;
+ padding-top: 8px;
+}
+
+.md-link-settings-apply {
+ background: #264f78;
+ color: #fff;
+ border: 1px solid #3a7bd5;
+ border-radius: 3px;
+ padding: 4px 12px;
+ cursor: pointer;
+ font-family: inherit;
+ font-size: inherit;
+ transition: background 0.1s, color 0.1s;
+}
+
+.md-link-settings-apply:hover {
+ background: #2d5a8a;
+}

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.js
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.js
@@ -1648,9 +1648,9 @@ class MarkdownWYSIWYG {
     }
 
     _handleToolbarClick(buttonConfig, buttonElement) {
-        if (buttonConfig.id === 'table' || buttonConfig.id === 'image' || buttonConfig.id === 'admonition') {
+        if (buttonConfig.id === 'table' || buttonConfig.id === 'image' || buttonConfig.id === 'admonition' || buttonConfig.id === 'link') {
             if (typeof this[buttonConfig.action] === 'function') {
-                // Focus is handled inside the action (_insertImageAction, _insertTableAction)
+                // Focus is handled inside the action (_insertImageAction, _insertTableAction, _insertLink)
                 // before showing the popup/grid, to save the correct range.
                 this[buttonConfig.action](buttonElement);
             }
@@ -2146,7 +2146,9 @@ class MarkdownWYSIWYG {
         this._finalizeUpdate(textarea.value);
     }
 
-    _insertLink() {
+    _insertLink(buttonElement) {
+        // Link insertion/editing is patched by live-wysiwyg-integration.js to show a dropdown menu.
+        // Fallback when patch is not applied (e.g. integration not loaded):
         if (this.currentMode === 'wysiwyg') {
             this.editableArea.focus();
             const selection = window.getSelection();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,8 @@ name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-live-wysiwyg-plugin"
-version = "0.1.9"
+version = "0.1.36"
 source = { editable = "." }
 dependencies = [
     { name = "mkdocs" },
@@ -236,6 +236,11 @@ dev = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mkdocs", specifier = ">=1.5" },
@@ -243,6 +248,9 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
New UI Features:

- New URL menu where if you insert a URL you get a menu instead of popups.
- The new URL menu allows you to modify existing links.

Enhancements:

- After selection, cursor tracking, and readonly selection heuristics were fixed... I enhanced selection heuristics to reliably traverse a more diverse set of elements including handling HTML comments.

Bug fixes

- Raw HTML handling is now more reliable at not producing a diff specifically leading or trailing newlines.
- Selection tracking was broken by Raw HTML handling and is now fixed across WYSIWYG and Markdown modes.
- Upon first load the WYSIWYG couldn't render ref links where the refs were wrapped in HTML comments.
- Selection heuristics in readonly mode to editor were completely broken by Raw HTML handling.  Now fixed.