### PR TITLE
Fix mkdocs-nav-weight migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Add both plugins to your `mkdocs.yml`. **Important:** `live-edit` must be listed
 ```yaml
 plugins:
   - live-edit
-  - live-wysiwyg:
-      autoload_wysiwyg: true # optional, if false, start with plain textarea and show "Enable Editor"
+  - live-wysiwyg
 ```
 
 ### Options

--- a/docs/design/backend/DESIGN-cautions.md
+++ b/docs/design/backend/DESIGN-cautions.md
@@ -10,7 +10,11 @@ Per-page warning system with scoped reason ownership. Each feature owns its reas
 
 **Rule B.** `mkdocs.yml` warnings should ALWAYS and ONLY come from active snapshot state — because the active snapshot contains `mkdocs.yml` contents or desired contents if the user clicks Save.
 
-**Rule C.** "Applying" `mkdocs.yml` changes ONLY affects snapshot state — deferred to the Declarative Save Planner on Save. Action handlers mutate `_virtualMkdocsYml` and call `_commitNavSnapshot()`. The save planner's `mkdocsYmlOps` diff detects the change and emits `write-mkdocs-yml` / `merge-mkdocs-yml` ops.
+**Rule C.** "Applying" `mkdocs.yml` changes ONLY affects snapshot state — deferred to the Declarative Save Planner on Save. Action handlers mutate `_virtualMkdocsYml` and call `_commitNavSnapshot()`. The save planner's `mkdocsYmlOps` diff detects the change and emits `write-mkdocs-yml` ops.
+
+**Rule D.** Every apply button — whether on a top-level warning or a page-level caution — MUST produce a saveable snapshot diff. The handler must call `_enterNavEditMode()` before any mutations so that `_navCleanSnapshot` captures the pre-change state. After the handler commits a snapshot, `_snapshotHasSaveableChanges()` must return `true` and the Save button must be visible. An apply button that silently succeeds without surfacing a Save button is a bug.
+
+**Rule E.** Every apply button MUST add at least one badge to the Review Changes menu via `_addNavBadge()`. The badge gives the user a human-readable summary of what will change when they click Save. An apply action without a corresponding Review Changes badge is a bug — the user must always be able to review what an apply action staged before committing.
 
 For all mkdocs.yml modification procedures and cardinal rules, see [DESIGN-changing-mkdocs-yml.md](DESIGN-changing-mkdocs-yml.md). Caution action handlers that modify mkdocs.yml (e.g., mermaid auto-fix) must follow the transform procedures documented there.
 
@@ -158,7 +162,8 @@ Both actions create a snapshot, so they can be undone.
 ```
 _navCautionActions[reason] = {
   text: string,         // button label
-  style?: string,       // optional cssText for the button
+  primary?: boolean,    // if true, uses live-wysiwyg-nav-popup-primary class (purple accent)
+  style?: string,       // optional cssText for the button (ignored when primary is true)
   handler: function(navItem, warningEntry) -> void
 }
 ```
@@ -171,12 +176,17 @@ All handlers are synchronous. The popup is dismissed before the handler runs (di
 // 1. Register the action (once, at init time)
 _navCautionActions['My feature needs attention'] = {
   text: 'Fix it',
-  style: 'background:#5cb85c;color:#fff;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:.75rem;',
+  primary: true,
   handler: function (navItem, warningEntry) {
+    // Enter nav edit mode FIRST so _navCleanSnapshot captures pre-change state (Rule D)
+    if (!_navEditMode) _enterNavEditMode();
     // Mutate snapshot state only — no disk I/O
     _removeNavWarningReason(navItem, 'My feature needs attention');
+    // Add a Review Changes badge so the user can see what was staged (Rule E)
+    if (!_navBadges.some(function (b) { return b.text === 'Fix applied'; })) {
+      _addNavBadge({ className: 'live-wysiwyg-nav-normalize-badge', text: 'Fix applied' });
+    }
     _commitNavSnapshot();
-    if (!_navEditMode) _enterNavEditMode();
   }
 };
 
@@ -186,22 +196,26 @@ _addCautionPage(pagePath, 'My feature needs attention', { extra: 'context' });
 
 ### Handler contract
 
-Action handlers registered in `_navCautionActions` MUST:
+Action handlers registered in `_navCautionActions` or `_navTopWarningActions` MUST:
 
 1. Be synchronous — no Promises, no async disk I/O (Cardinal Rule A)
 2. Only mutate snapshot state: navData (via `_removeNavWarningReason` or direct property changes), `_virtualMkdocsYml`
-3. Call `_commitNavSnapshot()` after mutations to trigger a nav DOM rebuild
-4. Call `_enterNavEditMode()` if the mutation creates saveable changes, so Save/Discard buttons become visible
-5. Never use `classList`, `setAttribute`, `removeChild`, or any DOM API on nav sidebar elements
+3. Enter nav edit mode BEFORE making mutations (not after) — `_enterNavEditMode()` captures `_navCleanSnapshot` from the current state, so it must run before changes to ensure the Save button appears when the snapshot differs (Cardinal Rule D)
+4. Add at least one badge via `_addNavBadge()` describing what the action staged (Cardinal Rule E)
+5. Call `_commitNavSnapshot()` after mutations to trigger a nav DOM rebuild
+6. Never use `classList`, `setAttribute`, `removeChild`, or any DOM API on nav sidebar elements
 
 ### Mermaid Config Auto-fix
 
-The Mermaid auto-fix is registered in `_navCautionActions[MERMAID_CONFIG_REASON]`:
+The Mermaid auto-fix appears at both levels — a **top-level warning** (`_navTopWarningActions['apply-mermaid-config']`) and a **page-level caution action** (`_navCautionActions[MERMAID_CONFIG_REASON]`). Both use the purple primary button styling and perform the same action.
 
-1. Calls `_applyMermaidConfigFix()` which applies `_addMermaidSuperfencesConfig` to `_virtualMkdocsYml` in-memory — no disk I/O (Cardinal Rule C)
-2. Removes only the mermaid config reason via `_removeNavWarningReason(navItem, MERMAID_CONFIG_REASON)` — respecting scoped resolution
-3. Commits a nav snapshot so the caution icon update is reflected
-4. Enters edit mode so the user can Save the mkdocs.yml change (the Declarative Save Planner's `mkdocsYmlOps` diff detects the virtual change and emits `write-mkdocs-yml` ops)
+When the user clicks "Apply to mkdocs.yml" from either surface:
+
+1. Enters nav edit mode FIRST (if not already active) — this captures `_navCleanSnapshot` before changes, so the Save button appears when the snapshot differs
+2. Calls `_applyMermaidConfigFix()` which applies `_addMermaidSuperfencesConfig` to both `_virtualMkdocsYml` and `_virtualGeneratedMkdocsYml` via `_applyYmlTransform` — no disk I/O (Cardinal Rule C)
+3. Removes the top-level warning via `_removeNavTopWarning('mermaid-config-missing')`
+4. Removes all page-level mermaid cautions via `_removeNavWarningReasonFromAll(null, MERMAID_CONFIG_REASON)` — respecting scoped resolution (only removes the mermaid reason, preserving other reasons on any page)
+5. Commits a nav snapshot — the diff against `_navCleanSnapshot` makes Save visible; the Declarative Save Planner's `mkdocsYmlOps` diff emits `write-mkdocs-yml` ops
 
 See `docs/design/mermaid/DESIGN-mkdocs-yml-mermaid-config.md` for the full auto-fix architecture.
 
@@ -220,7 +234,7 @@ See `docs/design/mermaid/DESIGN-mkdocs-yml-mermaid-config.md` for the full auto-
 | Content Scanning (Dead Link Finder) | `"Internal dead links found"`, `"External dead links found"` | — |
 | Nav Migration | `"Link integrity may need attention"` | — |
 | Unreferenced Asset Finder | `"Unreferenced asset"` | — |
-| Mermaid Mode | `"Mermaid diagrams require pymdownx.superfences configuration"` | `_navCautionActions[MERMAID_CONFIG_REASON]` (virtual mkdocs.yml mutation) |
+| Mermaid Mode | `"Mermaid diagrams require pymdownx.superfences configuration"` | `_navCautionActions[MERMAID_CONFIG_REASON]` (page-level) + `_navTopWarningActions['apply-mermaid-config']` (top-level) — both apply the same mkdocs.yml fix |
 
 ## Helper Functions
 
@@ -228,6 +242,7 @@ See `docs/design/mermaid/DESIGN-mkdocs-yml-mermaid-config.md` for the full auto-
 |----------|---------|
 | `_addCautionPage(srcPath, reason, actionData?)` | Add page-level caution; optional `actionData` is stored as `_actionData` on the warning entry |
 | `_removeNavWarningReason(item, reason)` | Remove a specific reason from `item._warnings`; delete array if empty |
+| `_removeNavWarningReasonFromAll(items, reason)` | Recursively remove a specific reason from all items in the tree |
 | `_clearAllNavWarnings(items)` | Recursively delete `_warnings` and `_deadLinks` from all items |
 | `_clearAllNavDeadLinks(items)` | Recursively delete `_deadLinks` and dead-link warning reasons |
 | `_collectNavWarnings(items)` | Walk tree, return `[{path, reasons, renames, actionData?}]` for localStorage format |

--- a/docs/design/backend/DESIGN-changing-mkdocs-yml.md
+++ b/docs/design/backend/DESIGN-changing-mkdocs-yml.md
@@ -31,54 +31,39 @@ All code lives in `live-wysiwyg-integration.js`.
 
 ## Virtual Mutation Pattern
 
-Transforms are applied to `_virtualMkdocsYml` (the single in-memory copy of the user's mkdocs.yml content). After applying a transform, the caller commits a nav snapshot via `_commitNavSnapshot()`. The snapshot captures the current `_virtualMkdocsYml` value, making the change part of the undo/redo history.
+Transforms are applied to both `_virtualMkdocsYml` (the user's original config) and `_virtualGeneratedMkdocsYml` (the techdocs-generated config) via `_applyYmlTransform(fn)`. After applying a transform, the caller commits a nav snapshot via `_commitNavSnapshot()`. The snapshot captures both virtual copies, making the change part of the undo/redo history.
 
 ```
 Action handler
-  → apply transform to _virtualMkdocsYml
+  → _applyYmlTransform(transformFn)  // applies to both virtual copies
   → _commitNavSnapshot()
-  → snapshot captures _virtualMkdocsYml
-  → on Save: _computeSavePlan detects diff → emits mkdocsYmlOps
+  → snapshot captures mkdocsYml + generatedMkdocsYml
+  → on Save: _computeSavePlan detects diff → emits write-mkdocs-yml ops for each changed file
 ```
 
 ## Source of Truth Architecture
 
-`original-mkdocs.yml` is the primary source of truth for `_virtualMkdocsYml`. The generated `../mkdocs.yml` (which includes techdocs-core plugins, hooks, theme overrides) is only used as a fallback when `original-mkdocs.yml` is not available.
+Two virtual copies are maintained when `original-mkdocs.yml` exists:
+
+- `_virtualMkdocsYml` — the user's original config (`original-mkdocs.yml`)
+- `_virtualGeneratedMkdocsYml` — the techdocs-generated config (`../mkdocs.yml`)
+
+When `original-mkdocs.yml` does not exist, only `_virtualMkdocsYml` is used (loaded from `../mkdocs.yml`), and `_virtualGeneratedMkdocsYml` remains `null`.
 
 ### Prefetch
 
-`_prefetchMkdocsYml()` loads `_virtualMkdocsYml` from:
-1. `liveWysiwygOriginalMkdocsYml` (if available — the user's original config)
-2. `../mkdocs.yml` (fallback — the generated config)
+`_prefetchMkdocsYml()` loads:
+1. `_virtualMkdocsYml` from `liveWysiwygOriginalMkdocsYml` (if available) or `../mkdocs.yml` (fallback)
+2. `_virtualGeneratedMkdocsYml` from `../mkdocs.yml` (only when `liveWysiwygOriginalMkdocsYml` exists)
 
-Only one virtual copy is maintained. All transforms are applied to `_virtualMkdocsYml` only.
+### Save: Direct Writes via Save Planner
 
-### Save: Dual-Write via Save Planner
+When `_computeSavePlan` detects that either virtual copy changed between snapshot 0 and the active snapshot:
 
-When `_computeSavePlan` detects that `_virtualMkdocsYml` changed between snapshot 0 and the active snapshot:
+- **With `original-mkdocs.yml`**: Emits `write-mkdocs-yml` (overwrite) for `original-mkdocs.yml` with `currentSnap.mkdocsYml`, and `write-mkdocs-yml` (overwrite) for `../mkdocs.yml` with `currentSnap.generatedMkdocsYml`.
+- **Without `original-mkdocs.yml`**: Emits `write-mkdocs-yml` (overwrite) for `../mkdocs.yml` with `currentSnap.mkdocsYml` directly.
 
-- **With `original-mkdocs.yml`**: Emits `write-mkdocs-yml` (overwrite) for `original-mkdocs.yml`, then `merge-mkdocs-yml` (3-way YAML deep merge) for `../mkdocs.yml`.
-- **Without `original-mkdocs.yml`**: Emits `write-mkdocs-yml` (overwrite) for `../mkdocs.yml` directly.
-
-### 3-Way YAML Deep Merge (`_yamlDeepMerge`)
-
-The `merge-mkdocs-yml` op handler reads `../mkdocs.yml` from disk and performs a 3-way merge:
-
-- **base**: snapshot 0's mkdocs.yml (before user changes)
-- **source**: active snapshot's mkdocs.yml (after user changes)
-- **target**: the generated `../mkdocs.yml` currently on disk
-
-The merge computes the delta (base → source) and applies only those changes to target:
-
-- Key unchanged between base and source → target untouched
-- Key changed between base and source → target updated with source's value
-- Key in base but not source → deleted from target
-- Key in source but not base → added to target
-- Key in target but not in base or source → preserved (e.g., techdocs-core plugins, hooks)
-
-For `plugins` and `markdown_extensions` lists, set-union merge is used instead of atomic overwrite: items added in source are added to target, items removed from source are removed from target, items only in target are preserved.
-
-If the merged content is identical to the disk content, the write is skipped entirely.
+No `merge-mkdocs-yml` ops are emitted. Both files receive their complete content directly.
 
 ### `!!python/name:` Tag Handling
 

--- a/docs/design/mermaid/DESIGN-mkdocs-yml-mermaid-config.md
+++ b/docs/design/mermaid/DESIGN-mkdocs-yml-mermaid-config.md
@@ -57,7 +57,10 @@ Both functions use a shared constant `_PYTHON_NAME_TAG = '!!python/name:'` for c
 
 ### Trigger
 
-When `exitMermaidMode()` fires and `_isMermaidConfiguredInYml(_virtualMkdocsYml)` returns `false`, the function calls `_addCautionPage(pagePath, MERMAID_CONFIG_REASON)` where `pagePath` is the current page's `src_path`. This adds a caution icon to the page in the nav sidebar.
+When `exitMermaidMode()` fires and `_isMermaidConfiguredInYml(_virtualMkdocsYml)` returns `false`, two warnings are created:
+
+1. **Page-level caution** (informational, no action): `_addCautionPage(pagePath, MERMAID_CONFIG_REASON)` adds a caution icon to the current page in the nav sidebar, marking it as containing mermaid content that won't render.
+2. **Top-level warning** (with action): A `mermaid-config-missing` entry is pushed to `_navTopWarnings` with `actionId: 'apply-mermaid-config'` and `actionText: 'Apply to mkdocs.yml'`. This appears as a caution icon next to the nav title with a purple primary action button.
 
 The detection reads from snapshot state (`_virtualMkdocsYml`), satisfying Cardinal Rule B: mkdocs.yml warnings should ALWAYS and ONLY come from active snapshot state.
 
@@ -65,23 +68,28 @@ The detection reads from snapshot state (`_virtualMkdocsYml`), satisfying Cardin
 
 `MERMAID_CONFIG_REASON = "Mermaid diagrams require pymdownx.superfences configuration"`
 
-This reason is registered in the caution reason string inventory alongside dead links, nav migration, and unreferenced assets.
+This reason is used for page-level cautions and is registered in `_navCautionActions` with an "Apply to mkdocs.yml" button. The top-level warning uses a separate id (`mermaid-config-missing`) with `actionId: 'apply-mermaid-config'`.
 
-### Auto-fix in Caution Popup
+### Auto-fix Buttons (Two Surfaces, Same Action)
 
-`_showCautionPopup` renders action buttons for any warning reason registered in `_navCautionActions`. The mermaid config auto-fix is registered as `_navCautionActions[MERMAID_CONFIG_REASON]`. When the user clicks "Auto-fix mkdocs.yml":
+The "Apply to mkdocs.yml" button appears in two places, both using the purple accent primary styling:
+
+1. **Top-level warning:** `_navTopWarningActions['apply-mermaid-config']` — triggered via `_showNavPopup` with `primary: true`
+2. **Page-level caution popup:** `_navCautionActions[MERMAID_CONFIG_REASON]` — rendered with `primary: true` which applies the `live-wysiwyg-nav-popup-primary` CSS class
+
+Both handlers perform the identical action sequence. When the user clicks "Apply to mkdocs.yml" from either surface:
 
 1. The popup is dismissed (dismiss-first invocation)
-2. The handler calls `_applyMermaidConfigFix()` which mutates `_virtualMkdocsYml` in-memory — no disk I/O
-3. Calls `_removeNavWarningReason(navItem, MERMAID_CONFIG_REASON)` to remove only the mermaid reason (respecting caution resolve scoping)
-4. Commits a nav snapshot so the icon update is reflected
-5. Enters edit mode so Save/Discard buttons become visible — the Declarative Save Planner's `mkdocsYmlOps` diff will detect the virtual change and emit `write-mkdocs-yml` ops when the user clicks Save
+2. The handler enters nav edit mode FIRST (if not already in it) — this captures `_navCleanSnapshot` from the pre-change state, so the Save button will appear when changes are made
+3. Calls `_applyMermaidConfigFix()` which mutates `_virtualMkdocsYml` (and `_virtualGeneratedMkdocsYml` via `_applyYmlTransform`) in-memory — no disk I/O
+4. Removes the top-level warning via `_removeNavTopWarning('mermaid-config-missing')`
+5. Removes all page-level mermaid cautions via `_removeNavWarningReasonFromAll(null, MERMAID_CONFIG_REASON)`
+6. Commits a nav snapshot — the diff against `_navCleanSnapshot` makes the Save button visible, and the Declarative Save Planner's `mkdocsYmlOps` diff will emit `write-mkdocs-yml` ops when the user clicks Save
 
 ### Resolve Scoping
 
-The mermaid config reason follows the caution resolve scoping contract:
-- "Resolve" in the popup removes all warnings (including mermaid config) — standard behavior
-- "Auto-fix mkdocs.yml" removes only the mermaid config reason, preserving other reasons on the same page
+- "Apply to mkdocs.yml" (either surface) clears both the top-level warning and all page-level mermaid cautions
+- "Resolve" in the page popup removes all warnings on that page (including mermaid config) — standard behavior
 - "Resolve All" clears all cautions across all pages — standard behavior
 
 ---
@@ -116,9 +124,9 @@ Applies the mermaid config fix to the virtual mkdocs.yml state in memory. No dis
 
 | Step | Action |
 |------|--------|
-| 1 | Apply `_addMermaidSuperfencesConfig` to `_virtualMkdocsYml` |
+| 1 | Apply `_addMermaidSuperfencesConfig` to both `_virtualMkdocsYml` and `_virtualGeneratedMkdocsYml` via `_applyYmlTransform` |
 
-The save planner's `_computeSavePlan` compares the active snapshot's `mkdocsYml` against the original snapshot's `mkdocsYml`. When they differ, it emits `write-mkdocs-yml` (for `original-mkdocs.yml`) and `merge-mkdocs-yml` (for `../mkdocs.yml`) ops. The dual-write is handled by the save planner, not by the fix function.
+The save planner's `_computeSavePlan` compares the active snapshot's `mkdocsYml` and `generatedMkdocsYml` against the original snapshot's copies. When they differ, it emits `write-mkdocs-yml` ops for both files (direct writes, no merge). The dual-write is handled by the save planner, not by the fix function.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,7 @@
 site_name: WYSIWYG Test
 plugins:
   - live-edit
-  - live-wysiwyg:
-      autoload_wysiwyg: true         # set to false to start with plain textarea
+  - live-wysiwyg
   - mkdocs-nav-weight
 theme:
   features:

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -13388,6 +13388,14 @@
     if (!item._warnings.length) delete item._warnings;
   }
 
+  function _removeNavWarningReasonFromAll(items, reason) {
+    items = items || (typeof liveWysiwygNavData !== 'undefined' ? liveWysiwygNavData : []);
+    for (var i = 0; i < items.length; i++) {
+      _removeNavWarningReason(items[i], reason);
+      if (items[i].children) _removeNavWarningReasonFromAll(items[i].children, reason);
+    }
+  }
+
   function _clearAllNavWarnings(items) {
     items = items || (typeof liveWysiwygNavData !== 'undefined' ? liveWysiwygNavData : []);
     for (var i = 0; i < items.length; i++) {
@@ -16512,7 +16520,14 @@
   // ======================================================================
   var _navTopWarningActions = {
     'start-migration': function () { _startMigrationFlow(); },
-    'apply-default-weight': function (warn) { _applyDefaultPageWeight(warn._suggestedWeight); }
+    'apply-default-weight': function (warn) { _applyDefaultPageWeight(warn._suggestedWeight); },
+    'apply-mermaid-config': function () {
+      if (!_navEditMode) _enterNavEditMode();
+      _applyMermaidConfigFix();
+      _removeNavTopWarning('mermaid-config-missing');
+      _removeNavWarningReasonFromAll(null, MERMAID_CONFIG_REASON);
+      _commitNavSnapshot();
+    }
   };
 
   var _navCautionActions = {};
@@ -17992,38 +18007,9 @@
     }
 
     var totalCautionItems = _collectNavWarnings().length;
-    var buttons = [
-      {
-        text: 'Resolve', action: function () {
-          delete navItem._warnings;
-          delete navItem._deadLinks;
-          _hideDeadLinkPanel();
-          _commitNavSnapshot();
-        }
-      }
-    ];
-    if (totalCautionItems > 1) {
-      buttons.push({
-        text: 'Resolve All', action: function () {
-          _clearAllNavWarnings();
-          _hideDeadLinkPanel();
-          _commitNavSnapshot();
-        }
-      });
-    }
-    var cautionBtnRow = document.createElement('div');
-    cautionBtnRow.style.marginTop = '8px';
-    buttons.forEach(function (btn) {
-      var b = document.createElement('button');
-      b.textContent = btn.text;
-      b.addEventListener('click', function () {
-        popup.parentNode.removeChild(popup);
-        if (btn.action) btn.action();
-      });
-      cautionBtnRow.appendChild(b);
-    });
-    popup.appendChild(cautionBtnRow);
+    var hasResolveAll = totalCautionItems > 1;
 
+    var actionBtns = [];
     reasons.forEach(function (reason) {
       var actionDef = _navCautionActions[reason];
       if (!actionDef) return;
@@ -18031,18 +18017,53 @@
       for (var w = 0; w < (navItem._warnings || []).length; w++) {
         if (navItem._warnings[w].reason === reason) { warningEntry = navItem._warnings[w]; break; }
       }
-      var fixRow = document.createElement('div');
-      fixRow.style.marginTop = '6px';
       var fixBtn = document.createElement('button');
       fixBtn.textContent = actionDef.text;
-      if (actionDef.style) fixBtn.style.cssText = actionDef.style;
+      if (actionDef.primary) fixBtn.className = 'live-wysiwyg-nav-popup-primary';
+      else if (actionDef.style) fixBtn.style.cssText = actionDef.style;
       fixBtn.addEventListener('click', function () {
         if (popup.parentNode) popup.parentNode.removeChild(popup);
         actionDef.handler(navItem, warningEntry);
       });
-      fixRow.appendChild(fixBtn);
-      popup.appendChild(fixRow);
+      actionBtns.push(fixBtn);
     });
+
+    if (actionBtns.length && hasResolveAll) {
+      var actionRow = document.createElement('div');
+      actionRow.style.marginTop = '8px';
+      actionBtns.forEach(function (b) { actionRow.appendChild(b); });
+      popup.appendChild(actionRow);
+    }
+
+    var cautionBtnRow = document.createElement('div');
+    cautionBtnRow.style.marginTop = '8px';
+    var resolveBtn = document.createElement('button');
+    resolveBtn.textContent = 'Resolve';
+    resolveBtn.addEventListener('click', function () {
+      popup.parentNode.removeChild(popup);
+      delete navItem._warnings;
+      delete navItem._deadLinks;
+      _hideDeadLinkPanel();
+      _commitNavSnapshot();
+    });
+    cautionBtnRow.appendChild(resolveBtn);
+
+    if (actionBtns.length && !hasResolveAll) {
+      actionBtns.forEach(function (b) { cautionBtnRow.appendChild(b); });
+    }
+
+    if (hasResolveAll) {
+      var resolveAllBtn = document.createElement('button');
+      resolveAllBtn.textContent = 'Resolve All';
+      resolveAllBtn.addEventListener('click', function () {
+        popup.parentNode.removeChild(popup);
+        _clearAllNavWarnings();
+        _hideDeadLinkPanel();
+        _commitNavSnapshot();
+      });
+      cautionBtnRow.appendChild(resolveAllBtn);
+    }
+    popup.appendChild(cautionBtnRow);
 
     var rect = anchorEl.getBoundingClientRect();
     popup.style.position = 'fixed';
@@ -21836,6 +21857,17 @@
       if (!_isMermaidConfiguredInYml(_virtualMkdocsYml)) {
         var pagePath = _getCurrentSrcPath();
         if (pagePath) _addCautionPage(pagePath, MERMAID_CONFIG_REASON);
+        if (!_hasNavTopWarning('mermaid-config-missing')) {
+          _navTopWarnings.push({
+            id: 'mermaid-config-missing',
+            text: 'Mermaid diagrams require pymdownx.superfences configuration in mkdocs.yml. Apply the fix to enable mermaid rendering.',
+            icon: 'caution',
+            title: 'Mermaid not configured',
+            actionId: 'apply-mermaid-config',
+            actionText: 'Apply to mkdocs.yml'
+          });
+          _ensureNavUncollapsed();
+        }
       }
 
       if (callback) callback();
@@ -22059,19 +22091,26 @@
   var MERMAID_CONFIG_REASON = 'Mermaid diagrams require pymdownx.superfences configuration';
 
   _navCautionActions[MERMAID_CONFIG_REASON] = {
-    text: 'Auto-fix mkdocs.yml',
-    style: 'background:#5cb85c;color:#fff;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:.75rem;',
+    text: 'Apply to mkdocs.yml',
+    primary: true,
     handler: function (navItem) {
-      _applyMermaidConfigFix();
-      _removeNavWarningReason(navItem, MERMAID_CONFIG_REASON);
-      _commitNavSnapshot();
       if (!_navEditMode) _enterNavEditMode();
+      _applyMermaidConfigFix();
+      _removeNavTopWarning('mermaid-config-missing');
+      _removeNavWarningReasonFromAll(null, MERMAID_CONFIG_REASON);
+      _commitNavSnapshot();
     }
   };
 
   function _applyMermaidConfigFix() {
     if (_virtualMkdocsYml != null) {
       _applyYmlTransform(_addMermaidSuperfencesConfig);
+      if (!_navBadges.some(function (b) { return b.text === 'Add mermaid to mkdocs.yml'; })) {
+        _addNavBadge({
+          className: 'live-wysiwyg-nav-normalize-badge',
+          text: 'Add mermaid to mkdocs.yml'
+        });
+      }
     }
   }
 


### PR DESCRIPTION
It didn't properly handle mkdocs.yml migrations.

- Critically fixing declarative save planner corrupting user files when attempting migration.
- Fix mdocs-nav-weight migration in mkdocs.yml
- Fix mermaid config not applying to mkdocs.yml