### PR TITLE
Dark mode theming

### DIFF
--- a/docs/design/DESIGN-theme-detection.md
+++ b/docs/design/DESIGN-theme-detection.md
@@ -1,0 +1,179 @@
+# Theme Detection & CSS Variable Injection — Design Document
+
+## Purpose
+
+The WYSIWYG plugin must look visually consistent with the page's theme regardless of whether the theme is Material, Cinder, MkDocs default, or any other MkDocs-compatible theme. Rather than depending on the upstream `mkdocs-live-edit-plugin` to adopt CSS variables (an unmerged change), the WYSIWYG plugin owns all theming: it detects colors at runtime, sets CSS custom properties on `:root`, and injects a `<style>` block that overrides the upstream plugin's hardcoded colors.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Page loads with theme-provided CSS                          │
+│  (Material sets --md-* vars; other themes do not)            │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+            ┌──────────▼──────────┐
+            │  _detectThemeColors │  Called once from replaceTextareaWithWysiwyg()
+            └──────────┬──────────┘
+                       │
+          ┌────────────▼────────────┐
+          │ Material vars present?  │
+          └────┬───────────────┬────┘
+             YES               NO
+               │                │
+   ┌───────────▼───────┐  ┌────▼─────────────────────┐
+   │ Fill gaps only:   │  │ Sample computed styles:   │
+   │ --md-footer-bg-*  │  │ • navbar bg/fg → primary  │
+   │ --md-code-font-*  │  │ • body bg/fg → default    │
+   │ (if theme lacks)  │  │ • <a> color → accent      │
+   └───────────────────┘  │ • body font → text/code   │
+                          │ Derive variants:           │
+                          │ • darken/lighten/alpha     │
+                          │ Set all on :root           │
+                          └────────────────────────────┘
+                       │
+            ┌──────────▼──────────────────────┐
+            │ <style id="live-wysiwyg-theme-  │  Injected alongside width overrides
+            │          overrides">             │  in replaceTextareaWithWysiwyg()
+            │ Overrides upstream hardcoded     │
+            │ colors with var(--md-*, fallback)│
+            └─────────────────────────────────┘
+```
+
+## Two Branches of Detection
+
+### Branch 1 — Material Theme (CSS variables already exist)
+
+When `--md-primary-fg-color` is already defined on `:root` (by the Material theme), the detector takes a minimal path:
+
+1. Check for `--md-footer-bg-color`. If absent, derive it by darkening `--md-primary-fg-color` by 10%.
+2. Check for `--md-code-font-family`. If absent, fall back to the body's computed `fontFamily`.
+3. Return an empty `colors` map (no overrides needed for focus mode overlay since the `:root` vars already work).
+
+### Branch 2 — Non-Material Theme (no CSS variables)
+
+When `--md-primary-fg-color` is not present, colors are sampled from computed styles:
+
+| Source Element | Computed Property | CSS Variables Set |
+|---|---|---|
+| `document.body.children[0]` (navbar) | `backgroundColor` | `--md-primary-fg-color`, `--md-primary-fg-color--dark` (darken 15%), `--md-footer-bg-color` (darken 10%) |
+| `document.body.children[0]` (navbar) | `color` | `--md-primary-bg-color` |
+| `document.body` | `backgroundColor` | `--md-default-bg-color`, `--md-default-bg-color--light`, `--md-default-bg-color--lighter` |
+| `document.body` | `color` | `--md-default-fg-color`, `--md-default-fg-color--light` (alpha 0.54), `--md-default-fg-color--lighter` (alpha 0.32), `--md-default-fg-color--lightest` (alpha 0.12) |
+| First `a[href]` on page | `color` | `--md-accent-fg-color`, `--md-typeset-a-color` |
+| `document.body` | `fontFamily` | `--md-text-font-family`, `--md-code-font-family` |
+
+All derived variables are set on `document.documentElement.style` so they become available globally via `var()`.
+
+### Variant Derivation Functions
+
+| Function | Purpose | Algorithm |
+|---|---|---|
+| `_darken(rgb, factor)` | Darker shade | `channel * (1 - factor)` for each R/G/B |
+| `_lighten(rgb, factor)` | Lighter tint | `channel + (255 - channel) * factor` |
+| `_alpha(rgb, a)` | Transparent variant | `rgba(r, g, b, a)` |
+| `_isLight(rgb)` | Light/dark classification | `luminance > 0.4` (WCAG relative luminance) |
+| `_luminance(r, g, b)` | WCAG relative luminance | `0.2126*R + 0.7152*G + 0.0722*B` with sRGB linearization |
+
+Light/dark classification determines whether background variants should darken (for light themes) or lighten (for dark themes).
+
+## Injected Style Elements
+
+### `<style id="live-wysiwyg-theme-overrides">`
+
+Injected in **two layers** for zero-flash theming:
+
+1. **Server-side** (`plugin.py` `on_page_content`): The style block is emitted as the first `<style>` tag in the injected assets, before the editor CSS and before any `<script>`. This ensures the overrides are parsed by the browser before the upstream `live-edit.css` can paint the controls with hardcoded colors. For Material themes, the `var()` references resolve immediately against the theme's own CSS variables. For non-Material themes, the fallback values in each `var()` apply until JS runs.
+
+2. **Client-side** (`_ensureThemeOverrides()` in JS): Called from `ensureToggleButton()` (earliest plugin interaction with controls) and `replaceTextareaWithWysiwyg()`. Checks `getElementById('live-wysiwyg-theme-overrides')` — since the server already injected it, the JS skips creating a duplicate. The JS still calls `_detectThemeColors()` to set `:root` CSS variables for non-Material themes, at which point the `var()` references in the already-present style block resolve to the detected colors.
+
+Overrides the upstream `mkdocs-live-edit-plugin`'s hardcoded styles with CSS-variable-based equivalents. All declarations use `!important` to override the upstream stylesheet regardless of source order.
+
+| Selector | Properties Overridden | CSS Variables Used |
+|---|---|---|
+| `.live-edit-source` | `font-family`, `color`, `background`, `border-color` | `--md-code-font-family`, `--md-default-fg-color`, `--md-default-bg-color`, `--md-default-fg-color--lightest` |
+| `button.live-edit-button` | `background`, `border`, `color` | `--md-primary-bg-color` |
+| `button.live-edit-button:hover` | `background` | (static rgba) |
+| `button.live-edit-save-button` | `background`, `border-color`, `color` | (static green values, preserved from upstream) |
+| `button.live-edit-save-button:hover` | `background` | (static green) |
+| `button.live-edit-cancel-button` | `background`, `border-color`, `color` | (static red values, preserved from upstream) |
+| `button.live-edit-cancel-button:hover` | `background` | (static red) |
+| `div.live-edit-controls` | `background` (gradient), `border-color`, `color` | `--md-primary-fg-color`, `--md-footer-bg-color`, `--md-primary-fg-color--dark`, `--md-primary-bg-color` |
+| `.live-edit-label` | `color` | `--md-primary-bg-color` |
+| `.live-edit-info-modal` | `background-color`, `border-color` | `--md-default-bg-color--light`, `--md-default-fg-color--lightest` |
+
+### `<style id="live-wysiwyg-width-overrides">`
+
+Separate style block for width alignment (documented in `DESIGN-editor-width-alignment` / `editor-width-alignment.mdc`). Not part of the theming system.
+
+## Focus Mode Theming
+
+Focus mode CSS (`_getFocusModeCSS()`) references the same `--md-*` variable set. Because `_detectThemeColors()` now sets these on `:root`, focus mode inherits them automatically.
+
+Additionally, `_detectThemeColors()` returns a `colors` map. For non-Material themes this map is non-empty and is applied as inline `style.setProperty()` calls directly on the `.live-wysiwyg-focus-overlay` element. This provides a second layer of specificity for the focus mode overlay, ensuring variables are available even if some edge case prevents `:root` inheritance (e.g., Shadow DOM in future).
+
+Focus mode CSS variables used:
+
+| Variable | Elements |
+|---|---|
+| `--md-default-bg-color` | `.live-wysiwyg-focus-overlay`, `.live-wysiwyg-focus-content .md-wysiwyg-editor-wrapper`, `.live-wysiwyg-focus-exit-btn` |
+| `--md-default-fg-color` | `.live-wysiwyg-focus-overlay`, `.live-wysiwyg-focus-exit-btn` |
+| `--md-text-font-family` | `.live-wysiwyg-focus-overlay` |
+| `--md-primary-fg-color` | `.live-wysiwyg-focus-header` |
+| `--md-primary-bg-color` | `.live-wysiwyg-focus-header`, `.live-wysiwyg-focus-drawer-toggle`, `.live-wysiwyg-focus-close` |
+| `--md-primary-fg-color--dark` | `.live-wysiwyg-focus-save-btn:hover` |
+| `--md-default-bg-color--light` | `.live-wysiwyg-focus-toolbar-drawer`, `.live-wysiwyg-focus-mode-toggle button:not(.active)` |
+| `--md-default-bg-color--lighter` | `.live-wysiwyg-focus-mode-toggle button:not(.active):hover`, `.live-wysiwyg-focus-exit-btn:hover` |
+| `--md-default-fg-color--light` | `.live-wysiwyg-focus-mode-toggle button:not(.active)`, `.live-wysiwyg-focus-autofocus-label` |
+| `--md-default-fg-color--lighter` | `.live-wysiwyg-focus-mode-toggle`, `.live-wysiwyg-focus-exit-btn`, `.live-wysiwyg-focus-autofocus-cb`, `.live-wysiwyg-focus-toc` scrollbar |
+| `--md-default-fg-color--lightest` | `.live-wysiwyg-focus-toolbar-open .live-wysiwyg-focus-toolbar-drawer`, `.live-wysiwyg-focus-toc-link` border |
+| `--md-accent-fg-color` | `.live-wysiwyg-focus-mode-toggle button.active`, `.live-wysiwyg-focus-save-btn`, `.live-wysiwyg-focus-autofocus-cb:checked`, `.live-wysiwyg-focus-toc-link.active` |
+
+## Execution Order
+
+1. **Server-side** (`plugin.py`): `<style id="live-wysiwyg-theme-overrides">` is emitted as the first asset in `on_page_content`. For Material themes, controls are fully themed from first paint. For non-Material themes, `var()` fallbacks provide reasonable defaults.
+2. User enters edit mode — upstream `live-edit-plugin` creates the controls bar. The server-injected style overrides apply immediately.
+3. WYSIWYG plugin JS loads and discovers the textarea via `observeForTextarea()`.
+4. **`ensureToggleButton()`** is called — this calls **`_ensureThemeOverrides()`** which:
+   - Runs `_detectThemeColors()` — sets CSS variables on `:root` for non-Material themes (idempotent via `_themeColorsDetected` flag). For Material themes, fills any missing derived variables.
+   - Checks `getElementById('live-wysiwyg-theme-overrides')` — finds the server-injected element, so skips creating a duplicate.
+5. For non-Material themes, the `var()` references in the already-present style block now resolve to detected colors (replacing the fallback values).
+6. If the user activates the editor, `replaceTextareaWithWysiwyg()` calls `_ensureThemeOverrides()` again (no-op) and injects `<style id="live-wysiwyg-width-overrides">`.
+7. If the user enters focus mode later, `_detectThemeColors()` is called again — the `_themeColorsDetected` flag prevents `:root` re-writes, but the returned `colors` map is applied to the overlay element.
+
+## Cleanup
+
+`destroyWysiwyg()` removes the width overrides style element:
+- `document.getElementById('live-wysiwyg-width-overrides')` → remove
+
+The theme overrides (`live-wysiwyg-theme-overrides`) are **not** removed by `destroyWysiwyg()`. The controls bar remains visible after the WYSIWYG editor is disabled (showing Edit, Rename, Delete, New buttons), and those buttons must stay themed. The theme style persists for the lifetime of the page.
+
+The CSS variables set on `document.documentElement.style` are also **not** removed. They are harmless when the editor is inactive and would be re-set on next activation anyway.
+
+## Complete CSS Variable Inventory
+
+Every `--md-*` CSS variable that the WYSIWYG plugin references or generates:
+
+| Variable | Source (Material) | Source (Non-Material) | Consumers |
+|---|---|---|---|
+| `--md-primary-fg-color` | Theme CSS | navbar `backgroundColor` | Controls gradient, focus header |
+| `--md-primary-fg-color--dark` | Theme CSS | `_darken(navBg, 0.15)` | Controls border, focus save hover |
+| `--md-primary-bg-color` | Theme CSS | navbar `color` | Button text, label, focus header text |
+| `--md-footer-bg-color` | Theme CSS (or derived) | `_darken(navBg, 0.1)` | Controls gradient bottom |
+| `--md-default-bg-color` | Theme CSS | body `backgroundColor` | Textarea bg, focus overlay bg |
+| `--md-default-bg-color--light` | Theme CSS | `_darken/_lighten(bodyBg, 0.04/0.06)` | Info modal bg, focus drawer bg |
+| `--md-default-bg-color--lighter` | Theme CSS | `_darken/_lighten(bodyBg, 0.07/0.1)` | Focus toggle hover |
+| `--md-default-fg-color` | Theme CSS | body `color` | Textarea text, focus overlay text |
+| `--md-default-fg-color--light` | Theme CSS | `_alpha(bodyFg, 0.54)` | Focus toggle inactive text |
+| `--md-default-fg-color--lighter` | Theme CSS | `_alpha(bodyFg, 0.32)` | Focus toggle border, checkbox border |
+| `--md-default-fg-color--lightest` | Theme CSS | `_alpha(bodyFg, 0.12)` | Textarea border, info modal border |
+| `--md-accent-fg-color` | Theme CSS | first `<a>` `color` | Focus active toggle, save button, checkbox |
+| `--md-typeset-a-color` | Theme CSS | first `<a>` `color` | Link styling in editable area |
+| `--md-text-font-family` | Theme CSS | body `fontFamily` | Focus overlay font |
+| `--md-code-font-family` | Theme CSS (or derived) | body `fontFamily` | Textarea font |
+
+## Relationship to Upstream `mkdocs-live-edit-plugin`
+
+The upstream plugin (`mkdocs-live-edit-plugin`) has hardcoded colors in `live-edit.css`. An unmerged commit on the upstream exists that replaces these with CSS variables and adds its own `_detectThemeVars()` function. The WYSIWYG plugin's theme overrides make this upstream change **unnecessary** — the `<style id="live-wysiwyg-theme-overrides">` block uses `!important` to override all upstream hardcoded values, and `_detectThemeColors()` ensures the CSS variables are available regardless of theme.
+
+If the upstream eventually merges its own theming commit, the WYSIWYG plugin's overrides will still function correctly (they reference the same variables with `!important`). To retire the WYSIWYG overrides at that point, remove the `live-wysiwyg-theme-overrides` style injection and cleanup code, and remove the `:root` variable-setting logic from `_detectThemeColors()` (keeping only the focus mode overlay application).

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -7309,10 +7309,129 @@
 
   var FOCUS_MODE_STYLE_ID = 'live-wysiwyg-focus-mode-styles';
 
+  var _themeColorsDetected = false;
+  function _detectThemeColors() {
+    var colors = {};
+    var cs = getComputedStyle(document.documentElement);
+
+    function _cssVar(name) {
+      var v = cs.getPropertyValue(name);
+      return v ? v.trim() : '';
+    }
+    function _luminance(r, g, b) {
+      var a = [r, g, b].map(function (v) {
+        v /= 255;
+        return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+    }
+    function _parseRgb(str) {
+      if (!str) return null;
+      var m = str.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+      return m ? { r: +m[1], g: +m[2], b: +m[3] } : null;
+    }
+    function _isLight(rgb) {
+      return rgb && _luminance(rgb.r, rgb.g, rgb.b) > 0.4;
+    }
+    function _darken(rgb, factor) {
+      var f = 1 - (factor || 0.15);
+      return 'rgb(' + Math.round(rgb.r * f) + ',' + Math.round(rgb.g * f) + ',' + Math.round(rgb.b * f) + ')';
+    }
+    function _lighten(rgb, factor) {
+      var f = factor || 0.15;
+      return 'rgb(' +
+        Math.round(rgb.r + (255 - rgb.r) * f) + ',' +
+        Math.round(rgb.g + (255 - rgb.g) * f) + ',' +
+        Math.round(rgb.b + (255 - rgb.b) * f) + ')';
+    }
+    function _alpha(rgb, a) {
+      return 'rgba(' + rgb.r + ',' + rgb.g + ',' + rgb.b + ',' + a + ')';
+    }
+
+    var hasMdVars = !!_cssVar('--md-primary-fg-color');
+    if (hasMdVars) {
+      if (!_themeColorsDetected) {
+        _themeColorsDetected = true;
+        if (!_cssVar('--md-footer-bg-color')) {
+          var primary = _parseRgb(_cssVar('--md-primary-fg-color'));
+          if (primary) {
+            var root = document.documentElement;
+            root.style.setProperty('--md-footer-bg-color', _darken(primary, 0.1));
+          }
+        }
+        if (!_cssVar('--md-code-font-family')) {
+          document.documentElement.style.setProperty('--md-code-font-family',
+            getComputedStyle(document.body).fontFamily || 'monospace');
+        }
+      }
+      return colors;
+    }
+
+    var root = document.documentElement;
+    var navbar = document.body.children[0];
+    if (!navbar || navbar.nodeType !== 1) return colors;
+    var navCs = getComputedStyle(navbar);
+    var navBg = navCs.backgroundColor;
+    var navFg = navCs.color;
+    var navBgRgb = _parseRgb(navBg);
+    var navFgRgb = _parseRgb(navFg);
+
+    if (navBg && navBgRgb) {
+      colors['--md-primary-fg-color'] = navBg;
+      colors['--md-primary-fg-color--dark'] = _darken(navBgRgb, 0.15);
+      colors['--md-footer-bg-color'] = _darken(navBgRgb, 0.1);
+    }
+    if (navFg && navFgRgb) {
+      colors['--md-primary-bg-color'] = navFg;
+    }
+
+    var bodyCs = getComputedStyle(document.body);
+    var bodyBg = bodyCs.backgroundColor;
+    var bodyFg = bodyCs.color;
+    var bodyBgRgb = _parseRgb(bodyBg);
+    var bodyFgRgb = _parseRgb(bodyFg);
+
+    if (bodyBg && bodyBgRgb) {
+      colors['--md-default-bg-color'] = bodyBg;
+      colors['--md-default-bg-color--light'] = _isLight(bodyBgRgb)
+        ? _darken(bodyBgRgb, 0.04) : _lighten(bodyBgRgb, 0.06);
+      colors['--md-default-bg-color--lighter'] = _isLight(bodyBgRgb)
+        ? _darken(bodyBgRgb, 0.07) : _lighten(bodyBgRgb, 0.1);
+    }
+    if (bodyFg && bodyFgRgb) {
+      colors['--md-default-fg-color'] = bodyFg;
+      colors['--md-default-fg-color--light'] = _alpha(bodyFgRgb, 0.54);
+      colors['--md-default-fg-color--lighter'] = _alpha(bodyFgRgb, 0.32);
+      colors['--md-default-fg-color--lightest'] = _alpha(bodyFgRgb, 0.12);
+    }
+
+    var link = document.querySelector('a[href]');
+    if (link) {
+      var linkColor = getComputedStyle(link).color;
+      if (linkColor) {
+        colors['--md-accent-fg-color'] = linkColor;
+        colors['--md-typeset-a-color'] = linkColor;
+      }
+    }
+
+    colors['--md-text-font-family'] = bodyCs.fontFamily || 'inherit';
+    colors['--md-code-font-family'] = bodyCs.fontFamily || 'monospace';
+
+    if (!_themeColorsDetected) {
+      _themeColorsDetected = true;
+      for (var v in colors) {
+        if (colors.hasOwnProperty(v)) {
+          root.style.setProperty(v, colors[v]);
+        }
+      }
+    }
+    return colors;
+  }
+
   function _getFocusModeCSS() {
     return '' +
       '.live-wysiwyg-focus-overlay{' +
-        'position:fixed;inset:0;z-index:999;' +
+        'position:fixed;inset:0;z-index:999999999;' +
         'display:flex;flex-direction:column;' +
         'background-color:var(--md-default-bg-color,#fff);' +
         'color:var(--md-default-fg-color,#333);' +
@@ -7762,6 +7881,13 @@
       overlay.classList.add('live-wysiwyg-focus-toolbar-open');
     }
     _focusOverlay = overlay;
+
+    var themeColors = _detectThemeColors();
+    for (var varName in themeColors) {
+      if (themeColors.hasOwnProperty(varName)) {
+        overlay.style.setProperty(varName, themeColors[varName]);
+      }
+    }
 
     // --- Header (styled like md-header md-header--shadow) ---
     var header = document.createElement('div');
@@ -8480,7 +8606,7 @@
   function getButtonLabel(isWysiwygActive) {
     var text = isWysiwygActive ? 'Disable Editor' : 'Enable Editor';
     if (typeof liveWysiwygIconDataUrl !== 'undefined' && liveWysiwygIconDataUrl) {
-      return '<img src="' + liveWysiwygIconDataUrl + '" alt="" class="live-wysiwyg-btn-icon" aria-hidden="true"> ' + text;
+      return '<img src="' + liveWysiwygIconDataUrl + '" alt="" class="live-wysiwyg-btn-icon" aria-hidden="true" style="display:inline;width:1.2em;height:1.2em;vertical-align:middle;margin-right:.25em"> ' + text;
     }
     return text;
   }
@@ -8494,8 +8620,57 @@
     }
   }
 
+  function _ensureThemeOverrides() {
+    _detectThemeColors();
+    if (document.getElementById('live-wysiwyg-theme-overrides')) return;
+    var s = document.createElement('style');
+    s.id = 'live-wysiwyg-theme-overrides';
+    s.textContent =
+      '.live-edit-source{' +
+        'font-family:var(--md-code-font-family,monospace)!important;' +
+        'color:var(--md-default-fg-color,#333)!important;' +
+        'background:var(--md-default-bg-color,#fff)!important;' +
+        'border-color:var(--md-default-fg-color--lightest,#ccc)!important;' +
+      '}' +
+      'button.live-edit-button{' +
+        'background:rgba(255,255,255,0.12)!important;' +
+        'border:1px solid rgba(255,255,255,0.2)!important;' +
+        'color:var(--md-primary-bg-color,#fff)!important;' +
+        'transition:background .2s;' +
+      '}' +
+      'button.live-edit-button:hover{' +
+        'background:rgba(255,255,255,0.25)!important;' +
+      '}' +
+      'button.live-edit-save-button{' +
+        'background:#5cb85c!important;border-color:#4cae4c!important;color:#fff!important;' +
+      '}' +
+      'button.live-edit-save-button:hover{' +
+        'background:#4cae4c!important;' +
+      '}' +
+      'button.live-edit-cancel-button{' +
+        'background:#d9534f!important;border-color:#d43f3a!important;color:#fff!important;' +
+      '}' +
+      'button.live-edit-cancel-button:hover{' +
+        'background:#d43f3a!important;' +
+      '}' +
+      'div.live-edit-controls{' +
+        'background:linear-gradient(to bottom,var(--md-primary-fg-color,#fff2dc),var(--md-footer-bg-color,#f0c36d))!important;' +
+        'border-color:var(--md-primary-fg-color--dark,#f0c36d)!important;' +
+        'color:var(--md-primary-bg-color,inherit)!important;' +
+      '}' +
+      '.live-edit-label{' +
+        'color:var(--md-primary-bg-color,inherit)!important;' +
+      '}' +
+      '.live-edit-info-modal{' +
+        'background-color:var(--md-default-bg-color--light,#fff2dc)!important;' +
+        'border-color:var(--md-default-fg-color--lightest,#f0c36d)!important;' +
+      '}';
+    document.head.appendChild(s);
+  }
+
   function ensureToggleButton(textarea, isWysiwygActive) {
     if (toggleButton && toggleButton.parentNode) return;
+    _ensureThemeOverrides();
     var controls = getControlsElement(textarea);
     if (!controls) return;
     var label = controls.querySelector('.live-edit-label');
@@ -8696,6 +8871,8 @@
 
     textarea.parentNode.insertBefore(wysiwygContainer, textarea);
     textarea.style.display = 'none';
+
+    _ensureThemeOverrides();
 
     var widthStyle = document.getElementById('live-wysiwyg-width-overrides');
     if (!widthStyle) {

--- a/mkdocs_live_wysiwyg_plugin/plugin.py
+++ b/mkdocs_live_wysiwyg_plugin/plugin.py
@@ -202,8 +202,53 @@ class LiveWysiwygPlugin(BasePlugin):
         with open(vendor_dir / "editor.js", "r", encoding="utf-8") as f:
             editor_js_content = f.read()
 
-        # Inject: marked.js, MkDocs admonition extension, editor CSS, admonition CSS, editor JS, integration script (all local)
+        live_edit_theme_css = (
+            '.live-edit-source{'
+              'font-family:var(--md-code-font-family,monospace)!important;'
+              'color:var(--md-default-fg-color,#333)!important;'
+              'background:var(--md-default-bg-color,#fff)!important;'
+              'border-color:var(--md-default-fg-color--lightest,#ccc)!important;'
+            '}'
+            'button.live-edit-button{'
+              'background:rgba(255,255,255,0.12)!important;'
+              'border:1px solid rgba(255,255,255,0.2)!important;'
+              'color:var(--md-primary-bg-color,#fff)!important;'
+              'transition:background .2s;'
+            '}'
+            'button.live-edit-button:hover{'
+              'background:rgba(255,255,255,0.25)!important;'
+            '}'
+            'button.live-edit-save-button{'
+              'background:#5cb85c!important;border-color:#4cae4c!important;color:#fff!important;'
+            '}'
+            'button.live-edit-save-button:hover{'
+              'background:#4cae4c!important;'
+            '}'
+            'button.live-edit-cancel-button{'
+              'background:#d9534f!important;border-color:#d43f3a!important;color:#fff!important;'
+            '}'
+            'button.live-edit-cancel-button:hover{'
+              'background:#d43f3a!important;'
+            '}'
+            'div.live-edit-controls{'
+              'background:linear-gradient(to bottom,var(--md-primary-fg-color,#fff2dc),var(--md-footer-bg-color,#f0c36d))!important;'
+              'border-color:var(--md-primary-fg-color--dark,#f0c36d)!important;'
+              'color:var(--md-primary-bg-color,inherit)!important;'
+            '}'
+            '.live-edit-label{'
+              'color:var(--md-primary-bg-color,inherit)!important;'
+            '}'
+            '.live-edit-info-modal{'
+              'background-color:var(--md-default-bg-color--light,#fff2dc)!important;'
+              'border-color:var(--md-default-fg-color--lightest,#f0c36d)!important;'
+            '}'
+        )
+
+        # Inject: theme overrides (first, before upstream CSS can paint),
+        # marked.js, MkDocs admonition extension, editor CSS, admonition CSS,
+        # editor JS, integration script (all local)
         assets = (
+            f'<style id="live-wysiwyg-theme-overrides">{live_edit_theme_css}</style>'
             f'<style>{editor_css_content}</style>'
             f'<style>{admonition_css_content}</style>'
             f'<script>{marked_js_content}</script>'


### PR DESCRIPTION
Support for light and dark mode material theming.

Theme detection is attempted for themes other than markdown.

I found some themes to have a ~1000 z-index so I increased the focus mode z-index to 999999999 instead of 999.