### PR TITLE
Stability fixes and undo UI

### DIFF
--- a/.cursor/rules/content-history.mdc
+++ b/.cursor/rules/content-history.mdc
@@ -19,26 +19,81 @@ The Content History subsystem provides DAG-based undo/redo for document content.
 
 5. **Cmd+Z in content editor always dispatches to content undo.** When content has focus, `Cmd+Z` must be routed to `_contentUndo()`. Browser native undo must never fire. In WYSIWYG mode, a `beforeinput` listener intercepts `historyUndo`/`historyRedo` input types before the native action (required for Safari, where native undo fires before `keydown`). The `keydown` handler in Tier 2 remains as fallback for markdown mode and browsers without `beforeinput` support.
 
-6. **Skip capture on double-render corruption detection.** If `_doubleRenderCheck()` fails, skip the capture and log. Do not store a diff that could produce corrupted content on restore.
+6. **Always capture HTML snapshots in WYSIWYG mode.** `_createHistoryNode` must unconditionally store `editableArea.innerHTML` as `htmlSnapshot` when the editor is in WYSIWYG mode. This eliminates all markdown-to-HTML drift during undo/redo. On restore in WYSIWYG mode, `_historyApplyContent` uses the snapshot directly (bypassing `_markdownToHtml`). On restore in markdown mode, reconstructed markdown from diffs is used. Never gate snapshot capture on fidelity checks — always capture.
 
-7. **Diffs are line-level, not character-level.** The unit of change is a line. Word-boundary grouping is achieved by debounce timing, not character-level diffs.
+7. **Undo/redo must be markdown-aware.** The undo system stores markdown diffs but must respect that some DOM states don't survive a markdown round-trip (literal markdown syntax as text, enhanced elements with attributes). `_historyApplyContent` must fulfill the Markdown Awareness content-loading contract: refresh all 7 preprocess stores and run all 6 DOM enhancers. The always-on HTML snapshot (Rule 6) bypasses the parser to restore the actual DOM in WYSIWYG mode. Undo must never produce a DOM state that differs from what the user saw when the state was captured. See `markdown-awareness.mdc`.
 
-8. **Root node always stores full content.** `_historyRootMd` is the single source of truth for reconstructing any node's content by walking diffs from root.
+8. **Diffs are line-level, not character-level.** The unit of change is a line. Word-boundary grouping is achieved by debounce timing, not character-level diffs.
 
-9. **`activeChildId` determines default redo path.** `Cmd+Shift+Z` always follows `activeChildId`.
+9. **Root node always stores full content.** `_historyRootMd` is the single source of truth for reconstructing any node's content by walking diffs from root.
 
-10. **Never discard redo branches.** Old children remain in the `children` array when new branches are created. Only pruning removes nodes, and it only removes leaves not on the current path.
+10. **`activeChildId` determines default redo path.** `Cmd+Shift+Z` always follows `activeChildId`.
 
-11. **Content undo is independent of nav snapshot undo.** Dispatch is determined by whether the active element has content focus. Content focus always wins.
+11. **Never discard redo branches.** Old children remain in the `children` array when new branches are created. Only pruning removes nodes, and it only removes leaves not on the current path.
 
-12. **`_historyApplyContent` must fulfill the Markdown Awareness contract.** After restoring content, refresh all 7 preprocess stores and run all 6 DOM enhancers. Without this, advanced code blocks degrade to basic fences and enhanced UI elements (title bars, line numbers, checkboxes) are missing after undo/redo. See `markdown-awareness.mdc`.
+12. **Content undo is independent of nav snapshot undo.** Dispatch is determined by whether the active element has content focus. Content focus always wins.
+
+13. **Programmatic DOM mutations must bracket with flush and capture.** Any code path that modifies the editor DOM programmatically — bypassing the browser's input pipeline via `e.preventDefault()` — must call `_flushHistoryCapture()` **before** the mutation and `_scheduleHistoryCapture(true)` **after** `_finalizeUpdate`. This applies to inline typing auto-replacements (backtick → `<code>`, `**` → `<strong>`, `~~` → `<del>`, `[text](url)` → `<a>`, etc.), backspace reverts (`handleRevertOnBackspace`), code block backspace (selection delete and empty revert in `_ekh.codeBlockBackspace`), and any future handler that manipulates the DOM directly. Without both calls, the intermediate state is invisible to the DAG and `Cmd+Z` skips over it.
+
+14. **Conversions with default content are atomic undo steps.** When a block conversion produces an element that includes default content — mermaid diagrams with the stateDiagram template, code blocks with language-specific stubs, admonitions with default titles, etc. — the replacement element and its default content must be captured as a single unified DAG node. `Cmd+Z` must undo the entire conversion in one step, never landing on an intermediate state where the element exists but the default content is missing.
+
+15. **Block conversions must pre-flush with HTML snapshot safety.** The Space-keydown handler for `handleBlockConversions` calls `_flushHistoryCapture()` before the conversion to capture the pre-conversion typing state (e.g. `` ```mermaid ``). The pre-conversion text is markdown syntax that the parser reinterprets on round-trip, so `_markdownRoundTripFaithful` detects lossiness and stores an HTML snapshot. Undo from the converted element first reaches the snapshot node (restoring literal typing text) before earlier states. The HTML snapshot fallback (Rule 6) ensures no corruption.
+
+16. **The DAG is mode-agnostic: undo/redo feature parity between WYSIWYG and markdown is mandatory.** Every node stores a markdown diff regardless of which mode created it. A node created in WYSIWYG must be undoable from markdown mode and vice versa. `_contentUndo`/`_contentRedo` never branch on current mode for content reconstruction — only cursor restoration is mode-aware. When adding capture points or mutation handlers, verify undo/redo works when the user switches modes between the edit and the undo invocation.
+
+17. **Markdown mode must have the same debounce and word-boundary capture behavior as WYSIWYG mode.** Both modes use the same `_scheduleHistoryCapture` / `_flushHistoryCapture` functions and the same 500ms debounce constant. The markdown textarea uses a two-listener strategy (`keydown` for immediate word-boundary flush, `input` for debounced regular-character capture) because `<textarea>` `input` events do not reliably provide `e.data`. Any change to capture timing or word-boundary detection must be applied to both modes.
+
+18. **Immediate post-restore sync eliminates drift.** Both `_contentUndo` and `_contentRedo` must sync `_historyLastMd = wysiwygEditor.getValue()` immediately after `_historySetContent` returns. This absorbs normalization drift so subsequent flushes only detect actual user edits. Do not use a deferred flag-based mechanism — it creates a race condition where user typing between the restore and the deferred sync is absorbed as "drift" and lost on redo.
+
+19. **Block-child cursor is the primary restore strategy for HTML snapshot nodes.** `_restoreHistoryCursor` must first try `blockChildIndex` + `innerOffset` before falling back to semantic or flat text offset. The block-child strategy locates the cursor by structural index within `editableArea.childNodes` and cumulative text offset within that block — this works for classless elements (empty paragraphs) where semantic matching fails. Fallback chain: block-child → semantic → flat offset → position 0.
+
+20. **Cursor capture must record block-child position.** `_captureHistoryCursor` must always compute `blockChildIndex` (direct child index of `editableArea`) and `innerOffset` (cumulative text offset within that block via `TreeWalker`) for WYSIWYG mode cursors. Both fields must be stored alongside `start`, `end`, and `semantic`.
+
+21. **Mermaid diagrams must re-render on snapshot restore.** `enhanceMermaidBlocks` must detect already-wrapped `.md-mermaid-block` elements with empty previews after snapshot restore, re-trigger mermaid rendering from the hidden `<pre>` source, and re-attach expand button handlers. Without this, mermaid diagrams appear blank after undo/redo.
+
+22. **Synchronous cursor placement for mermaid diagram creation.** When `doCodeBlock` creates a mermaid diagram, the trailing paragraph and cursor placement must be synchronous (not `requestAnimationFrame`). History capture runs immediately after `_finalizeUpdate` — the cursor must already be in the trailing paragraph so `_captureHistoryCursor` records the correct block-child position.
+
+23. **`_markdownRoundTripFaithful` must strip frontmatter.** The fidelity check must parse and strip YAML frontmatter via `parseFrontmatter()` before the `md → html → md` comparison. Frontmatter is not markdown and causes false lossy detections.
+
+24. **Redo must flush pending captures to respect new branches.** `_contentRedo()` must call `_flushHistoryCapture()` before checking `activeChildId`. If the user typed after undoing, the flush creates a new branch node, moving `_historyCurrentId` to a node with no children — redo correctly does nothing. Without this flush, redo follows the stale `activeChildId` and overwrites new content.
+
+25. **Branch picker popup appears on redo or at end of history.** `_contentRedo()` calls `_showHistoryBranchPopup()` either after redo at a branch point (`children.length > 1`) or when no redo is available (`!activeChildId`). The popup persists until editing begins (dismissed on `beforeinput` for non-undo input types) and allows switching branches via Tab/Enter or entering full History Mode via "Show All Redo History". The popup is dismissed by `_dismissAllDropdowns()`.
+
+26. **History Mode is mutually exclusive with Mermaid Mode.** `_enterHistoryMode()` returns early if `_mermaidModeActive`, and `enterMermaidMode()` returns early if `_historyModeActive`. Both share z-index 99995 (Cardinal Rule #9). `exitFocusMode()` calls `_exitHistoryMode()` before `exitMermaidMode()`.
+
+27. **`_restoreToHistoryNode` enables direct DAG jumps.** The function flushes pending captures, reconstructs markdown at any node, sets `_historyCurrentId`, applies content, syncs `_historyLastMd`, and restores cursor. Used by the DAG overlay (double-click/Enter) and full-size preview (Restore button/Enter).
+
+28. **Container group crumple accordion is inline.** `_computeContainerGroups` identifies consecutive active-path edits within the same markdown container (code block, admonition, blockquote, list). Collapsed groups render as single crumple icon nodes in the DAG layout, occupying exactly 1 row. Hidden nodes are tracked in `hiddenByGroup` and skipped during row assignment. Expanding a crumple reveals the individual nodes with a staggered entrance animation.
+
+29. **DAG branch expansion is mutually exclusive.** Only one root-level branch or V-tree can be expanded at a time, controlled by `_historyDagActiveBranchKey`. Expanding a new branch collapses the previous one. V-tree pickers (`_historyDagVtreeSelectedBranch`) are per-branch-point. This prevents layout conflicts between expanded branches.
+
+30. **V-tree forks handle multi-branch points.** When an active-path node has 2+ branch children, a V-tree fork icon is rendered at col 1. Clicking shows branch options at col 2; selecting an option replaces the picker with that branch's **vertical** history layout (`_layoutBranchVertical` subtree positions from phase 1).
+
+31. **Summary generation must be markdown-aware.** `_generateSummary` must detect common markdown structures (mermaid blocks, fenced code with language, headings, admonitions, blockquotes, lists) and produce human-readable labels. Fallback is the first few words of changed text or "edited N lines".
+
+32. **Preview content must exclude YAML frontmatter.** All preview rendering paths (hover tooltip, side panel, full-size preview) must call `_stripFrontmatterForPreview` before `_renderMarkdownPreview`. Frontmatter is editor metadata, not user-visible content.
+
+33. **DAG visualization state resets on entry.** `_enterHistoryMode` must reset `_historyDagActiveBranchKey`, `_historyDagVtreeSelectedBranch`, `_historyDagAnimatingGroup`, and `_historyDagViewMode` (`'detailed'`) to ensure a clean initial view with all branches collapsed.
+
+34. **History DAG view mode toggle.** `_historyDagViewMode` is `'detailed'` or `'organic'`. The modal header toggle switches between the full card DAG (`_computeDagLayout` / standard `_renderDag`) and the compact organic tree (`_computeOrganicLayout` / `_renderOrganicDag`). `_renderDag` branches on `_historyDagViewMode` at the start. Preserve the transition class behavior on toggle (short CSS transition on the DAG container).
 
 ## Key Functions
 
 - `_flushHistoryCapture`, `_scheduleHistoryCapture` — capture timing
 - `_contentUndo`, `_contentRedo` — undo/redo dispatch
 - `_reconstructContentAtNode`, `_restoreHistoryCursor` — state restore
+- `_restoreToHistoryNode` — direct DAG node restoration
+- `_showHistoryBranchPopup`, `_dismissHistoryBranchPopup` — branch picker popup
+- `_enterHistoryMode`, `_exitHistoryMode` — History Mode (Layer 4) lifecycle
+- `_computeDagLayout`, `_layoutBranchVertical` — detailed DAG layout (three phases: full walk + vertical branches with `colOccupied`, crumple/`hiddenByZone` + compact rows, visible nodes + Bézier edges)
+- `_computeOrganicLayout`, `_renderOrganicDag` — organic tree view (center trunk, balanced L/R, 10px dots); gated by `_historyDagViewMode`
+- `_computeContainerGroups` — markdown-aware container group detection
+- `_createCrumpleSvg`, `_createVtreeForkSvg` — SVG icon helpers
+- `_renderDag` — renders SVG edges + DOM nodes (standard, crumple, fork, vtree-option)
+- `_stripFrontmatterForPreview`, `_enhancePreviewContent` — preview pipeline helpers
+- `_generateSummary` — markdown-aware change description generator
 
-## Design Document
+## Design Documents
 
-See `docs/design/ui/DESIGN-unified-content-undo.md`.
+- `docs/design/ui/DESIGN-unified-content-undo.md` — DAG data structure and undo/redo mechanics
+- `docs/design/ui/DESIGN-history-mode.md` — History Mode (Layer 4) UI architecture

--- a/.cursor/rules/markdown-awareness.mdc
+++ b/.cursor/rules/markdown-awareness.mdc
@@ -23,6 +23,10 @@ The Markdown Awareness subsystem preserves markdown fidelity through the lossy H
 
 7. **New preprocess/postprocess pairs must be added to all content-loading paths.** If a new pair is introduced, it must be added to `setValue`, `switchToMode`, `_historyApplyContent`, and `getValue`.
 
+8. **Undo/redo snapshot restore must run DOM enhancers.** When `_historyApplyContent` restores an HTML snapshot via `editableArea.innerHTML`, all 6 DOM enhancers must still run. Enhancers are idempotent and handle re-initialization of interactive elements lost during `innerHTML` assignment — notably mermaid diagram previews (empty in snapshot, re-rendered from hidden `<pre>` source) and button event handlers.
+
+9. **Undo history is aware of markdown construct boundaries.** The Content History pre-flush captures intermediate typing states (literal `` ```mermaid `` text, `## ` prefixes, `> ` prefixes) as HTML snapshot nodes before block conversions. This preserves the exact DOM of partially-typed markdown constructs that the parser would reinterpret on round-trip. The always-on HTML snapshot ensures faithful restoration during undo, allowing walkback through every conversion step.
+
 ## Preprocess/Postprocess Pairs
 
 | Store | Preprocessor | Postprocessor |

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -14,7 +14,10 @@ All keyboard shortcuts available in the WYSIWYG editor, organized by mode.
 | Cmd+I / Ctrl+I | Italic | Toggle italic on selection |
 | Cmd+A / Ctrl+A | Select all | Progressive: block, then full document |
 | Enter | New paragraph / bubble exit | See enter-bubble-navigation rules |
-| Shift+Enter | Line break | Bypasses bubble behavior |
+| Enter (in inline element) | Split / escape inline element | Left edge: move element down. Right edge: new line below. Middle: split element. |
+| Shift+Enter | Line break | Bypasses bubble and inline escape behavior |
+| ArrowRight (end of inline) | Exit inline element rightward | Cursor lands after the inline element in the same block |
+| ArrowLeft (start of inline) | Exit inline element leftward | Cursor lands before the inline element in the same block |
 | Backspace | Delete / revert markdown element | See targeted-markdown-revert rules |
 | Tab | Indent list / next table cell / insert 4 spaces | Context-dependent |
 | Shift+Tab | Outdent list / previous table cell | Context-dependent |

--- a/docs/design/DESIGN-architecture-overview.md
+++ b/docs/design/DESIGN-architecture-overview.md
@@ -16,6 +16,7 @@ Cardinal rules are cross-cutting constraints that apply across multiple subsyste
 | 6 | **Exclusive Disk I/O in Focus Mode** | `DESIGN-declarative-save-planner.md` Invariant 10 | In Focus Mode (Layer 2+), all disk-writing operations flow exclusively through the Declarative Save Planner batch executor. Does not apply to Unfocused Mode (Layer 1). |
 | 7 | **In-Place Extension Replacement** | `DESIGN-changing-mkdocs-yml.md` | When upgrading a `markdown_extensions` list item from bare string to dict form (e.g., `pymdownx.superfences` to `pymdownx.superfences: {custom_fences: [...]}`), replace the item in-place at its current index. Never add a new entry alongside the old one. |
 | 8 | **In-Place Plugin Replacement** | `DESIGN-changing-mkdocs-yml.md` | When upgrading a `plugins` list item from bare string to dict form (e.g., `mkdocs-nav-weight` to `mkdocs-nav-weight: {default_page_weight: 1000}`), replace the item in-place at its current index. Never add a new entry alongside the old one. |
+| 9 | **Layer-Level Mutual Exclusion for Editor Modes** | `DESIGN-modes-of-operation.md` | Editor modes at the same layer are mutually exclusive. They share a single z-index value and entry into one must be blocked while another at the same layer is active. This applies only to editor modes, not to non-modal UI elements (dropdowns, toasts, popups, progress bars). |
 
 ## High-Level Pipeline
 
@@ -115,10 +116,11 @@ flowchart LR
 ```
 UI Subsystem
   |-- Modes of Operation
-  |     |-- Readonly Mode (Layer 1)
+  |     |-- Readonly Mode (Layer 0)
   |     |-- Unfocused Mode (Layer 1)
   |     |-- Focus Mode (Layer 2)
   |     |-- Mermaid Mode (Layer 3)
+  |     |-- Help Mode (Layer 5)
   |-- Mermaid Subsystem
   |     |-- Mermaid Mode (UI, Layer 3 in mode hierarchy)
   |     |-- Vendor Subsystem (mermaid.js + mermaid-live-editor)
@@ -128,6 +130,7 @@ UI Subsystem
   |     |-- Editor Core
   |     |-- Cursor & Selection
   |     |-- Content History
+  |     |     |-- History Mode (UI, Layer 4 in mode hierarchy)
   |     |-- Keyboard
   |     |-- Progressive Select All
   |     |-- Markdown Awareness
@@ -190,6 +193,7 @@ Mermaid-related design documents are organized under `docs/design/mermaid/` whil
 - [DESIGN-image-insertion-resize.md](ui/DESIGN-image-insertion-resize.md) -- Image insertion, resize, and settings.
 - [DESIGN-readonly-selection-heuristics.md](ui/DESIGN-readonly-selection-heuristics.md) -- Read-only to edit mode text selection.
 - [DESIGN-unified-content-undo.md](ui/DESIGN-unified-content-undo.md) -- DAG-based content undo/redo.
+- [DESIGN-history-mode.md](ui/DESIGN-history-mode.md) -- History Mode (Layer 4) — visual DAG history UI with branch picker, overlay, and preview.
 - [DESIGN-uninterrupted-content-save.md](ui/DESIGN-uninterrupted-content-save.md) -- Auto-save and persistent content history.
 - [DESIGN-centralized-keyboard.md](ui/DESIGN-centralized-keyboard.md) -- Three-tier keyboard handling.
 - [DESIGN-progressive-select-all.md](ui/DESIGN-progressive-select-all.md) -- Progressive Ctrl+A selection and cut/copy auto-expansion.

--- a/docs/design/ui/DESIGN-centralized-keyboard.md
+++ b/docs/design/ui/DESIGN-centralized-keyboard.md
@@ -24,10 +24,10 @@ flowchart TD
     end
     subgraph tier3 [Tier 3: Editor Keyboard Router]
         EKR["_setupEditorKeyboard(ea, ...)"]
-        EKR --> EnterGroup["Enter: bubble chain"]
+        EKR --> EnterGroup["Enter: inline escape + bubble chain"]
         EKR --> BackspaceGroup["Backspace: revert chain"]
         EKR --> SpaceGroup["Space: auto-convert"]
-        EKR --> ArrowGroup["Arrows: checklist nav"]
+        EKR --> ArrowGroup["Arrows: inline escape + checklist nav"]
         EKR --> EmojiGroup["Emoji: autocomplete"]
         EKR --> SelectAll["Ctrl+A: progressive"]
         EKR --> BoldItalic["Ctrl+B/I: formatting"]
@@ -243,13 +243,14 @@ The router dispatches by key, with handlers tried in priority order. Each handle
 
 #### Enter Priority (highest to lowest)
 
-1. `_handleReverseBubble` — Exit containers at start (Cases A, B, C, D)
-2. `_handleListEnterExit` — 2x Enter on empty LI exits list
-3. `_handleAdmonitionEnterExit` — 3x Enter (or 1 with credit) exits admonition
-4. `_handleBlockquoteEnterExit` — 3x Enter (or 1 with credit) exits blockquote
-5. `_handleHeadingEnter` — Enter at start of heading inserts paragraph before
-6. `_handleHiddenTitleAdmonitionEnter` — Enter at start of hidden-title admonition body
-7. `_handleCodeBlockEnterExit` — Enter in title / 3x Enter exits code block
+1. `_handleInlineEnterEscape` — Split/escape inline elements (CODE, STRONG, EM, DEL, A, B) on Enter; skips when Shift held or inside PRE
+2. `_handleReverseBubble` — Exit containers at start (Cases A, B, C, D)
+3. `_handleListEnterExit` — 2x Enter on empty LI exits list
+4. `_handleAdmonitionEnterExit` — 3x Enter (or 1 with credit) exits admonition
+5. `_handleBlockquoteEnterExit` — 3x Enter (or 1 with credit) exits blockquote
+6. `_handleHeadingEnter` — Enter at start of heading inserts paragraph before
+7. `_handleHiddenTitleAdmonitionEnter` — Enter at start of hidden-title admonition body
+8. `_handleCodeBlockEnterExit` — Enter in title / 3x Enter exits code block
 
 Reverse bubble **must** be first. This was previously enforced by handler registration order; now it is enforced by line order in the router.
 
@@ -266,7 +267,7 @@ Reverse bubble **must** be first. This was previously enforced by handler regist
 |-----|---------|
 | Space | `_handleMarkdownAutoConvert` — Block-level markdown conversions |
 | Delete | `_handleMarkdownAutoConvert` — Delete selected image (inside `_ekh.mdAuto`) |
-| ArrowLeft/Right | `_handleChecklistArrows` — Cursor normalization around checkboxes |
+| ArrowLeft/Right | `_handleInlineArrowEscape` — Escape inline elements (CODE, STRONG, EM, DEL, A, B) at edges; then `_handleChecklistArrows` — Cursor normalization around checkboxes |
 | Ctrl+A | `_handleSelectAllInBlock` — Progressive select-all |
 | Ctrl+B | Bold — `_compat.exec('bold')` + `_finalizeUpdate` |
 | Ctrl+I | Italic — `_compat.exec('italic')` + `_finalizeUpdate` |
@@ -396,4 +397,14 @@ All messages carry the raw base64 state token in a `state` field (not decoded `c
 
 7. **`enterGuard` for special cases.** Dropdowns with autocomplete or other sub-UIs that consume Enter use `opts.enterGuard` to conditionally bypass dialog-level Enter handling.
 
-8. **Shift bypass in Tier 3.** Each Enter handler (reverseBubble, listEnterExit, admonitionEnterExit, blockquoteEnterExit, headingEnter, hiddenTitleAdmonitionEnter, codeBlockEnterExit) checks `e.shiftKey` individually and returns early when Shift is held, allowing Shift+Enter to pass through to browser default. The router has no central shift check.
+8. **Shift bypass in Tier 3.** Each Enter handler (inlineEnterEscape, reverseBubble, listEnterExit, admonitionEnterExit, blockquoteEnterExit, headingEnter, hiddenTitleAdmonitionEnter, codeBlockEnterExit) checks `e.shiftKey` individually and returns early when Shift is held, allowing Shift+Enter to pass through to browser default. The router has no central shift check. The inlineArrowEscape handler also checks `e.shiftKey` to allow Shift+Arrow to extend selection normally.
+
+## History Mode Keyboard
+
+History Mode (Layer 4) has its own keyboard handling that is independent of the three-tier system above. When History Mode is active, the history overlay captures keydown events directly:
+
+- **Branch picker popup**: inline keydown handler for Arrow Up/Down, Tab/Enter, Escape.
+- **DAG overlay**: `_attachHistoryOverlayKeyboard()` handles Arrow keys (DAG navigation), Enter (restore), Escape (exit).
+- **Full-size preview**: inline keydown handler for Enter (restore) and Escape (close preview).
+
+These handlers are registered on the overlay/popup elements and do not interact with the Tier 2/3 routers because the overlay is above Focus Mode in the z-index stack. See [DESIGN-history-mode.md](DESIGN-history-mode.md) for details.

--- a/docs/design/ui/DESIGN-enter-bubble-navigation.md
+++ b/docs/design/ui/DESIGN-enter-bubble-navigation.md
@@ -127,17 +127,18 @@ Title handlers do not check `e.shiftKey` because Shift+Enter in a title area sho
 
 ## Handler Registration Order
 
-All handlers are registered on the editable area element in capture phase (`addEventListener('keydown', fn, true)`). Registration order determines firing order for capture-phase listeners on the same element:
+All handlers are dispatched by the centralized `_editorKeydownRouter` in priority order (see [DESIGN-centralized-keyboard.md](DESIGN-centralized-keyboard.md)):
 
-1. **Reverse bubble** (`liveWysiwygReverseBubbleAttached`, ~8241) -- fires first, uses `stopImmediatePropagation`
-2. **List exit** (`liveWysiwygListEnterExitAttached`, ~8489)
-3. **Admonition exit** (`liveWysiwygAdmonitionEnterExitAttached`, ~8688)
-4. **Blockquote exit** (`liveWysiwygBlockquoteEnterExitAttached`, ~8915)
-5. **Heading enter-at-start** (`liveWysiwygHeadingEnterAttached`, ~9093)
-6. **Hidden-title admonition** (`liveWysiwygHiddenTitleAdmonitionEnterAttached`, ~9145) -- subsumed by reverse bubble for Enter
-7. **Code block exit** (`liveWysiwygCodeBlockEnterExitAttached`, ~9214)
+1. **Inline element escape** (`_ekh.inlineEnterEscape`) -- fires first; splits/escapes inline elements (CODE, STRONG, EM, DEL, A, B) when cursor is inside one. Skips when Shift held or inside PRE.
+2. **Reverse bubble** (`_ekh.reverseBubble`) -- exits containers at start
+3. **List exit** (`_ekh.listEnterExit`)
+4. **Admonition exit** (`_ekh.admonitionEnterExit`)
+5. **Blockquote exit** (`_ekh.blockquoteEnterExit`)
+6. **Heading enter-at-start** (`_ekh.headingEnter`)
+7. **Hidden-title admonition** (`_ekh.hiddenTitleAdmonitionEnter`) -- subsumed by reverse bubble for Enter
+8. **Code block exit** (`_ekh.codeBlockEnterExit`)
 
-The reverse bubble handler must be first because it needs to intercept Enter before any forward-bubble handler processes it. When it fires, `stopImmediatePropagation` prevents all subsequent handlers from running.
+The inline element escape handler must be first because inline elements (bold, code, etc.) can appear inside any block container. If the cursor is inside an inline element within, say, an admonition paragraph, the inline handler takes priority. The reverse bubble handler fires next for container-level navigation. When any handler fires (`preventDefault`), subsequent handlers are skipped.
 
 ## Interaction Rules
 

--- a/docs/design/ui/DESIGN-history-mode.md
+++ b/docs/design/ui/DESIGN-history-mode.md
@@ -1,0 +1,408 @@
+# History Mode — Design Document
+
+## Overview
+
+History Mode is a **Layer 4** editor mode that provides a visual interface to the DAG-based content undo/redo system. It gives users a top-down, git-like view of their document editing history with the ability to inspect and restore content from any traceable point in the current editing session.
+
+All code lives in `live-wysiwyg-integration.js`.
+
+## Mode Definition
+
+| Property | Value |
+|---|---|
+| **Layer** | 4 |
+| **Z-index** | 99995 (shared with Mermaid Mode — mutually exclusive per Cardinal Rule #9) |
+| **Entry** | "Document History" button in branch picker popup, or programmatic call to `_enterHistoryMode()` |
+| **Exit** | ESC, close button, backdrop click, content restoration, or parent mode exit |
+| **Active flag** | `_historyModeActive` |
+| **Overlay element** | `.live-wysiwyg-history-overlay` |
+| **Disk I/O** | None (read-only inspection; restoration modifies in-memory DAG state only) |
+
+## Mutual Exclusion
+
+History Mode and Mermaid Mode are mutually exclusive (Cardinal Rule #9). Both overlay Focus Mode at z-index `99995` but cannot coexist:
+
+- `_enterHistoryMode()` returns early if `_mermaidModeActive` is true.
+- `enterMermaidMode()` returns early if `_historyModeActive` is true.
+- `exitFocusMode()` calls `_exitHistoryMode()` before `exitMermaidMode()`.
+
+## Three-Tier UI
+
+History Mode presents three progressive levels of interaction:
+
+### Tier 1: Branch Picker Popup (Way 1)
+
+A transient popup that appears when `Cmd+Shift+Z` (redo) executes at a DAG branch point. This is not a full mode entry — it's a lightweight notification with interaction.
+
+**Trigger**: `_contentRedo()` calls `_showHistoryBranchPopup()` either after redo at a DAG branch point (`children.length > 1`) or when no redo is available (`!activeChildId`). This ensures History Mode is always accessible via `Cmd+Shift+Z`.
+
+**Behavior**:
+- When redo is available: redo executes immediately on the `activeChildId` branch (default behavior unchanged). Popup shows all child branches of the branch point with summary, snippet, and relative timestamp. The active branch (just-followed) is highlighted.
+- When no redo is available: popup shows "End of history" header with only the "Show All Redo History" option.
+- Arrow Up/Down navigates between branches. Tab/Enter on a non-active branch undoes the just-executed redo, switches `activeChildId`, and redoes on the selected branch.
+- ESC or click-outside dismisses (accepting the already-executed redo).
+- Popup persists until the user performs typing or other editing (dismissed via `beforeinput` handler for non-undo/redo input types).
+- "Show All Redo History" menu item (with expand icon) opens Tier 2 (full History Mode).
+- Popup is positioned near the text caret, offset to the right edge, with viewport boundary clamping.
+
+**Positioning**: The popup is placed near the text caret using `window.getSelection().getRangeAt(0).getBoundingClientRect()`, offset to the right edge to avoid obscuring the user's text. Viewport boundary clamping ensures the popup remains fully visible.
+
+**Dismiss**: Registered in `_dismissAllDropdowns()` via `_dismissHistoryBranchPopup()`. Also dismissed by `beforeinput` handler when the user performs any editing (non-undo/redo input types).
+
+**Z-index**: 99999 (same layer as other editor dropdowns).
+
+### Tier 2: Document History Overlay (Way 2)
+
+The full-screen DAG visualization overlay. This is the actual History Mode (Layer 4).
+
+**UI Structure**:
+- Modal dialog with backdrop (click-to-dismiss).
+- Left panel: scrollable DAG visualization (SVG edges + DOM nodes).
+- Right panel (40% width): preview of selected node's content.
+
+**DAG Visualization**:
+- Flipped layout: latest history at top, oldest at bottom. **Detailed** view: `_computeDagLayout()`. **Organic** compact tree: `_computeOrganicLayout()` via header toggle; see [Organic Tree View](#organic-tree-view).
+- Active path is flat on the left (column 0). Branches fork to the right.
+- SVG layer draws connection lines (edges). Active path uses thicker/brighter stroke.
+- DOM layer positions node elements over the SVG. Each node shows a color-coded dot, summary text (up to 2 lines), and relative timestamp.
+- Current node has accent-colored dot with glow plus a "You Are Here" dotted-line indicator extending to the right edge of the DAG with a pill-shaped label (`<-----(< You Are Here)`).
+
+**Inline Crumple Accordion System**:
+
+Container groups (consecutive edits within the same markdown block) are collapsed into inline crumple icon nodes that occupy a single row in the layout. This eliminates gaps and overlaps:
+
+- **Crumple icon**: A zigzag fold SVG (`==\==/==\==`) representing compressed history. Clicking unfolds to reveal individual nodes.
+- **Type-specific colors**: Code blocks = teal, admonitions = amber, blockquotes = purple, lists = green. Applied via `data-container-type` attribute.
+- **Block context dotted outline**: When "You Are Here" is inside a container group, a dashed outline with the container label (e.g., "bash code block") wraps the current node and adjacent crumple icons.
+- **Unfold animation**: Expanding a crumple triggers a staggered entrance animation (`scaleY(0)→scaleY(1)`) on the revealed nodes.
+
+**Column Layout for Branches**:
+
+| Column | Content |
+|--------|---------|
+| 0 | Active path (always visible, linear) |
+| 1 | Branch entry points: single-branch crumple nodes or V-tree fork icons |
+| 2+ | Expanded branch content (vertical layout) or V-tree branch picker |
+
+- **Single branch**: Crumple icon at col 1 with the branch's first node summary and edit count. Clicking expands the branch vertically into col 2+.
+- **V-tree (2+ branches from one point)**: Fork icon (`diverging arrows`) at col 1 with "Multiple histories (N)" label. Clicking shows branch options at col 2. Selecting an option replaces the picker with that branch's expanded history.
+- **Mutual exclusivity**: Only one root-level branch can be expanded at a time. Expanding a new branch collapses the previous one. Within a branch, sub-crumples can be expanded (columns shift right, horizontal scroll available).
+
+**Interaction**:
+- **Hover** (200ms debounce): floating preview tooltip with markdown snippet, rendered HTML, and "Full Screen" button.
+- **Click**: selects node, updates right preview panel.
+- **Double-click**: restores content to that node and exits.
+- **Arrow keys**: Up = parent, Down = active child, Left/Right = sibling branches.
+- **Enter**: restores to selected node and exits.
+- **ESC**: exits History Mode.
+
+### Tier 3: Full-Size Readonly Preview (Way 3)
+
+A full-viewport rendered preview of a specific history node's content. Overlays the DAG overlay within the same z-index layer.
+
+**Trigger**: "Full Screen" button on hover tooltips or the preview panel.
+
+**UI Structure**:
+- Header with node summary, "Restore to this point" button, and "Close" button.
+- Scrollable body with rendered HTML content (`contenteditable="false"`).
+- Content is styled with Material theme typography for visual fidelity.
+
+**Behavior**:
+- ESC returns to the DAG overlay (does not exit History Mode).
+- Enter restores to the previewed node and exits History Mode entirely.
+- "Restore to this point" button does the same as Enter.
+
+## Content Restoration
+
+`_restoreToHistoryNode(nodeId)` enables jumping to any node in the DAG:
+
+1. Flush pending captures (`_flushHistoryCapture()`).
+2. Reconstruct markdown at the target node (`_reconstructContentAtNode(nodeId)`).
+3. Set `_historyCurrentId = nodeId`.
+4. Apply content via `_historySetContent(markdown, node.htmlSnapshot)`.
+5. Sync `_historyLastMd` to absorb normalization drift.
+6. Restore cursor from the node's stored cursor state.
+7. Persist DAG and auto-save.
+
+This is analogous to `_contentUndo`/`_contentRedo` but jumps directly to any node rather than walking one step along the parent/child chain.
+
+## Preview Rendering Pipeline
+
+All previews (hover tooltip, side panel, full-size) use the same pipeline:
+
+1. `_reconstructContentAtNode(nodeId)` walks diffs from root to reconstruct full markdown.
+2. `_stripFrontmatterForPreview(markdown)` removes YAML frontmatter — previews show only body content.
+3. `_renderMarkdownPreview(markdown)` calls `marked.parse()` with GFM options (same parser used by the editor).
+4. `_enhancePreviewContent(html)` strips interactive controls (expand buttons, settings gears) from the rendered HTML so the preview is readonly.
+5. Results are cached in `_historyPreviewCache` (keyed by node ID) to avoid redundant reconstruction.
+6. Cache is cleared on History Mode entry/exit.
+
+Full-size preview additionally:
+- Sets `contenteditable="false"` to prevent editing.
+- Runs syntax highlighting post-processing for code blocks.
+- Triggers `_renderMermaidPreview` for valid mermaid fenced code blocks.
+- Styled with Material theme typography for visual fidelity.
+
+## Keyboard Handling
+
+| Context | Key | Action |
+|---|---|---|
+| Branch popup | Arrow Up/Down | Navigate branch items |
+| Branch popup | Tab / Enter | Confirm selection (switch branch if different) |
+| Branch popup | ESC | Dismiss popup |
+| DAG overlay | Arrow Up | Navigate to parent node |
+| DAG overlay | Arrow Down | Navigate to active child |
+| DAG overlay | Arrow Left/Right | Navigate to sibling branches |
+| DAG overlay | Enter | Restore to selected node |
+| DAG overlay | ESC | Exit History Mode |
+| Full-size preview | Enter | Restore to previewed node |
+| Full-size preview | ESC | Close preview, return to DAG |
+
+The branch popup uses inline keydown handlers. The DAG overlay uses `_attachHistoryOverlayKeyboard()`. The full-size preview has its own keydown listener.
+
+## Suppression Contract
+
+When History Mode is active (Layer 4), the suppression contract from [DESIGN-modes-of-operation.md](DESIGN-modes-of-operation.md) applies:
+
+- Lower-layer keyboard handlers do not fire (the overlay captures events).
+- Lower-layer scroll containers are not interactive (overlay has `inset:0` and backdrop).
+- The overlay's `z-index:99995` places it above Focus Mode (`99990`) but shares the layer with Mermaid Mode (mutually exclusive).
+
+## Entry/Exit Lifecycle
+
+### Entry (`_enterHistoryMode`)
+
+1. Guard: return if `_historyModeActive` or `_mermaidModeActive`.
+2. Set `_historyModeActive = true`.
+3. Clear preview cache.
+4. Reset DAG visualization state: `_historyDagActiveBranchKey = null`, `_historyDagVtreeSelectedBranch = {}`, `_historyDagAnimatingGroup = null`, `_historyDagViewMode = 'detailed'`.
+5. Build overlay DOM via `_buildHistoryOverlay()`.
+6. Render DAG, attach keyboard handler, focus overlay.
+
+### Exit (`_exitHistoryMode`)
+
+1. Guard: return if not `_historyModeActive`.
+2. Set `_historyModeActive = false`.
+3. Dismiss full-size preview if open.
+4. Remove overlay from DOM.
+5. Clear references and cache.
+
+### Auto-Exit
+
+`exitFocusMode()` calls `_exitHistoryMode()` first, same as the existing `exitMermaidMode()` pattern.
+
+## State Variables
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `_historyModeActive` | boolean | Layer 4 mode active flag |
+| `_historyOverlay` | Element | The overlay DOM element |
+| `_historyBranchPopup` | Element | The branch picker popup element |
+| `_historyBranchPopupTimer` | number | Auto-dismiss timer ID |
+| `_historyBranchPopupHighlight` | number | Currently highlighted branch index |
+| `_historyBranchPopupNodeId` | number | Branch point node ID for the popup |
+| `_historyDagSelectedNodeId` | number | Currently selected node in DAG overlay |
+| `_historyFullsizePreview` | Element | Full-size preview element |
+| `_historyPreviewCache` | Object | nodeId → markdown cache for previews |
+| `_historyDagActiveBranchKey` | string\|null | Currently expanded branch/V-tree key (mutual exclusivity) |
+| `_historyDagVtreeSelectedBranch` | Object | bpKey → selected child ID for V-tree pickers |
+| `_historyDagAnimatingGroup` | string\|null | Group key currently animating (cleared after render) |
+| `_historyDagExpandedGroups` | Object | groupKey → boolean for expanded container groups |
+| `_historyDagViewMode` | `'detailed'` \| `'organic'` | DAG panel rendering: full cards vs compact organic tree |
+
+## Helper Functions
+
+| Function | Purpose |
+|---|---|
+| `_formatRelativeTime(ts)` | Converts timestamp to "2m ago" format |
+| `_getSnippetForNode(node)` | Extracts first ~60 chars from diff ops |
+| `_renderMarkdownPreview(md)` | `marked.parse()` wrapper with fallback |
+| `_stripFrontmatterForPreview(md)` | Removes YAML frontmatter before preview rendering |
+| `_computeDagLayout()` | Three-phase detailed DAG layout (vertical branches, crumple zones, compact rows, edges) |
+| `_computeContainerGroups(activePathList)` | Identifies consecutive active-path edits within the same markdown container |
+| `_layoutBranchVertical(nodeId, preferCol, forkRow, positions, maxCol, colOccupied)` | Lays out an inactive subtree in vertical stacks in col 1+, with `colOccupied` collision resolution |
+| `_computeOrganicLayout()` | Compact tree layout: center trunk + balanced L/R branches for organic view |
+| `_renderOrganicDag(container)` | Renders organic view (dots + SVG edges) when `_historyDagViewMode === 'organic'` |
+| `_createCrumpleSvg()` | Returns zigzag fold SVG (~40×16) for crumple icons |
+| `_createVtreeForkSvg()` | Returns diverging arrows SVG (~24×20) for V-tree fork icons |
+| `_renderDag(container)` | Builds SVG edges + DOM nodes (standard, crumple, fork, vtree-option) in container |
+| `_navigateDag(key)` | Arrow key navigation within DAG |
+| `_restoreToHistoryNode(nodeId)` | Direct restoration to any DAG node |
+| `_enhancePreviewContent(html)` | Strips interactive controls from rendered preview HTML |
+| `_generateSummary(diff)` | Produces human-readable, markdown-aware change descriptions |
+
+## CSS
+
+All CSS is injected via `_getFocusModeCSS()`. Key class prefixes:
+
+- `.live-wysiwyg-history-branch-*` — branch picker popup
+- `.live-wysiwyg-history-overlay`, `.live-wysiwyg-history-modal*` — DAG overlay
+- `.live-wysiwyg-history-dag-*`, `.live-wysiwyg-dag-*` — DAG nodes and edges
+- `.live-wysiwyg-dag-crumple` — inline crumple accordion icons (container groups and single branches)
+- `.live-wysiwyg-dag-crumple-svg`, `.live-wysiwyg-dag-crumple-label` — crumple icon and text
+- `.live-wysiwyg-dag-crumple.branch-crumple` — branch-specific amber crumple variant
+- `.live-wysiwyg-dag-vtree-fork` — V-tree multi-branch fork nodes (purple)
+- `.live-wysiwyg-dag-vtree-svg`, `.live-wysiwyg-dag-vtree-label` — fork icon and text
+- `.live-wysiwyg-dag-vtree-option` — V-tree branch picker items
+- `.live-wysiwyg-dag-block-outline` — dashed outline around "You Are Here" container context
+- `.live-wysiwyg-dag-block-outline-title` — floating container label for the outline
+- `.live-wysiwyg-dag-you-are-here` — dotted line with right-aligned label
+- `.live-wysiwyg-dag-you-are-here-line`, `.live-wysiwyg-dag-you-are-here-label` — line and pill sub-elements
+- `.live-wysiwyg-history-toggle-view-btn` — detailed ↔ organic tree view toggle in the modal header
+- `.live-wysiwyg-dag-transitioning` — short-lived class on the DAG container during view-mode cross-fade (~350ms)
+- `.live-wysiwyg-organic-wrapper`, `.live-wysiwyg-organic-svg` — organic view root and edge layer
+- `.live-wysiwyg-organic-dot`, `.live-wysiwyg-organic-dot.active-path`, `.live-wysiwyg-organic-dot.current` — 10px dots; trunk vs glow current
+- `.live-wysiwyg-organic-edge`, `.live-wysiwyg-organic-edge-active` — organic Bézier edges
+- `.live-wysiwyg-history-hover-*` — hover preview tooltip
+- `.live-wysiwyg-history-preview-*` — side preview panel
+- `.live-wysiwyg-history-fullsize-*` — full-size readonly preview
+
+Crumple nodes use `data-container-type` for type-specific colors:
+- `code` → teal (`#009688` border, `rgba(0,150,136,.08)` bg)
+- `admonition` → amber (`#ff8f00` border, `rgba(255,143,0,.08)` bg)
+- `blockquote` → purple (`#7c4dff` border, `rgba(124,77,255,.08)` bg)
+- `list` → green (`#43a047` border, `rgba(67,160,71,.08)` bg)
+- `branch-crumple` → amber scheme (`#f59e0b`)
+
+Animation keyframes:
+- `@keyframes liveWysiwygGroupEnter` — node entrance with `scaleY(0)→scaleY(1)` and opacity fade, staggered via `animationDelay`.
+
+All colors use `var(--md-*)` CSS variables with fallbacks for theme-agnostic rendering.
+
+## DAG Layout Algorithm (`_computeDagLayout`)
+
+The layout algorithm transforms the DAG into positioned nodes and Bézier edges for the **detailed** DAG view (`_historyDagViewMode === 'detailed'`). It runs in **three phases** and returns `nodes`, `edges`, `width`, `height`, and `groups`. The **organic** tree view uses a separate pipeline (`_computeOrganicLayout` / `_renderOrganicDag`); see [Organic Tree View](#organic-tree-view).
+
+### Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `NODE_W` | 300 | Node width in pixels |
+| `H_GAP` | 28 | Horizontal gap between columns |
+| `V_GAP` | 20 | Vertical gap between rows |
+| `CRUMPLE_H` | 40 | Height of crumple icon nodes |
+
+### Phase 1: Full tree walk and vertical branch layout
+
+1. **Active path** — Walk from the DAG root along the undo/redo spine, building `activePath` (set) and `activePathList` (ordered **oldest → newest**: root first, latest leaf last). Include nodes reachable from `_historyCurrentId` toward root and along `activeChildId` so the current position is always on the path.
+2. **Column 0 and row indices** — Assign each active-path node **column 0**. In working row coordinates, **root = row 0** and the **latest leaf = highest row index** (rows increase down the spine in this coordinate system).
+3. **Inactive subtrees** — For each active-path fork, every child **not** on the active path is laid out with **`_layoutBranchVertical`**: the subtree is ordered, placed in **consecutive rows** starting below the fork row, and assigned a column **≥ 1**. A **`colOccupied`** map (`"col:row"` → true) records occupied cells; if the preferred column conflicts with any row the subtree needs, the column index is incremented until the placement fits. **`maxCol`** tracks the rightmost column for width calculation.
+
+### Phase 2: Crumple zones, `hiddenByZone`, and compact rows
+
+1. **`_computeContainerGroups(activePathList)`** — Identifies consecutive active-path edits within the same markdown container (code block, admonition, blockquote, list). Each group yields a stable key and metadata for crumple UI.
+2. **`hiddenByZone`** — For each **collapsed** group (not expanded in `_historyDagExpandedGroups`), all nodes after the **representative** (first node in the group) map from node id → group key in `hiddenByZone`. Those nodes are omitted from visible output in phase 3.
+3. **Crumple zones** — Collapsed groups register a crumple zone with `repId`, `nodeIds`, type, and label for synthetic crumple nodes.
+4. **Branch metadata** — `branchPoints`, synthetic branch crumples, V-tree forks, and V-tree option rows are positioned in the same row/column model (`fullPositions` / `syntheticNodes`), respecting `_historyDagActiveBranchKey` and `_historyDagVtreeSelectedBranch`.
+5. **Visible rows and `compactMap`** — Collect all row indices that must remain visible (active-path nodes not in `hiddenByZone`, crumple representatives, expanded branch subtrees, fork/option rows, etc.). Sort them and build **`compactMap`**: full row index → dense index `0…n-1` so **gaps from hidden nodes collapse**. Final **`displayRow = totalCompactRows - 1 - compactRow`** maps into screen space so **newest history appears toward the top** of the overlay (Cardinal Rule #1).
+
+### Phase 3: Layout nodes, edges, visibility, and “You Are Here”
+
+1. **Visibility filter** — Only **visible** entries become DOM/SVG output: skip real nodes that are **`hiddenByZone`** or off-path branch nodes when that branch is collapsed (unless they are synthetic). Expanded branches include the full subtree marked visible in phase 2.
+2. **`layoutNodes` and `edges`** — Visible positions convert to pixel `x` / `y` using `NODE_W`, `H_GAP`, `V_GAP`, and `CRUMPLE_H` where applicable. Parent/child pairs emit edge records for SVG.
+3. **Bézier edges** — `_renderDag` draws **cubic Bézier** paths when source and target differ horizontally (shared mid-Y control points); same-column connections use straight **vertical** segments. Active-path edges use thicker, accent styling.
+4. **“You Are Here”** — On the **current** node row, render the dotted horizontal indicator and pill label from the node’s right edge toward the DAG width.
+
+### Layout Node Metadata Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isCrumple` | boolean | Container group crumple icon |
+| `crumpleKey` | string | Group identifier |
+| `crumpleType` | string | Container type (`code`, `admonition`, `blockquote`, `list`) |
+| `crumpleLabel` | string | Human-readable label (e.g., "bash code block") |
+| `crumpleCount` | number | Number of collapsed nodes |
+| `crumpleNodeIds` | number[] | IDs of collapsed nodes |
+| `isVtreeFork` | boolean | Multi-branch fork point |
+| `vtreeParentId` | number | Active-path parent of the fork |
+| `vtreeChildIds` | number[] | Branch child IDs |
+| `vtreeBpKey` | string | Branch-point key for state tracking |
+| `isVtreeOption` | boolean | Branch picker option in V-tree |
+| `optionChildId` | number | Child ID this option represents |
+| `optionSummary` | string | Summary text for the option |
+| `optionCount` | number | Depth of the branch |
+| `isBranchCrumple` | boolean | Single-branch crumple at col 1 |
+| `branchKey` | string | Branch identifier |
+| `branchChildId` | number | Root node of the branch |
+| `branchCount` | number | Depth of the branch |
+| `isSynthetic` | boolean | Not a real DAG node (crumple/fork/option) |
+
+## Organic Tree View
+
+The modal header includes a **view toggle** (`.live-wysiwyg-history-toggle-view-btn`): in detailed mode the label is **“Tree View”**; in organic mode it is **“Detailed View”**. Clicking flips **`_historyDagViewMode`** between `'detailed'` and `'organic'`, re-runs `_renderDag` on the DAG container, and applies **`.live-wysiwyg-dag-transitioning`** for ~350ms so the switch uses an **animated transition** between layouts. On History Mode entry, `_historyDagViewMode` resets to **`'detailed'`**.
+
+When `_historyDagViewMode === 'organic'`, `_renderDag` calls **`_renderOrganicDag`** after **`_computeOrganicLayout()`** (the detailed three-phase algorithm above is skipped).
+
+- **Compact dots** — Each node is a **10px** circle (`.live-wysiwyg-organic-dot`), centered on the layout coordinate with a −5px absolute offset. Tooltip/title uses the node summary; click/double-click behavior matches the detailed DAG (select / restore).
+- **Center trunk** — The active path is a **vertical line** at fixed **`centerX`**: the spine of the tree.
+- **Balanced L/R branches** — At each active-path fork, inactive children are queued with **alternating** `side` **−1 / +1** and stepped horizontally by `depth * STEP`, so branches grow **left and right** in balance. Deeper descendants continue with alternating sides per BFS expansion.
+- **Current node** — The dot for `_historyCurrentId` adds **`.current`** for a **glow** treatment (distinct from `.active-path` trunk styling).
+- **Edges** — SVG paths use the same **vertical vs cubic Bézier** rule as the detailed DAG, with organic-specific edge classes (`.live-wysiwyg-organic-edge` / `-active`).
+- **Scroll** — After render, the **current** dot is **`scrollIntoView`** (`block`/`inline`: `center`) so the present state stays in view.
+
+## Container Group Detection (`_computeContainerGroups`)
+
+Detects consecutive active-path nodes whose diffs modify lines within the same markdown structure:
+
+1. Reconstruct markdown at each node on the active path.
+2. For each node, examine the diff ops to find the primary line range being modified.
+3. Use regex patterns to detect if the modified lines fall within a fenced code block (`` ``` ``), admonition (`!!!`/`???`/`???+`), blockquote (`> `), or list (`- `/`* `/`1. `).
+4. If consecutive nodes modify the same container (matched by type + starting line number), they form a group.
+5. Minimum group size is 2 nodes.
+
+Group labels are markdown-aware:
+- Code blocks: language from the fence line (e.g., "bash code block")
+- Admonitions: type from the marker (e.g., "note admonition")
+- Blockquotes: "blockquote"
+- Lists: "list"
+
+## Summary Generation (`_generateSummary`)
+
+Produces human-readable, markdown-aware descriptions for DAG node labels:
+
+| Pattern | Summary Example |
+|---------|-----------------|
+| Mermaid code block created | "Mermaid diagram created" |
+| Fenced code block with language | "python code block" |
+| Heading changed/added | `"heading text"` (quoted) |
+| Admonition inserted | "note admonition" |
+| Blockquote added | "blockquote added" |
+| List items added | "list items added" |
+| Single-line edit | First few words of the changed text |
+| Multi-line fallback | "edited N lines" |
+
+These summaries appear in DAG nodes, crumple labels, branch picker items, and V-tree options.
+
+## "You Are Here" Indicator
+
+A horizontal dotted-line arrow that spans the full width of the DAG from the right edge of the current node to the far right:
+
+```
+(current node label) <-----(< You Are Here)
+```
+
+- Positioned at the current node's row.
+- Starts at `currentNode.x + NODE_W/2 + 6` (right edge of node + gap).
+- Width extends to `max(layout.width, 600) - startX`.
+- Contains a flex-growing dotted line (2px dashed, primary color) and a pill-shaped label with a left-pointing arrow SVG.
+- Z-index 0 (renders behind nodes but above the SVG edge layer).
+
+## Cardinal Rules
+
+1. **Latest history at top, oldest at bottom.** The active undo-redo branch always renders with the most recent history node at the top of the DAG UI and the oldest (root) at the bottom. The user reads chronologically from bottom to top.
+
+2. **Active branch is linear at column 0.** The active history branch renders as a straight vertical line in the leftmost column (col 0). All inactive branches fork off to the right. The active path must never be displaced from col 0.
+
+3. **Branch subtrees stack vertically; columns resolve collisions.** Inactive subtrees are placed by `_layoutBranchVertical` as **vertical** stacks in columns 1+. The **`colOccupied`** map prevents two subtrees from sharing the same `(col, row)` cells; when the preferred column is blocked, the algorithm advances to the next column. SVG edges may curve between columns, but **node placement** is grid-aligned vertical stacking, not a diagonal grid.
+
+4. **Multi-branch history from a single node shows branch options.** When a node has multiple inactive branches, a V-tree fork icon appears. Clicking it reveals the available branches. When the user selects a branch, it expands upward in col 1 unless doing so would visually collide with another branch, in which case it expands upward in the next available column. Branch options are not locked to a fixed column — they render wherever space permits.
+
+5. **Edges use smooth curved paths.** Connecting lines between history nodes render as smooth cubic Bézier curves, styled like mermaid git diagram arrows. Straight-column connections (same x) use vertical lines. Cross-column connections (branching/merging) use S-curves that depart and arrive vertically. Active-path edges use thicker, accent-colored strokes; inactive edges use thinner, muted strokes.
+
+## Cross-References
+
+- [DESIGN-unified-content-undo.md](DESIGN-unified-content-undo.md) — DAG data structure, helper functions, content reconstruction
+- [DESIGN-modes-of-operation.md](DESIGN-modes-of-operation.md) — Layer 4 position, suppression contract, mutual exclusion
+- [DESIGN-layout.md](DESIGN-layout.md) — Z-index registry (99995 shared with Mermaid, 99999 for branch popup)
+- [DESIGN-centralized-keyboard.md](DESIGN-centralized-keyboard.md) — Keyboard tier integration
+- [DESIGN-popup-dialog-ux.md](DESIGN-popup-dialog-ux.md) — Branch popup in dialog inventory

--- a/docs/design/ui/DESIGN-layout.md
+++ b/docs/design/ui/DESIGN-layout.md
@@ -59,10 +59,10 @@ Every z-index value in the codebase. New z-index values must be added here befor
 | `99989` | `.live-wysiwyg-early-overlay` | `plugin.py`, `_getFocusModeCSS` |
 | `99990` | `.live-wysiwyg-focus-overlay`, `.live-wysiwyg-nav-transition-overlay` | `_getFocusModeCSS` |
 | `99993` | `.live-wysiwyg-dead-link-panel` | `_getFocusModeCSS` |
-| `99995` | `.live-wysiwyg-focus-settings-dropdown`, `.live-wysiwyg-page-submenu`, `.live-wysiwyg-mermaid-overlay` | `_getFocusModeCSS` |
+| `99995` | `.live-wysiwyg-focus-settings-dropdown`, `.live-wysiwyg-page-submenu`, `.live-wysiwyg-mermaid-overlay`, `.live-wysiwyg-history-overlay`, `.live-wysiwyg-history-fullsize-preview` | `_getFocusModeCSS` |
 | `99996` | `.live-wysiwyg-nav-popup`, `.live-wysiwyg-asset-preview-popup` | `_getFocusModeCSS` |
 | `99998` | `.md-link-chain-indicator` | JS inline style |
-| `99999` | `.md-table-grid-selector`, `.md-contextual-table-toolbar`, `.md-code-lang-dropdown`, `.md-code-settings-dropdown`, `.md-admonition-settings-dropdown`, `.md-link-settings-dropdown`, `.md-image-insert-dropdown`, `.md-image-gear-dropdown`, `.live-wysiwyg-nav-dialog`, `.live-wysiwyg-selection-edit-popup`, `.live-wysiwyg-emoji-autocomplete`, `.md-admonition-dropdown`, `.live-wysiwyg-nav-review-popup`, `.live-wysiwyg-asset-lightbox` | `editor.css`, `_getFocusModeCSS`, JS inline styles |
+| `99999` | `.md-table-grid-selector`, `.md-contextual-table-toolbar`, `.md-code-lang-dropdown`, `.md-code-settings-dropdown`, `.md-admonition-settings-dropdown`, `.md-link-settings-dropdown`, `.md-image-insert-dropdown`, `.md-image-gear-dropdown`, `.live-wysiwyg-nav-dialog`, `.live-wysiwyg-selection-edit-popup`, `.live-wysiwyg-emoji-autocomplete`, `.md-admonition-dropdown`, `.live-wysiwyg-nav-review-popup`, `.live-wysiwyg-asset-lightbox`, `.live-wysiwyg-history-branch-popup`, `.live-wysiwyg-history-hover-preview` | `editor.css`, `_getFocusModeCSS`, JS inline styles |
 | `100000` | `.live-wysiwyg-toast` | `_getFocusModeCSS` |
 | `100001` | `#live-wysiwyg-pipeline-progress` | JS inline style |
 | `100002` | `#live-wysiwyg-post-save-notifications` | JS inline style |
@@ -74,7 +74,7 @@ Every z-index value in the codebase. New z-index values must be added here befor
 - **0–100**: In-content elements that layer relative to each other within the editable area.
 - **99989**: Early overlay that appears before focus mode is fully initialized.
 - **99990**: Focus overlay — the primary stacking context for all focus-mode UI.
-- **99993–99996**: Panels and popups that float above the focus overlay but below editor dropdowns. The mermaid overlay (`.live-wysiwyg-mermaid-overlay` at 99995) is Layer 3, above the focus overlay (Layer 2).
+- **99993–99996**: Panels and popups that float above the focus overlay but below editor dropdowns. The mermaid overlay (`.live-wysiwyg-mermaid-overlay` at 99995) is Layer 3, and the history overlay (`.live-wysiwyg-history-overlay` at 99995) is Layer 4 — both above the focus overlay (Layer 2). Mermaid and History share z-index 99995 because they are mutually exclusive per Cardinal Rule #9 (see [DESIGN-modes-of-operation.md](DESIGN-modes-of-operation.md) § Layer-Level Mutual Exclusion).
 - **99999**: All editor dropdowns share the same layer so they can overlap each other freely.
 - **100000–100002**: Global UI elements (toast, progress bar, notifications) that must appear above everything.
 - **100003**: Help modal (Layer 5) — above all editing surfaces and global UI. See [DESIGN-help-system.md](DESIGN-help-system.md).
@@ -106,6 +106,7 @@ New dropdowns must follow this contract. The `z-index` must be `99999` (matching
 - `_dismissLinkDropdownFn()` (link settings — via closure variable)
 - `_admonitionDropdownDismiss()` (admonition toolbar type picker)
 - `hideSelectionEditPopup()` (selection edit popup)
+- `_dismissHistoryBranchPopup()` (history branch picker popup)
 
 ### Rules
 

--- a/docs/design/ui/DESIGN-markdown-awareness.md
+++ b/docs/design/ui/DESIGN-markdown-awareness.md
@@ -16,7 +16,7 @@ All code lives in `live-wysiwyg-integration.js`.
 - **Ordered list numbering**: `1.`, `2.`, `3.` become `1.`, `1.`, `1.`
 - **Table separators**: column alignment markers are normalized
 - **Horizontal rule style**: `***`, `___` become `---`
-- **Inline code backtick count**: double backticks become single backticks
+- **Inline code backtick count**: preserved via run-length fence calculation (longest backtick run + 1)
 - **Reference links**: `[text][ref]` with `[ref]: url` become inline `[text](url)`
 - **Raw HTML blocks**: stripped or mangled by the markdown parser
 
@@ -97,11 +97,19 @@ Any function that loads markdown content into the WYSIWYG editable area must:
 
 `_doubleRenderCheck(markdown)` performs markdown → HTML → markdown → HTML and compares the two HTML outputs after whitespace normalization. If they differ, the markdown content would be corrupted by a round-trip.
 
-Used by the Content History subsystem (`_createHistoryNode`) to guard against storing diffs that would produce corrupted content on undo/redo restore. If the check fails, the capture is skipped and a console warning is logged.
+Previously used by the Content History subsystem to gate history capture (skipping when the check failed). This is **no longer used for history capture gating** — the Content History subsystem now uses always-on HTML snapshots to eliminate round-trip drift entirely (see [DESIGN-unified-content-undo.md](DESIGN-unified-content-undo.md) Rule 6). The double render check remains available for initial content-load validation and diagnostic purposes.
+
+## Markdown Round-Trip Fidelity Check
+
+`_markdownRoundTripFaithful(markdown)` performs markdown → HTML → markdown and compares the normalized results. Unlike the double render check (which compares two HTML outputs), this compares two markdown outputs to detect when markdown content cannot survive the HTML round-trip.
+
+The function strips YAML frontmatter before testing (frontmatter is not markdown and causes false negatives). Returns `true` for empty or whitespace-only bodies.
+
+Used for diagnostic logging in the Content History subsystem but does **not** gate capture or snapshot creation. All WYSIWYG history nodes unconditionally capture HTML snapshots regardless of this check's result.
 
 ## Relationship to Other Subsystems
 
-- **Content History** ([DESIGN-unified-content-undo.md](DESIGN-unified-content-undo.md)): The DAG captures markdown via `getValue()` (which runs postprocessors) and restores via `_historyApplyContent` (which must run preprocessors + enhancers per the content-loading contract). The double render check is a corruption guard before capture.
+- **Content History** ([DESIGN-unified-content-undo.md](DESIGN-unified-content-undo.md)): The DAG captures markdown via `getValue()` (which runs postprocessors) and restores via `_historyApplyContent` (which must run preprocessors + enhancers per the content-loading contract). Every WYSIWYG-mode node also stores an HTML snapshot (`editableArea.innerHTML`) unconditionally, which is used as the primary restore mechanism in WYSIWYG mode — bypassing `_markdownToHtml` entirely to eliminate round-trip drift. DOM enhancers still run after snapshot restore for re-initialization of interactive elements (mermaid preview re-rendering, event handler re-attachment). The undo system is aware of markdown construct boundaries when capturing intermediate typing states: pre-flush before block conversions captures literal markdown syntax (e.g. `` ```mermaid ``) as HTML snapshot nodes, preserving the exact DOM even though the markdown parser would reinterpret the syntax on round-trip. This ensures undo can walk through every intermediate state including partially-typed markdown constructs that straddle code block fence boundaries.
 
 - **Progressive Select All** ([DESIGN-progressive-select-all.md](DESIGN-progressive-select-all.md)): `_isSelectableTarget` must recognize all enhanced DOM elements (`.md-code-block`, `.admonition`, etc.) for the selection hierarchy to work correctly. If enhancement doesn't run after content restoration, the wrapper elements don't exist and selection scoping degrades to raw `<pre>` / `<div>` elements.
 

--- a/docs/design/ui/DESIGN-modes-of-operation.md
+++ b/docs/design/ui/DESIGN-modes-of-operation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The WYSIWYG editor operates in three primary modes, with additional modes planned for future releases. Each mode defines a distinct editing context, UI surface, and user interaction model.
+The WYSIWYG editor operates in multiple modes. Each mode defines a distinct editing context, UI surface, and user interaction model.
 
 | Mode | Description |
 |---|---|
@@ -10,6 +10,8 @@ The WYSIWYG editor operates in three primary modes, with additional modes planne
 | **Unfocused** | WYSIWYG editor rendered inline on the readonly page with the live-edit controls bar overlay. |
 | **Focus** | Fullscreen overlay emulating the Material theme layout with nav sidebar, content area, and TOC. |
 | **Mermaid** | Full-screen diagram editor for mermaid code blocks. Overlays Focus Mode with iframe embedding vendored mermaid-live-editor. |
+| **History** | Document history DAG visualization with branch picker, full-screen overlay, and readonly preview. Overlays Focus Mode. See [DESIGN-history-mode.md](DESIGN-history-mode.md). |
+| **Help** | Layer 5 informational overlay displaying context-sensitive keyboard shortcut reference. See [DESIGN-help-system.md](DESIGN-help-system.md). |
 
 Planned future modes include Theme Mode.
 
@@ -24,6 +26,10 @@ Planned future modes include Theme Mode.
 | Focus | Unfocused | X button or Escape key |
 | Focus | Mermaid | Expand button on `.md-mermaid-block` |
 | Mermaid | Focus | Close button, ESC, or Ctrl+S |
+| Focus | History | "Document History" button in branch picker popup |
+| History | Focus | Close button, ESC, backdrop click, or content restoration |
+| Any | Help | Ctrl+? or help icon |
+| Help | Previous | ESC, Enter, backdrop click, Ctrl+? |
 | Unfocused | Readonly | Cancel button |
 
 ### Transition Diagram
@@ -79,6 +85,8 @@ Browser fullscreen and contenteditable behavior vary across browsers. See [DESIG
 | Unfocused | Controls bar (`.live-edit-controls`) from upstream live-edit-plugin |
 | Focus | Fullscreen overlay (`.live-wysiwyg-focus-overlay`) |
 | Mermaid | Fullscreen overlay (`.live-wysiwyg-mermaid-overlay`, z-index 99995) |
+| History | Modal overlay (`.live-wysiwyg-history-overlay`, z-index 99995) |
+| Help | Modal overlay (`.live-wysiwyg-help-overlay`, z-index 100003) |
 
 ## Mode Hierarchy
 
@@ -87,8 +95,9 @@ Browser fullscreen and contenteditable behavior vary across browsers. See [DESIG
 Modes form a layered stack. Only one mode is active at a time. When a higher-layer mode activates, all lower layers are suppressed. When the higher mode exits, the lower mode resumes.
 
 ```
-Layer 5:  Help Modal        (informational overlay, z-index 100003)
-Layer 3:  Mermaid Mode      (full-screen diagram editor, overlays Focus, z-index 99995)
+Layer 5:  Help Mode         (informational overlay, z-index 100003; exclusively reserved)
+Layer 4:  History Mode      (document history DAG + preview, z-index 99995)
+Layer 3:  Mermaid Mode      (full-screen diagram editor, z-index 99995)
 Layer 2:  Focus Mode        (fullscreen overlay, own scroll, own shortcuts)
 Layer 1:  Unfocused Mode    (inline editor, controls bar, page scroll)
 Layer 0:  Readonly Mode     (static HTML, page scroll, no editing)
@@ -103,6 +112,7 @@ Layer 4+: Theme Mode (override Focus or peer with Focus)
 | 1 | Unfocused | Edit button / period shortcut | Cancel button | — |
 | 2 | Focus | Focus Mode toolbar / fullscreen | X button / Escape | 99990 |
 | 3 | Mermaid | Expand button on mermaid code block (from Focus Mode only) | Close button, ESC, Ctrl+S | 99995 |
+| 4 | History | "Document History" button in branch picker popup | ESC, close button, backdrop click, content restore | 99995 |
 | 5 | Help | Ctrl+? or help icon (from any mode) | ESC, Enter, backdrop click, Ctrl+? | 100003 |
 
 ### Disk I/O Authority by Layer
@@ -113,6 +123,8 @@ Layer 4+: Theme Mode (override Focus or peer with Focus)
 | 1 (Unfocused) | Upstream live-edit-plugin Save button (direct WebSocket) |
 | 2 (Focus) | Declarative Save Planner exclusively (`_runBatchOps`) |
 | 3 (Mermaid) | None (all changes in-memory; persisted when Focus Mode saves) |
+| 4 (History) | None (read-only inspection; restoration modifies in-memory DAG only) |
+| 5 (Help) | None |
 
 In Focus Mode and above, no code path may perform disk writes outside the batch executor pipeline. This is enforced architecturally: all disk-writing functions (`_wsSetContents`, `_wsNewFile`, `_wsDeleteFile`, mutating `_apiPost`) are called only from `_execute*Op` functions dispatched by `_dispatchSingleOp` within `_runBatchOps`. See DESIGN-declarative-save-planner.md Invariant 10.
 
@@ -126,6 +138,28 @@ When Layer N is active, all layers < N must have:
 | **Keyboard shortcuts** | Lower-layer keyboard handlers must early-return or not fire. Handlers registered on `document` must guard with the active mode check. |
 | **Event handlers** | Permanent document-level handlers from lower layers must check `isFocusModeActive` (or equivalent) and return early. |
 | **UI** | Lower-layer overlays and controls are behind the higher layer's z-index. Not interactive. |
+
+### Layer-Level Mutual Exclusion (Cardinal Rule #9)
+
+Editor modes at the same layer are mutually exclusive. Within each layer of the mode hierarchy (Layers 0–5), only one editor mode may be active at a time. Mutually exclusive modes at the same layer share a single z-index value, since they can never coexist. Entry into one mode at a layer must be blocked while another mode at that layer is active.
+
+This principle applies exclusively to editor modes — not to non-modal UI elements such as dropdowns, toasts, popups, or progress bars, which have their own z-index assignments independent of the mode hierarchy.
+
+**Current z-index sharing:**
+
+| Z-index | Modes | Relationship |
+|---|---|---|
+| 99995 | Mermaid (Layer 3), History (Layer 4) | Mutually exclusive — both overlay Focus Mode |
+| 100003 | Help (Layer 5) | Exclusively reserved — overlays all other modes |
+
+**Guard implementation:**
+
+- `_enterHistoryMode()`: returns early if `_mermaidModeActive`.
+- `enterMermaidMode()`: returns early if `_historyModeActive`.
+- `exitFocusMode()`: exits both History and Mermaid modes before tearing down Focus Mode.
+- Future modes at Layer 3 or 4 must add analogous guards against all other modes at their layer.
+
+**Layer 5 reservation:** Layer 5 is exclusively reserved for Help Mode. Help documentation must be capable of overlaying every other editor mode.
 
 ### Audit Findings
 
@@ -160,6 +194,28 @@ A dedicated mode for editing site theme configuration, colors, and styling. Feat
 - Persists changes to theme configuration files
 
 Entry and exit would follow the same lifecycle pattern: explicit triggers, cursor/state preservation where applicable, and cleanup on exit.
+
+### History Mode (Layer 4)
+
+History Mode provides a visual interface to the DAG-based content undo/redo system with three tiers:
+
+- **Branch picker popup** (Tier 1): caret-positioned popup when redo hits a branch point or at end of history. Shows branch options and "Show All Redo History" entry point.
+- **Document History overlay** (Tier 2): full-screen DAG visualization with inline crumple accordion, V-tree branch forks, column-based layout, and preview panel.
+- **Full-size readonly preview** (Tier 3): full-viewport rendered content inspection with mermaid/code rendering.
+
+Key properties:
+
+- **Overlays Focus Mode** with modal DAG diagram and preview UI
+- **`_historyModeActive` flag** — guards mode-specific behavior
+- **Mutually exclusive with Mermaid Mode** — both share z-index 99995 (Cardinal Rule #9)
+- **Read-only**: no disk writes; content restoration modifies in-memory DAG state
+- **Auto-exits when Focus Mode exits** — `exitFocusMode()` calls `_exitHistoryMode()` first
+- **Inline crumple accordion**: consecutive edits within the same markdown container are collapsed into crumple icon nodes. Clicking unfolds the hidden nodes.
+- **V-tree forks**: multi-branch points show a fork icon; clicking opens a branch picker; selecting a branch shows its history diagonally.
+- **"You Are Here" indicator**: dotted-line arrow across the full DAG width at the current node.
+- **Frontmatter-free previews**: all preview rendering strips YAML frontmatter.
+
+For full architecture, DAG layout algorithm, inline crumple system, and keyboard handling, see [DESIGN-history-mode.md](DESIGN-history-mode.md).
 
 ### Mermaid Mode (Layer 3)
 

--- a/docs/design/ui/DESIGN-popup-dialog-ux.md
+++ b/docs/design/ui/DESIGN-popup-dialog-ux.md
@@ -204,6 +204,9 @@ Triggered on the Insert click or URL blur when alt is empty and a URL has been t
 | Asset Preview | `_showAssetPreviewPopup` | Expand btn | Small preview with expand; ESC + Enter |
 | Asset Lightbox | `_showAssetLightbox` | Close btn | Modal image/text viewer; ESC to dismiss, click-outside backdrop |
 | Help Modal | `_showHelp` | Close btn | Layer 5 tabbed help reference; ESC + Enter + backdrop click; arrow keys navigate tabs. See [DESIGN-help-system.md](DESIGN-help-system.md) |
+| History Branch Popup | `_showHistoryBranchPopup` | popup itself | Transient branch picker on redo; Arrow Up/Down, Tab/Enter to confirm, ESC/click-outside to dismiss; auto-dismiss 3s. See [DESIGN-history-mode.md](DESIGN-history-mode.md) |
+| History DAG Overlay | `_buildHistoryOverlay` | overlay itself | Layer 4 DAG visualization; Arrow keys navigate DAG, Enter restores, ESC exits. See [DESIGN-history-mode.md](DESIGN-history-mode.md) |
+| History Full-Size Preview | `_showHistoryFullsizePreview` | preview itself | Full-viewport readonly preview; Enter restores, ESC returns to DAG. See [DESIGN-history-mode.md](DESIGN-history-mode.md) |
 
 ### Excluded (No Changes)
 

--- a/docs/design/ui/DESIGN-targeted-markdown-revert.md
+++ b/docs/design/ui/DESIGN-targeted-markdown-revert.md
@@ -70,12 +70,14 @@ Applies to: headings, blockquotes, admonitions, details/collapsible, single-item
 
 ### Inline elements
 
-When the cursor is at a revert position (start, end, or immediately after a zero-width space) of an inline element and the user presses Backspace:
+When the cursor is at a revert position of an inline element and the user presses Backspace:
 
 - **`data-md-literal` present**: Replace the element with a text node containing the stored literal (e.g., `` `text` ``). Cursor placed at end.
 - **`data-md-literal` absent**: Replace the element with a text node containing just the plain text content (no markdown markers). This is the **unwrap** path.
 
-Applies to: `<code>`, `<strong>`/`<b>`, `<em>`, `<del>`, `<a>`.
+Applies to: `<strong>`/`<b>`, `<em>`, `<del>`, `<a>` — revert triggers at start, end, or immediately after the element.
+
+**`<code>` exception**: Inline code elements (`<code>` not inside `<pre>`) only revert when the cursor is **immediately after** the element (in the trailing zero-width space text node). When the cursor is **inside** a `<code>` element at the start or end, Backspace behaves normally (deletes characters). This prevents accidental revert while editing code content. The "immediately after" detection works identically for all backtick counts (single, double, triple, N-backtick inline code).
 
 ### Code block (separate handler)
 

--- a/docs/design/ui/DESIGN-unified-content-undo.md
+++ b/docs/design/ui/DESIGN-unified-content-undo.md
@@ -40,11 +40,14 @@ Global variables:
   children: number[],        // ordered by creation time (oldest first)
   activeChildId: number | null,  // which child Cmd+Shift+Z follows
   diff: { ops: [...] } | null,  // null for root node only
+  htmlSnapshot: string | null,  // editableArea.innerHTML (WYSIWYG nodes only)
   cursor: {
     mode: 'wysiwyg' | 'markdown',
-    start: number,             // markdown: selectionStart
-    end: number,               // markdown: selectionEnd
-    semantic: object | null    // wysiwyg: captureSemanticSelection() result
+    start: number,             // markdown: selectionStart / estimated md offset
+    end: number,               // markdown: selectionEnd / estimated md offset
+    semantic: object | null,   // wysiwyg: captureSemanticSelection() result
+    blockChildIndex: number,   // wysiwyg: index of block element in editableArea.childNodes
+    innerOffset: number        // wysiwyg: text offset within that block element
   },
   timestamp: number,
   summary: string | null       // auto-generated human-readable change description
@@ -75,13 +78,15 @@ Each diff contains an array of line-level operations:
 
 ### Summary Generation
 
-`_generateSummary(diff)` produces a human-readable string from the diff ops:
+`_generateSummary(diff)` produces a human-readable, markdown-aware string from the diff ops. Summaries appear in DAG nodes, crumple labels, branch picker items, and V-tree options:
 
-- Single-line text change → `"edited line N"`
-- Multi-line insert between ``` delimiters → `"inserted code block"`
-- Line starting with `#` added/changed → `"changed heading"`
-- Admonition insert (`!!!`/`???`/`???+`) → `"inserted admonition"`
-- List items added → `"added list items"`
+- Mermaid fenced code block created → `"Mermaid diagram created"`
+- Fenced code block with language → `"python code block"` (language extracted from fence)
+- Line starting with `#` added/changed → `"heading text"` (quoted heading content)
+- Admonition insert (`!!!`/`???`/`???+`) → `"note admonition"` (type extracted)
+- Blockquote added → `"blockquote added"`
+- List items added → `"list items added"`
+- Single-line text change → first few words of the changed text
 - Fallback → `"edited N lines"`
 
 ## Markdown-Aware Construct Grouping
@@ -106,6 +111,15 @@ Grouping only applies when an entire construct appears or disappears in one diff
 - **Word boundaries** (space, punctuation, Enter): flush immediately (captures the completed word/line), then start a new debounce window
 - **Timer expiry**: capture snapshot
 
+**WYSIWYG mode** uses a single `input` listener on `editableArea` that inspects `e.inputType` and `e.data` to decide `immediate` per-event. Word-boundary characters, paragraph inserts, paste, drop, format commands, and deletions all trigger `immediate=true`.
+
+**Markdown mode** uses a two-listener strategy on `markdownArea` because `<textarea>` `input` events do not reliably provide `e.data` across browsers:
+
+1. A `keydown` listener fires first and calls `_scheduleHistoryCapture(true)` for Space, Enter, and punctuation — capturing the completed word before the boundary character is inserted.
+2. An `input` listener fires after and calls `_scheduleHistoryCapture(false)` — resetting the 500ms debounce timer for the next typing stretch.
+
+The net behavior is equivalent: regular characters debounce at 500ms, word boundaries flush immediately.
+
 ### Immediate Flush
 
 `_flushHistoryCapture()` is called before any transition that could affect content or mode:
@@ -118,16 +132,51 @@ Grouping only applies when an entire construct appears or disappears in one diff
 | Paste | `ea.addEventListener('paste', ...)` handlers |
 | Toolbar format commands | `_handleToolbarClick`, `_insertCodeBlock`, `_wrapSelectionInBlockquote`, etc. |
 | Nav menu drag-and-drop | `ea.addEventListener('drop', ...)` handler |
+| Backspace revert | `_ekh.mdAuto` — before `handleRevertOnBackspace` |
+| Code block backspace (selection delete) | `_ekh.codeBlockBackspace` — before removing selected blocks |
+| Code block backspace (empty revert) | `_ekh.codeBlockBackspace` — before replacing empty code block |
+| Inline Enter/Arrow escape | `_ekh.inlineEnterEscape` — before DOM split |
 
-### Corruption Guard
+### Post-Mutation Capture (Programmatic Conversions)
 
-Before creating a diff node, the current markdown is passed through `_doubleRenderCheck()` (md → html → md → html, compare normalized HTML). If the check fails:
+Programmatic DOM mutations that bypass the browser's input pipeline — inline typing auto-replacements, backspace reverts, and keydown-triggered block conversions — call `e.preventDefault()`, which suppresses the browser's `input` event. The history `input` listener never fires for these mutations, so the post-mutation state would never enter the DAG without explicit capture.
 
-1. Log `console.log('[UNDO] history capture skipped: double-render corruption detected')`
-2. Skip this capture entirely
-3. The content will be captured at the next successful checkpoint
+After each such mutation completes and `_finalizeUpdate` is called, `_scheduleHistoryCapture(true)` is called to immediately flush the post-mutation state into the DAG.
 
-This prevents storing diffs that would produce corrupted content on undo/redo restore.
+| Mutation | Location |
+|----------|----------|
+| Inline code conversion (`` ` ``, ` `` `, ` ``` `, etc.) | `_doInlineCodeConvert` — after `_finalizeUpdate` |
+| Block code creation (` ``` ` at line start) | Capture-phase `input` handler — after `_finalizeUpdate` |
+| Block conversions on Space keydown | `_ekh.mdAuto` — after `handleBlockConversions` succeeds |
+| Backspace revert (all element types) | `_ekh.mdAuto` — after `handleRevertOnBackspace` succeeds |
+| Code block backspace (selection delete) | `_ekh.codeBlockBackspace` — after `_finalizeUpdate` |
+| Code block backspace (empty revert) | `_ekh.codeBlockBackspace` — after `_finalizeUpdate` |
+| Inline typing conversions (bold, italic, strikethrough, links, HR, lists, headings) | Main `input` handler — after `converted && _finalizeUpdate` |
+
+Without these post-mutation captures, the intermediate state between a conversion and its revert is invisible to the DAG. Example: typing `` ``` code ``` `` creates a `<code>` element, pressing Backspace reverts it to text. If the code-element state was never captured, `Cmd+Z` after the revert cannot restore it — the pre-conversion and post-revert markdown are identical, so `_flushHistoryCapture` inside `_contentUndo` sees no change and skips to the wrong ancestor node.
+
+### Always-On HTML Snapshot Strategy
+
+Every history node created in WYSIWYG mode stores `editableArea.innerHTML` as `htmlSnapshot`. This is unconditional — snapshots are captured regardless of whether the markdown round-trip is faithful or lossy.
+
+**Why always-on:** The markdown round-trip (`_markdownToHtml` then `_htmlToMarkdown`) is inherently lossy for many DOM states — literal backtick text the parser reinterprets as fences, enhanced elements with `data-*` attributes, mermaid diagram wrappers, etc. Rather than trying to detect every edge case, always capturing the HTML eliminates all markdown-to-HTML drift during undo/redo restore. The snapshot is the exact DOM the user saw.
+
+**Restore behavior:**
+
+- **WYSIWYG mode**: `_historyApplyContent` sets `editableArea.innerHTML` from the snapshot, then runs all 6 DOM enhancers (idempotent) plus mermaid re-rendering for already-wrapped blocks. This bypasses `_markdownToHtml` entirely, so the restored DOM exactly matches what was captured.
+- **Markdown mode**: Always uses the reconstructed markdown from diffs (correct as raw text regardless of HTML fidelity).
+
+**History is never skipped.** The old `_doubleRenderCheck`-based skip (which dropped undo steps entirely) was replaced by always-on snapshots. A lost undo step is a user-visible bug; a snapshot is transparent.
+
+**`_markdownRoundTripFaithful`** (`md → html → md`, compare normalized markdown) remains available. It strips YAML frontmatter before testing (frontmatter is not markdown and causes false negatives). It is used for diagnostic logging but does not gate history capture. The original `_doubleRenderCheck()` (`md → html → md → html`, compare HTML) remains for initial content-load validation but is no longer used for history capture.
+
+### Immediate Post-Restore Sync
+
+After any content restore (HTML snapshot or markdown-to-HTML), the DOM's `getValue()` output may differ slightly from the diff-reconstructed markdown due to enhancer normalization, attribute differences, or whitespace. Without correction, the next `_flushHistoryCapture()` would see this drift as a change, create a spurious node, and break the redo chain.
+
+Both `_contentUndo` and `_contentRedo` sync `_historyLastMd` to `wysiwygEditor.getValue()` immediately after `_historySetContent` returns. Since `_historyApplyContent` runs all enhancers synchronously, `getValue()` is accurate at that point. This absorbs any normalization drift and ensures `_historyLastMd` always matches the actual DOM state. Subsequent user typing will diff correctly against this synced baseline.
+
+This immediate sync replaces a previous deferred mechanism (`_historyJustRestored` flag) that had a race condition: if the user typed new content and pressed Cmd+Shift+Z before the deferred sync fired, the flag would absorb the user's typing as "drift" and allow redo to overwrite it.
 
 ## Undo / Redo Flow
 
@@ -136,16 +185,20 @@ This prevents storing diffs that would produce corrupted content on undo/redo re
 1. If `_historyCurrentId` is the root node, do nothing
 2. Flush any pending capture (so current typing is saved as a node first)
 3. Get current node's diff, reverse-apply to reconstruct parent's markdown
-4. Set editor content via `_historyApplyContent()` (works in whichever mode is active). This refreshes all preprocess data stores and runs DOM enhancers per the [Markdown Awareness](DESIGN-markdown-awareness.md) contract.
-5. Restore cursor from parent node's stored cursor
-6. Set `_historyCurrentId = parentId`, update `_historyLastMd` cache
+4. Set editor content via `_historyApplyContent(parentMd, parent.htmlSnapshot)`. If the parent node has an HTML snapshot and the editor is in WYSIWYG mode, the snapshot restores the DOM directly (bypassing markdown parsing). Otherwise, `_markdownToHtml` produces HTML normally. Preprocess stores are always refreshed and DOM enhancers always run per the [Markdown Awareness](DESIGN-markdown-awareness.md) contract. `enhanceMermaidBlocks` re-renders any already-wrapped mermaid blocks whose preview containers are empty (from snapshot restore).
+5. Sync `_historyLastMd` to `getValue()` immediately (absorbs normalization drift)
+6. Restore cursor from parent node's stored cursor (block-child-first for snapshot nodes)
+7. Set `_historyCurrentId = parentId`
 
 ### Redo (`Cmd+Shift+Z` / `Cmd+Y` with content editor focused)
 
-1. If current node has no `activeChildId`, do nothing
-2. Get activeChild's diff, apply forward to reconstruct child's markdown
-3. Set editor content, restore cursor from child node
-4. Set `_historyCurrentId = activeChildId`, update `_historyLastMd` cache
+1. Flush any pending capture (if the user typed after undo, this creates a new branch — redo stops)
+2. If current node has no `activeChildId`, do nothing (covers both "no redo" and "new branch" cases)
+3. Get activeChild's diff, apply forward to reconstruct child's markdown
+4. Set editor content via `_historyApplyContent`
+5. Sync `_historyLastMd` to `getValue()` immediately (absorbs normalization drift)
+6. Restore cursor from child node (block-child-first for snapshot nodes)
+7. Set `_historyCurrentId = activeChildId`
 
 ### New Change After Undo (Branching)
 
@@ -157,16 +210,35 @@ This prevents storing diffs that would produce corrupted content on undo/redo re
 
 ## Cursor Preservation
 
+### Capture (`_captureHistoryCursor`)
+
 Each node stores cursor at capture time:
 
 - **Markdown mode**: `{ mode: 'markdown', start: selectionStart, end: selectionEnd, semantic: null }`
-- **WYSIWYG mode**: `{ mode: 'wysiwyg', start: estimatedMdOffset, end: estimatedMdOffset, semantic: captureSemanticSelection(editableArea) }`
+- **WYSIWYG mode**: `{ mode: 'wysiwyg', start: estimatedMdOffset, end: estimatedMdOffset, semantic: captureSemanticSelection(editableArea), blockChildIndex: N, innerOffset: M }`
 
-The WYSIWYG capture estimates a markdown character offset via `_estimateMdOffsetFromWysiwyg`, which counts the text length before the cursor in the editable area. This offset is approximate but enables meaningful cross-mode cursor placement.
+The WYSIWYG capture collects three independent cursor representations:
 
-On restore (`_restoreHistoryCursor(cursor, diff, mdContent, isRedo)`):
+1. **`start`/`end`**: Approximate markdown character offset via `_estimateMdOffsetFromWysiwyg` (text length before cursor). Enables cross-mode cursor placement.
+2. **`semantic`**: `captureSemanticSelection(editableArea)` result — block index + CSS class + text offset. Works well for elements with distinctive classes.
+3. **`blockChildIndex` + `innerOffset`**: The index of the direct child block element of `editableArea` that contains the cursor, and the cumulative text offset within that block's text nodes. This is the most precise representation — it locates the cursor by structural position rather than semantic class, so it works for classless elements like empty `<p><br></p>` paragraphs.
 
-**Diff-based positioning is always preferred.** The cursor is placed at the **end** of the last changed line in the resulting content, so the user can immediately continue typing. This applies to both undo and redo, in both WYSIWYG and markdown modes.
+The `blockChildIndex` is computed by walking `parentNode` from the selection's `startContainer` until reaching a direct child of `editableArea`, then finding that child's index in `childNodes`. The `innerOffset` is computed by walking text nodes within that block via `TreeWalker` and summing lengths until reaching the cursor's text node.
+
+### Restore (`_restoreHistoryCursor`)
+
+On restore (`_restoreHistoryCursor(cursor, diff, mdContent, isRedo)`), the strategy depends on whether the node has an HTML snapshot.
+
+**For HTML snapshot nodes** (most WYSIWYG nodes), a block-child-first strategy is used:
+
+1. **Block-child index** (primary): If `cursor.blockChildIndex` is valid (>= 0, within `editableArea.childNodes` range), locate that block element. Walk its text nodes with `TreeWalker` to place the cursor at `cursor.innerOffset`. If the block has no text nodes (e.g. `<p><br></p>`), place cursor at position 0 of the block. This is the most reliable strategy because it uses structural position, not content matching.
+2. **Semantic** (fallback): `restoreSelectionFromSemantic(editableArea, cursor.semantic)`.
+3. **Flat text offset** (fallback): `_placeCursorAtMdOffset(cursor.start, null)`.
+4. **Last resort**: focus editor at position 0.
+
+**For non-snapshot nodes** (markdown mode nodes, root node):
+
+**Diff-based positioning is preferred.** The cursor is placed at the **end** of the last changed line in the resulting content.
 
 1. **Diff available**: `_diffToMdOffset` computes the end-of-change-region offset. For **redo**, it tracks cumulative line shifts across all diff ops to find the end of the last inserted/replaced region in the child content. For **undo**, it finds the end of the last restored region in the parent content (replace/delete → end of old lines; insert → line before insertion point).
 2. **Same mode, markdown** (fallback): `setSelectionRange(start, end)` using stored offsets.
@@ -236,20 +308,33 @@ No separate timers are used for auto-save or DAG persistence. They reuse the exi
 - **Pruning**: when total node count exceeds ~200, oldest leaf branches are pruned (nodes with no children that are not on the current path from root to `_historyCurrentId`).
 - **Nav save reload**: `_navigateAfterBatchComplete` flushes pending captures and persists the DAG before the reload. `enterFocusMode` restores it afterwards.
 
-## Extensibility for Non-Linear Redo
+## Non-Linear Redo UI (History Mode)
 
-The DAG preserves all redo branches with metadata needed for a future branch navigation UI:
+The DAG preserves all redo branches with metadata consumed by History Mode (Layer 4):
 
 **Data at branch points:**
 - `node.children` lists all branches (in creation order)
 - Each child has `summary` and `timestamp` for branch picker display
 - `node.activeChildId` marks the default redo path
 
-**Helper functions (built now, consumed by future UI):**
+**Helper functions (consumed by History Mode UI):**
 - `_getHistoryBranchPoints()` — all nodes where `children.length > 1`
 - `_getHistoryBranches(nodeId)` — `[{ childId, summary, timestamp, depth }]` for each child
-- `_switchHistoryBranch(nodeId, childId)` — changes `activeChildId` for a future branch picker
+- `_switchHistoryBranch(nodeId, childId)` — changes `activeChildId` for the branch picker
 - `_reconstructContentAtNode(nodeId)` — returns full markdown at any node (for preview)
+- `_restoreToHistoryNode(nodeId)` — jumps to any node (used by DAG overlay restore)
+- `_computeContainerGroups(activePathList)` — identifies consecutive edits within the same markdown container for inline crumple accordion
+- `_stripFrontmatterForPreview(md)` — removes YAML frontmatter before preview rendering
+
+**Redo branch detection:** `_contentRedo()` shows the branch picker popup in two cases:
+1. After redo at a branch point (`children.length > 1` on the pre-redo node) — popup shows alternative branches.
+2. When no redo is available (`!activeChildId`) — popup shows "End of history" with a "Show All Redo History" entry point into History Mode.
+
+This ensures `Cmd+Shift+Z` always provides access to History Mode, even when the user is at the latest node.
+
+**Container group detection:** `_computeContainerGroups` analyzes consecutive active-path nodes to identify runs of edits within the same markdown structure (fenced code block, admonition, blockquote, list). Groups are collapsed into inline crumple accordion icons in the DAG visualization. See [DESIGN-history-mode.md](DESIGN-history-mode.md) § Container Group Detection.
+
+For the full History Mode UI architecture (branch picker, DAG overlay, full-size preview, inline crumple accordion, V-tree forks), see [DESIGN-history-mode.md](DESIGN-history-mode.md).
 
 ## Relationship to Nav Snapshot Undo
 
@@ -276,7 +361,9 @@ The DAG's capture pipeline drives content auto-saving. See [DESIGN-uninterrupted
 
 2. **DOM enhancers run** in WYSIWYG mode (`populateRawHtmlBlocks`, `enhanceCodeBlocks`, `enhanceBasicPreBlocks`, `enhanceChecklists`, `enhanceAdmonitions`, `enhanceImages`). This ensures code blocks have their `.md-code-block` wrappers, title bars, and line number gutters after undo/redo — matching the same enhanced DOM that `setValue` and `switchToMode` produce.
 
-The double render check (`_doubleRenderCheck`) is the corruption guard that prevents the Markdown Awareness round-trip from storing corrupted diffs. See [DESIGN-markdown-awareness.md](DESIGN-markdown-awareness.md) for the full contract.
+3. **Mermaid blocks re-render** when restoring from HTML snapshots. `enhanceMermaidBlocks` detects already-wrapped `.md-mermaid-block` elements with empty `.md-mermaid-preview` containers (the asynchronous SVG rendering is lost during `innerHTML` assignment) and re-triggers the mermaid rendering pipeline. Expand button handlers are also re-attached.
+
+The always-on HTML snapshot strategy (Rule 6) ensures that undo/redo always produces the exact DOM the user saw — the snapshot bypasses `_markdownToHtml` entirely in WYSIWYG mode. DOM enhancers still run after snapshot restore because they are idempotent and handle cases where the snapshot's interactive elements need re-initialization (mermaid previews, event handlers). See [DESIGN-markdown-awareness.md](DESIGN-markdown-awareness.md) for the full content-loading contract.
 
 ## Rules
 
@@ -290,14 +377,40 @@ The double render check (`_doubleRenderCheck`) is the corruption guard that prev
 
 5. **Cmd+Z in content editor always dispatches to content undo.** When `_hasEditFocus` is true, `Cmd+Z` must be `preventDefault`'d and routed to `_contentUndo()`. Browser native undo must never fire.
 
-6. **Skip capture on corruption.** If `_doubleRenderCheck()` fails, skip the capture and log. Do not store a diff that could produce corrupted content on restore.
+6. **Always capture HTML snapshots in WYSIWYG mode.** `_createHistoryNode` must unconditionally store `editableArea.innerHTML` as `htmlSnapshot` when the editor is in WYSIWYG mode. This eliminates all markdown-to-HTML drift during undo/redo — the snapshot is the exact DOM the user saw. On restore in WYSIWYG mode, `_historyApplyContent` uses the snapshot (bypassing `_markdownToHtml`). On restore in markdown mode, the reconstructed markdown from diffs is used. Never gate snapshot capture on `_markdownRoundTripFaithful()` or any other fidelity check — always capture. A skipped snapshot is a potential undo corruption bug.
 
-7. **Diffs are line-level, not character-level.** The unit of change is a line. Word-boundary grouping is achieved by controlling *when* captures happen (debounce timing), not by storing character-level diffs.
+7. **Undo/redo must be markdown-aware.** The undo system is built on markdown diffs, but it must respect the reality that some DOM states don't survive a markdown round-trip (literal markdown syntax as text, enhanced elements with attributes, etc.). `_historyApplyContent` must fulfill the [Markdown Awareness](DESIGN-markdown-awareness.md) content-loading contract: refresh all 7 preprocess stores and run all 6 DOM enhancers after restoring content. The always-on HTML snapshot (Rule 6) bypasses the markdown parser to restore the actual DOM in WYSIWYG mode, eliminating round-trip fidelity concerns. The undo system must never produce a DOM state that differs from what the user saw when the state was captured.
 
-8. **Root node always stores full content.** `_historyRootMd` is the single source of truth for reconstructing any node's content by walking diffs from root.
+8. **Diffs are line-level, not character-level.** The unit of change is a line. Word-boundary grouping is achieved by controlling *when* captures happen (debounce timing), not by storing character-level diffs.
 
-9. **`activeChildId` determines default redo.** `Cmd+Shift+Z` always follows `activeChildId`. A future branch picker can change this via `_switchHistoryBranch`.
+9. **Root node always stores full content.** `_historyRootMd` is the single source of truth for reconstructing any node's content by walking diffs from root.
 
-10. **Never discard redo branches.** Old children remain in the `children` array when new branches are created. Only pruning (lifecycle cap) removes nodes, and it only removes leaves not on the current path.
+10. **`activeChildId` determines default redo.** `Cmd+Shift+Z` always follows `activeChildId`. A future branch picker can change this via `_switchHistoryBranch`.
 
-11. **Mermaid edits use direct DAG node creation.** `_applyCodeAndTeardown` flushes pending captures, replaces the mermaid fenced code block at the markdown level, and creates a DAG node directly — bypassing `_doubleRenderCheck`. This is safe because the edit is a known-good string replacement inside a fenced code block. `_historySetContent` applies the new markdown via the full content-loading contract. See [DESIGN-mermaid-mode.md](../../mermaid/DESIGN-mermaid-mode.md) § Undo-Redo DAG Integration.
+11. **Never discard redo branches.** Old children remain in the `children` array when new branches are created. Only pruning (lifecycle cap) removes nodes, and it only removes leaves not on the current path.
+
+12. **Mermaid edits use direct DAG node creation.** `_applyCodeAndTeardown` flushes pending captures, replaces the mermaid fenced code block at the markdown level, and creates a DAG node directly — bypassing the standard `_createHistoryNode` path. This is safe because the edit is a known-good string replacement inside a fenced code block (always round-trip faithful). `_historySetContent` applies the new markdown via the full content-loading contract. See [DESIGN-mermaid-mode.md](../../mermaid/DESIGN-mermaid-mode.md) § Undo-Redo DAG Integration.
+
+13. **Programmatic DOM mutations must bracket with flush and capture.** Any code path that modifies the editor DOM programmatically (bypassing the browser's input pipeline) must call `_flushHistoryCapture()` **before** the mutation and `_scheduleHistoryCapture(true)` **after** `_finalizeUpdate`. This ensures the pre-mutation state is snapshotted and the post-mutation state is immediately captured. Without both calls, the DAG has a gap: the intermediate state is invisible to undo/redo. This applies to inline typing auto-replacements (backtick → `<code>`, `**` → `<strong>`, etc.), backspace reverts, code block backspace (selection delete and empty revert), and any future handler that calls `e.preventDefault()` and manipulates the DOM directly. If the pre-mutation flush finds that `_historyLastMd` already matches the current content (because the debounced input listener recently captured it), the flush is a no-op — this is intentional and harmless.
+
+14. **Conversions with default content are atomic undo steps.** When a block conversion produces an element that includes default content — mermaid diagrams with the stateDiagram template, code blocks with language-specific stubs, admonitions with default titles, etc. — the replacement element and its default content must be captured as a single unified DAG node. A user pressing `Cmd+Z` must undo the entire conversion in one step, never landing on an intermediate state where the element exists but the default content is missing (e.g. an empty `` ```mermaid\n``` `` block).
+
+15. **Block conversions must pre-flush with HTML snapshot safety.** The Space-keydown handler for `handleBlockConversions` calls `_flushHistoryCapture()` before the conversion to capture the pre-conversion typing state (e.g. `` ```mermaid ``, `## `, `> ``). The pre-conversion text is markdown syntax that the parser would reinterpret on round-trip (`` ```mermaid `` becomes a code fence), so `_markdownRoundTripFaithful` detects lossiness and stores an HTML snapshot. Undo from the converted element first reaches this snapshot node (restoring the literal typing text in the DOM) before reaching earlier states. The HTML snapshot fallback (Rule 6) makes this pre-flush safe: the snapshot preserves the exact DOM regardless of markdown round-trip fidelity.
+
+16. **The DAG is mode-agnostic: undo/redo feature parity between WYSIWYG and markdown is mandatory.** Every DAG node stores a line-level markdown diff regardless of which mode created it. A node created during WYSIWYG editing must be undoable and redoable from markdown mode, and vice versa. `_contentUndo` and `_contentRedo` must not branch on the current mode when reconstructing content — they apply the same diff math and call `_historyApplyContent`, which renders in whichever mode is active. Only cursor restoration is mode-aware (`_restoreHistoryCursor` checks `cursor.mode` vs `currentMode`). When adding any new capture point, programmatic mutation handler, or undo/redo behavior, verify it works correctly when the user switches modes between the original edit and the undo/redo invocation.
+
+17. **Markdown mode must have the same debounce and word-boundary capture behavior as WYSIWYG mode.** Both modes use the same `_scheduleHistoryCapture` / `_flushHistoryCapture` functions and the same 500ms debounce constant. The markdown textarea uses a two-listener strategy (`keydown` for immediate word-boundary flush, `input` for debounced regular-character capture) because `<textarea>` `input` events do not reliably provide `e.data`. Any change to capture timing or word-boundary detection must be applied to both modes.
+
+18. **Immediate post-restore sync eliminates drift.** Both `_contentUndo` and `_contentRedo` must sync `_historyLastMd = wysiwygEditor.getValue()` immediately after `_historySetContent` returns. Since `_historyApplyContent` runs all enhancers synchronously, `getValue()` is accurate. This absorbs normalization drift (enhancer output, attribute differences, whitespace) so subsequent `_flushHistoryCapture()` calls only detect actual user edits. Do not use a deferred flag-based mechanism — a flag that defers sync to the next flush creates a race condition where user typing between the restore and the first flush is absorbed as "drift" and lost on redo.
+
+19. **Block-child cursor is the primary restore strategy for HTML snapshot nodes.** When restoring cursor position from a node that has an `htmlSnapshot`, `_restoreHistoryCursor` must first try the `blockChildIndex` + `innerOffset` strategy before falling back to semantic or flat text offset. The block-child strategy locates the cursor by the structural index of the block element within `editableArea.childNodes` and the cumulative text offset within that block — this works for classless elements (empty paragraphs, plain text nodes) where semantic class matching fails. The fallback chain is: block-child index → semantic → flat text offset → position 0.
+
+20. **Cursor capture must record block-child position.** `_captureHistoryCursor` must always compute `blockChildIndex` and `innerOffset` for WYSIWYG mode cursors. The block-child index is found by walking `parentNode` from `sel.getRangeAt(0).startContainer` to the direct child of `editableArea`. The inner offset is the cumulative text length from the start of that block element to the cursor position, computed via `TreeWalker(SHOW_TEXT)`. Both fields must be stored on the cursor object alongside `start`, `end`, and `semantic`.
+
+21. **Mermaid diagrams must re-render on snapshot restore.** When `_historyApplyContent` restores an HTML snapshot containing already-wrapped mermaid blocks (`.md-mermaid-block`), the inline SVG in `.md-mermaid-preview` is empty (the snapshot captures the wrapper structure but mermaid rendering is asynchronous). `enhanceMermaidBlocks` must detect these empty-preview blocks, extract the source code from the hidden `<pre>` element, and re-trigger `_renderMermaidPreview`. It must also re-attach the expand button click handler (`__mermaidHandlerAttached` flag), which is lost during `innerHTML` restoration. Without this, mermaid diagrams appear as blank boxes after undo/redo.
+
+22. **Synchronous cursor placement for mermaid diagram creation.** When `doCodeBlock` creates a mermaid diagram, the trailing `<p><br></p>` and cursor placement into that paragraph must be synchronous (not deferred via `requestAnimationFrame`). History capture runs immediately after `_finalizeUpdate`, and the cursor must already be in the trailing paragraph at capture time so that `_captureHistoryCursor` records the correct `blockChildIndex` and `innerOffset`. Asynchronous cursor placement causes the history node to capture the cursor at the wrong position (typically in the paragraph above the diagram), which breaks cursor restore on undo/redo.
+
+23. **`_markdownRoundTripFaithful` must strip frontmatter.** The fidelity check must parse and strip YAML frontmatter before performing the `md → html → md` comparison. Frontmatter (e.g., `title: Home`) is not markdown content and the markdown parser will reinterpret it as headings or other constructs, causing false `NOT faithful` results on every capture. Use `parseFrontmatter()` to extract the body, and test only the body. Return `true` for empty/whitespace-only bodies.
+
+24. **Redo must flush pending captures to respect new branches.** `_contentRedo()` must call `_flushHistoryCapture()` before checking `activeChildId`. If the user typed new content after undoing, the flush creates a new node (new branch from the current position), updating `_historyCurrentId` to the new node. The new node has no children, so `activeChildId` is null and redo correctly does nothing. Without this flush, redo follows the stale `activeChildId` of the pre-branch parent node and overwrites the user's new content. This is symmetric with `_contentUndo()`, which already flushes at the top.

--- a/mkdocs_live_wysiwyg_plugin/help-reference.md
+++ b/mkdocs_live_wysiwyg_plugin/help-reference.md
@@ -25,6 +25,7 @@ In Focus Mode with "Remain in Focus Mode" enabled, saving triggers a seamless pa
 | **Unfocused** | Inline editor on the rendered page with the controls bar. |
 | **Focus Mode** | Fullscreen editing overlay with nav sidebar, content area, and table of contents. Press ESC to exit. |
 | **Mermaid Mode** | Full-screen diagram editor for mermaid code blocks. Overlays Focus Mode. |
+| **History Mode** | Document History: visual DAG view of undo/redo history. Accessible via redo branch picker popup. |
 
 ### Help
 
@@ -42,12 +43,15 @@ In Focus Mode with "Remain in Focus Mode" enabled, saving triggers a seamless pa
 | Ctrl+S / Cmd+S | Save page | Triggers upstream save |
 | Ctrl+. / Cmd+. | Toggle WYSIWYG / Markdown mode | Works in both modes |
 | Ctrl+Z / Cmd+Z | Undo | DAG content undo |
-| Ctrl+Y / Cmd+Y | Redo | Also Ctrl+Shift+Z / Cmd+Shift+Z |
+| Ctrl+Y / Cmd+Y | Redo | Also Ctrl+Shift+Z / Cmd+Shift+Z. Shows branch picker at branch points |
 | Ctrl+B / Cmd+B | Bold | Toggle bold on selection |
 | Ctrl+I / Cmd+I | Italic | Toggle italic on selection |
 | Ctrl+A / Cmd+A | Select all | Progressive: block → section → document |
 | Enter | New paragraph / bubble exit | See Block Elements tab |
+| Enter (in inline element) | Split / escape inline element | See Inline & Emoji tab |
 | Shift+Enter | Line break | Bypasses bubble behavior |
+| ArrowRight (end of inline element) | Exit inline element rightward | Moves cursor after the element |
+| ArrowLeft (start of inline element) | Exit inline element leftward | Moves cursor before the element |
 | Backspace | Delete / revert markdown element | See Auto-Conversions tab |
 | Tab | Indent list / next table cell / insert spaces | Context-dependent |
 | Shift+Tab | Outdent list / previous table cell | Context-dependent |
@@ -59,7 +63,7 @@ In Focus Mode with "Remain in Focus Mode" enabled, saving triggers a seamless pa
 | Ctrl+S / Cmd+S | Save page | Triggers upstream save |
 | Ctrl+. / Cmd+. | Toggle WYSIWYG / Markdown mode | Works in both modes |
 | Ctrl+Z / Cmd+Z | Undo | DAG content undo |
-| Ctrl+Y / Cmd+Y | Redo | Also Ctrl+Shift+Z / Cmd+Shift+Z |
+| Ctrl+Y / Cmd+Y | Redo | Also Ctrl+Shift+Z / Cmd+Shift+Z. Shows branch picker at branch points |
 | Ctrl+B / Cmd+B | Bold | Wraps selection in `**` |
 | Ctrl+I / Cmd+I | Italic | Wraps selection in `*` |
 | Tab | Indent list / insert spaces | Context-dependent |
@@ -114,6 +118,8 @@ Inline conversions trigger when you type the closing delimiter. The wrapped text
 ### Backspace Revert
 
 **Backspace** on an empty converted element (heading, blockquote, admonition, list item, or the paragraph after a horizontal rule) reverts it to the original literal characters, including the trailing space (e.g. `## ` restores `## `). The cursor is placed at the end of the restored text.
+
+For **inline code** elements, backspace revert only triggers when the cursor is **immediately after** the code element (outside it). When the cursor is inside an inline code element, backspace deletes characters normally. Other inline elements (bold, italic, strikethrough, links) revert on backspace at either edge.
 
 Elements created by toolbar buttons (not by typing markdown) are deleted on backspace instead of reverted.
 
@@ -180,6 +186,21 @@ Available types: note, danger, warning, tip, hint, important, caution, error, at
 - **Triple backtick** inline code: type ` ``` ` then **Backspace** (reverts the code block) then **Space** to open, type content, then **Space** + ` ``` ` to close. Preserves single and double backticks inside the content. Mid-line triple backticks followed by Space also open inline mode directly.
 - **4+ backtick** inline code: same space-delimited pattern works for any number of backticks (4, 5, 6, ...). Use more backticks when the content contains longer consecutive backtick runs.
 - The **Inline Code** toolbar button toggles inline code off if the cursor is on existing inline code.
+
+### Inline Element Navigation
+
+Arrow keys and Enter have special behavior when the cursor is inside any inline element (code, bold, italic, strikethrough, link):
+
+| Key | Cursor Position | Behavior |
+|-----|-----------------|----------|
+| **ArrowRight** | End of inline element | Exits the element — cursor lands after it in the same paragraph |
+| **ArrowLeft** | Start of inline element | Exits the element — cursor lands before it in the same paragraph |
+| **Enter** | Left edge | Moves the inline element (and everything after it) to a new line; original line keeps content before the element |
+| **Enter** | Right edge | Inserts a new line below; content after the element moves to the new line |
+| **Enter** | Middle | Splits the inline element at the cursor; left half stays, right half moves to a new line |
+| **Shift+Enter** | Anywhere | Normal line break (bypasses inline escape) |
+
+Arrow escape and Enter splitting work inside paragraphs, headings, list items, admonitions, and block quotes.
 
 ### Emoji
 

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -294,6 +294,7 @@
     if (_admonitionDropdownDismiss) _admonitionDropdownDismiss();
     hideSelectionEditPopup();
     _dismissAssetPreviewPopup();
+    _dismissHistoryBranchPopup();
   }
 
   function createLangDropdown(anchorBtn, currentLang, onSelect) {
@@ -826,7 +827,30 @@
     var pres = editableArea.querySelectorAll('pre[data-lang="mermaid"]');
     for (var i = 0; i < pres.length; i++) {
       var pre = pres[i];
-      if (pre.parentNode && pre.parentNode.classList && pre.parentNode.classList.contains('md-mermaid-block')) continue;
+      if (pre.parentNode && pre.parentNode.classList && pre.parentNode.classList.contains('md-mermaid-block')) {
+        var mermaidWrapper = pre.parentNode;
+        var existingPreview = mermaidWrapper.querySelector('.md-mermaid-preview');
+        if (existingPreview && !existingPreview.innerHTML.trim()) {
+          var code = pre.textContent || '';
+          if (code.trim()) {
+            (function (p, c) {
+              _loadMermaidJs(function () { _renderMermaidPreview(p, c); });
+            })(existingPreview, code);
+          }
+        }
+        var existingBtn = mermaidWrapper.querySelector('.md-mermaid-expand-btn');
+        if (existingBtn && !existingBtn.__mermaidHandlerAttached) {
+          existingBtn.__mermaidHandlerAttached = true;
+          (function (block, btn) {
+            btn.addEventListener('click', function (e) {
+              e.preventDefault();
+              e.stopPropagation();
+              if (typeof enterMermaidMode === 'function') enterMermaidMode(block);
+            });
+          })(mermaidWrapper, existingBtn);
+        }
+        continue;
+      }
       if (pre.parentNode && pre.parentNode.classList && pre.parentNode.classList.contains('md-code-block')) continue;
       var wrapper = document.createElement('div');
       wrapper.className = 'md-mermaid-block';
@@ -9452,6 +9476,34 @@
     }
   }
 
+  function _markdownRoundTripFaithful(markdownContent) {
+    if (!markdownContent || typeof markdownContent !== 'string') return true;
+    var editor = wysiwygEditor;
+    if (!editor || !editor._markdownToHtml || !editor._htmlToMarkdown) return true;
+    var parsed = parseFrontmatter(markdownContent);
+    var body = parsed.body;
+    if (!body || !body.trim()) return true;
+    var prev = _inMemoryRenderMode;
+    _inMemoryRenderMode = true;
+    try {
+      var html = editor._markdownToHtml(body);
+      var md2 = editor._htmlToMarkdown(html);
+      var norm = function (s) {
+        return (s || '').replace(/[\u200B\u200C\u200D\uFEFF]/g, '').replace(/\s+$/gm, '').replace(/\n{3,}/g, '\n\n').trim();
+      };
+      var n1 = norm(body);
+      var n2 = norm(md2);
+      var faithful = n1 === n2;
+      if (!faithful) {
+      }
+      return faithful;
+    } catch (e) {
+      return false;
+    } finally {
+      _inMemoryRenderMode = prev;
+    }
+  }
+
   // --- Unified Content Undo DAG ---
 
   var _historyNodes = {};
@@ -9462,6 +9514,7 @@
   var _historyLastMd = null;
   var _historyMaxNodes = 200;
   var _undoViaBeforeinput = false;
+
 
   function _historyReset(markdown) {
     _historyNodes = {};
@@ -9598,23 +9651,64 @@
       var oldLines = singleOp.old || [];
       if (newLines.length > 0) {
         var first = newLines[0];
-        if (/^```/.test(first) && newLines.length > 1) return 'inserted code block';
-        if (/^#{1,6}\s/.test(first)) return 'changed heading';
-        if (/^(!{3}|\?{3}\+?)\s/.test(first)) return 'inserted admonition';
-        if (/^>\s/.test(first) && newLines.length > 1) return 'inserted blockquote';
-        if (/^(\s*[-*+]|\s*\d+\.)\s/.test(first) && newLines.length > 1) return 'added list items';
-        if (/^(---|___|\*\*\*)\s*$/.test(first)) return 'inserted horizontal rule';
+        if (/^```mermaid\s*$/i.test(first) && newLines.length > 1) return 'mermaid diagram created';
+        if (/^```/.test(first) && newLines.length > 1) {
+          var lang = first.replace(/^```\s*/, '').trim();
+          return lang ? lang + ' code block' : 'code block';
+        }
+        if (/^#{1,6}\s/.test(first)) {
+          var headingText = first.replace(/^#{1,6}\s+/, '').trim();
+          return headingText ? '\u201C' + _truncateExcerpt(headingText, 40) + '\u201D' : 'heading';
+        }
+        if (/^(!{3}|\?{3}\+?)\s/.test(first)) {
+          var admType = first.replace(/^(?:!{3}|\?{3}\+?)\s+/, '').split(/\s/)[0] || '';
+          return admType ? admType + ' admonition' : 'admonition';
+        }
+        if (/^>\s/.test(first) && newLines.length > 1) return 'blockquote';
+        if (/^(\s*[-*+]|\s*\d+\.)\s/.test(first) && newLines.length > 1) return 'list items';
+        if (/^(---|___|\*\*\*)\s*$/.test(first)) return 'horizontal rule';
       }
       if (singleOp.type === 'delete') {
         if (oldLines.length > 0 && /^```/.test(oldLines[0]) && oldLines.length > 1) return 'removed code block';
-        if (oldLines.length > 0 && /^#{1,6}\s/.test(oldLines[0])) return 'removed heading';
+        if (oldLines.length > 0 && /^#{1,6}\s/.test(oldLines[0])) {
+          var removedText = oldLines[0].replace(/^#{1,6}\s+/, '').trim();
+          return removedText ? 'removed \u201C' + _truncateExcerpt(removedText, 30) + '\u201D' : 'removed heading';
+        }
       }
-      if (singleOp.type === 'replace' && singleOp.count === 1 && newLines.length === 1) {
-        return 'edited line ' + (singleOp.line + 1);
+      if (newLines.length > 0) {
+        var excerpt = _extractExcerptFromLines(newLines);
+        if (excerpt) return '\u201C' + excerpt + '\u201D';
+      }
+      if (singleOp.type === 'delete' && oldLines.length > 0) {
+        var delExcerpt = _extractExcerptFromLines(oldLines);
+        if (delExcerpt) return 'removed \u201C' + delExcerpt + '\u201D';
       }
     }
+    var allNewLines = [];
+    for (var j = 0; j < diff.ops.length; j++) {
+      var op2 = diff.ops[j];
+      var lines2 = op2.type === 'replace' ? op2.new : (op2.type === 'insert' ? op2.lines : null);
+      if (lines2) allNewLines = allNewLines.concat(lines2);
+    }
+    if (allNewLines.length > 0) {
+      var multiExcerpt = _extractExcerptFromLines(allNewLines);
+      if (multiExcerpt) return '\u201C' + multiExcerpt + '\u201D';
+    }
     var total = totalOld + totalNew;
-    return 'edited ' + total + ' line' + (total !== 1 ? 's' : '');
+    return total + ' line' + (total !== 1 ? 's' : '') + ' changed';
+  }
+
+  function _truncateExcerpt(text, maxLen) {
+    if (text.length <= maxLen) return text;
+    return text.substring(0, maxLen - 1) + '\u2026';
+  }
+
+  function _extractExcerptFromLines(lines) {
+    for (var i = 0; i < lines.length; i++) {
+      var clean = lines[i].replace(/^[\s#>*\-+`!?]+/, '').replace(/[*_~`]+/g, '').trim();
+      if (clean.length > 2) return _truncateExcerpt(clean, 45);
+    }
+    return '';
   }
 
   function _groupMarkdownConstructs(diff, newLines) {
@@ -9643,9 +9737,9 @@
     if (_historyLastMd === null || _historyCurrentId === null) return;
     if (markdown === _historyLastMd) return;
 
-    if (!_doubleRenderCheck(markdown)) {
-      console.log('[UNDO] history capture skipped: double-render corruption detected');
-      return;
+    var htmlSnapshot = null;
+    if (wysiwygEditor && wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor.editableArea) {
+      htmlSnapshot = wysiwygEditor.editableArea.innerHTML;
     }
 
     var oldLines = _historyLastMd.split('\n');
@@ -9665,7 +9759,8 @@
       diff: diff,
       cursor: cursor || null,
       timestamp: Date.now(),
-      summary: summary
+      summary: summary,
+      htmlSnapshot: htmlSnapshot
     };
     _historyNodes[nodeId] = node;
 
@@ -9686,11 +9781,29 @@
     var ids = Object.keys(_historyNodes);
     if (ids.length <= _historyMaxNodes) return;
 
+    // Protect: root-to-current path + active redo path from every branch point
     var onPath = {};
     var id = _historyCurrentId;
     while (id !== null && _historyNodes[id]) {
       onPath[id] = true;
       id = _historyNodes[id].parentId;
+    }
+    // Protect the active redo path forward from current
+    var fwd = _historyCurrentId;
+    while (fwd !== null && _historyNodes[fwd]) {
+      onPath[fwd] = true;
+      fwd = _historyNodes[fwd].activeChildId || null;
+    }
+    // Protect every node's activeChildId chain (preserves all active branches)
+    for (var ai = 0; ai < ids.length; ai++) {
+      var aN = _historyNodes[ids[ai]];
+      if (aN && aN.activeChildId && onPath[parseInt(ids[ai], 10)]) {
+        var walk = aN.activeChildId;
+        while (walk !== null && _historyNodes[walk] && !onPath[walk]) {
+          onPath[walk] = true;
+          walk = _historyNodes[walk].activeChildId || null;
+        }
+      }
     }
 
     var leaves = [];
@@ -9768,6 +9881,2253 @@
     return true;
   }
 
+  // --- History Mode (Layer 4) ---
+
+  var _historyModeActive = false;
+  var _historyOverlay = null;
+  var _historyBranchPopup = null;
+  var _historyBranchPopupTimer = null;
+  var _historyBranchPopupHighlight = 0;
+  var _historyBranchPopupNodeId = null;
+  var _historyDagSelectedNodeId = null;
+  var _historyFullsizePreview = null;
+  var _historyPreviewCache = {};
+  var _historyDagExpandedGroups = {};
+  var _historyDagActiveBranchKey = null;
+  var _historyDagVtreeSelectedBranch = {};
+  var _historyDagAnimatingGroup = null;
+  var _historyDagViewMode = 'detailed';
+
+  function _formatRelativeTime(ts) {
+    var diff = Date.now() - ts;
+    if (diff < 60000) return 'just now';
+    if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+    if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+    return Math.floor(diff / 86400000) + 'd ago';
+  }
+
+  function _getSnippetForNode(node) {
+    if (!node || !node.diff || !node.diff.ops || node.diff.ops.length === 0) return '';
+    for (var i = 0; i < node.diff.ops.length; i++) {
+      var op = node.diff.ops[i];
+      var lines = op.type === 'replace' ? op.new : (op.type === 'insert' ? op.lines : null);
+      if (lines && lines.length > 0) {
+        var snippet = [];
+        for (var k = 0; k < Math.min(lines.length, 4); k++) {
+          snippet.push(lines[k]);
+        }
+        var text = snippet.join('\n');
+        if (text.length > 120) text = text.substring(0, 117) + '...';
+        return text;
+      }
+    }
+    if (node.diff.ops.length > 0 && node.diff.ops[0].type === 'delete') {
+      var oldLines = node.diff.ops[0].old;
+      if (oldLines && oldLines.length > 0) {
+        var delSnippet = [];
+        for (var d = 0; d < Math.min(oldLines.length, 4); d++) {
+          delSnippet.push(oldLines[d]);
+        }
+        var delText = delSnippet.join('\n');
+        if (delText.length > 120) delText = delText.substring(0, 117) + '...';
+        return '\u2212 ' + delText;
+      }
+    }
+    return '';
+  }
+
+  function _stripFrontmatterForPreview(markdown) {
+    if (!markdown) return '';
+    var parsed = parseFrontmatter(markdown);
+    return parsed.body;
+  }
+
+  function _renderMarkdownPreview(markdown) {
+    var body = _stripFrontmatterForPreview(markdown);
+    if (typeof marked !== 'undefined') {
+      return marked.parse(body, { gfm: true, breaks: false, smartLists: true });
+    }
+    return '<pre>' + body.replace(/</g, '&lt;') + '</pre>';
+  }
+
+  // --- Way 1: Branch Picker Popup ---
+
+  function _dismissHistoryBranchPopup() {
+    if (_historyBranchPopupTimer) {
+      clearTimeout(_historyBranchPopupTimer);
+      _historyBranchPopupTimer = null;
+    }
+    if (_historyBranchPopup) {
+      if (_historyBranchPopup._docHandler) {
+        document.removeEventListener('mousedown', _historyBranchPopup._docHandler, true);
+      }
+      if (_historyBranchPopup.parentNode) _historyBranchPopup.parentNode.removeChild(_historyBranchPopup);
+      _historyBranchPopup = null;
+    }
+    _historyBranchPopupNodeId = null;
+    _historyBranchPopupHighlight = 0;
+  }
+
+  function _showHistoryBranchPopup(branchNodeId) {
+    _dismissHistoryBranchPopup();
+    var node = _historyNodes[branchNodeId];
+    if (!node) return;
+
+    var hasBranches = node.children.length >= 2;
+    var hasRedo = node.children.length >= 1;
+
+    var popup = document.createElement('div');
+    popup.className = 'live-wysiwyg-history-branch-popup';
+    popup.setAttribute('tabindex', '-1');
+
+    var header = document.createElement('div');
+    header.className = 'live-wysiwyg-history-branch-header';
+    var headerLabel = document.createElement('span');
+    headerLabel.textContent = hasBranches ? 'Redo branches' : (hasRedo ? 'Redo' : 'End of history');
+    header.appendChild(headerLabel);
+    popup.appendChild(header);
+
+    var list = document.createElement('div');
+    list.className = 'live-wysiwyg-history-branch-list';
+    var activeIdx = 0;
+    for (var i = 0; i < node.children.length; i++) {
+      var childId = node.children[i];
+      var child = _historyNodes[childId];
+      if (!child) continue;
+      if (childId === node.activeChildId) activeIdx = i;
+      var item = document.createElement('div');
+      item.className = 'live-wysiwyg-history-branch-item';
+      item.setAttribute('data-child-id', childId);
+      if (childId === node.activeChildId) item.classList.add('active');
+
+      var summarySpan = document.createElement('span');
+      summarySpan.className = 'live-wysiwyg-history-branch-summary';
+      summarySpan.textContent = child.summary || 'edit';
+      item.appendChild(summarySpan);
+
+      var snippetSpan = document.createElement('span');
+      snippetSpan.className = 'live-wysiwyg-history-branch-snippet';
+      snippetSpan.textContent = _getSnippetForNode(child);
+      item.appendChild(snippetSpan);
+
+      var timeSpan = document.createElement('span');
+      timeSpan.className = 'live-wysiwyg-history-branch-time';
+      timeSpan.textContent = _formatRelativeTime(child.timestamp);
+      item.appendChild(timeSpan);
+
+      list.appendChild(item);
+    }
+    if (!hasRedo) {
+      activeIdx = 0;
+    }
+
+    var showAllItem = document.createElement('div');
+    showAllItem.className = 'live-wysiwyg-history-branch-item show-all-history';
+    showAllItem.setAttribute('data-child-id', 'show-all');
+    var showAllIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    showAllIcon.setAttribute('width', '14');
+    showAllIcon.setAttribute('height', '14');
+    showAllIcon.setAttribute('viewBox', '0 0 14 14');
+    showAllIcon.style.verticalAlign = 'middle';
+    showAllIcon.style.marginRight = '6px';
+    showAllIcon.style.flexShrink = '0';
+    var iconPath1 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    iconPath1.setAttribute('d', 'M1 5 L1 1 L5 1');
+    iconPath1.setAttribute('stroke', 'currentColor');
+    iconPath1.setAttribute('stroke-width', '1.5');
+    iconPath1.setAttribute('fill', 'none');
+    iconPath1.setAttribute('stroke-linecap', 'round');
+    iconPath1.setAttribute('stroke-linejoin', 'round');
+    var iconPath2 = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    iconPath2.setAttribute('d', 'M13 9 L13 13 L9 13');
+    iconPath2.setAttribute('stroke', 'currentColor');
+    iconPath2.setAttribute('stroke-width', '1.5');
+    iconPath2.setAttribute('fill', 'none');
+    iconPath2.setAttribute('stroke-linecap', 'round');
+    iconPath2.setAttribute('stroke-linejoin', 'round');
+    var iconLine1 = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    iconLine1.setAttribute('x1', '1'); iconLine1.setAttribute('y1', '1');
+    iconLine1.setAttribute('x2', '7'); iconLine1.setAttribute('y2', '7');
+    iconLine1.setAttribute('stroke', 'currentColor');
+    iconLine1.setAttribute('stroke-width', '1.5');
+    iconLine1.setAttribute('stroke-linecap', 'round');
+    var iconLine2 = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    iconLine2.setAttribute('x1', '13'); iconLine2.setAttribute('y1', '13');
+    iconLine2.setAttribute('x2', '7'); iconLine2.setAttribute('y2', '7');
+    iconLine2.setAttribute('stroke', 'currentColor');
+    iconLine2.setAttribute('stroke-width', '1.5');
+    iconLine2.setAttribute('stroke-linecap', 'round');
+    showAllIcon.appendChild(iconPath1);
+    showAllIcon.appendChild(iconPath2);
+    showAllIcon.appendChild(iconLine1);
+    showAllIcon.appendChild(iconLine2);
+    var showAllLabel = document.createElement('span');
+    showAllLabel.className = 'live-wysiwyg-history-branch-summary';
+    showAllLabel.appendChild(showAllIcon);
+    showAllLabel.appendChild(document.createTextNode('Show All Redo History'));
+    showAllItem.appendChild(showAllLabel);
+    list.appendChild(showAllItem);
+
+    popup.appendChild(list);
+
+    _historyBranchPopupNodeId = branchNodeId;
+    _historyBranchPopupHighlight = activeIdx;
+
+    var caretRect = null;
+    var sel = window.getSelection();
+    if (sel && sel.rangeCount > 0) {
+      var rng = sel.getRangeAt(0);
+      caretRect = rng.getBoundingClientRect();
+      if (caretRect.width === 0 && caretRect.height === 0) caretRect = null;
+    }
+    var popupW = 380;
+    var popupH = 260;
+    var posLeft, posTop;
+    if (caretRect) {
+      posLeft = caretRect.right + 12;
+      posTop = caretRect.top - 20;
+    } else {
+      var editorRect = (wysiwygEditor && wysiwygEditor.editableArea)
+        ? wysiwygEditor.editableArea.getBoundingClientRect()
+        : { top: 100, right: window.innerWidth - 20 };
+      posLeft = editorRect.right - popupW;
+      posTop = editorRect.top;
+    }
+    if (posLeft + popupW > window.innerWidth - 8) posLeft = window.innerWidth - popupW - 8;
+    if (posLeft < 8) posLeft = 8;
+    if (posTop + popupH > window.innerHeight - 8) posTop = window.innerHeight - popupH - 8;
+    if (posTop < 8) posTop = 8;
+    popup.style.position = 'fixed';
+    popup.style.left = posLeft + 'px';
+    popup.style.top = posTop + 'px';
+    popup.style.zIndex = '99999';
+
+    var appendTarget = _focusOverlay || document.body;
+    appendTarget.appendChild(popup);
+    _historyBranchPopup = popup;
+
+    _updateBranchPopupHighlight();
+
+    popup.addEventListener('keydown', function (e) {
+      if ((e.key === 'z' || e.key === 'y') && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        _dismissHistoryBranchPopup();
+        if (e.key === 'y' || e.shiftKey) {
+          _contentRedo();
+        } else {
+          _contentUndo();
+        }
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        var items = list.querySelectorAll('.live-wysiwyg-history-branch-item');
+        _historyBranchPopupHighlight = Math.min(_historyBranchPopupHighlight + 1, items.length - 1);
+        _updateBranchPopupHighlight();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        _historyBranchPopupHighlight = Math.max(_historyBranchPopupHighlight - 1, 0);
+        _updateBranchPopupHighlight();
+      } else if (e.key === 'Tab' || e.key === 'Enter') {
+        e.preventDefault();
+        _confirmBranchPopupSelection();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        _dismissHistoryBranchPopup();
+      }
+    });
+
+    list.addEventListener('click', function (e) {
+      var item = e.target.closest('.live-wysiwyg-history-branch-item');
+      if (!item) return;
+      var items = list.querySelectorAll('.live-wysiwyg-history-branch-item');
+      for (var j = 0; j < items.length; j++) {
+        if (items[j] === item) { _historyBranchPopupHighlight = j; break; }
+      }
+      _updateBranchPopupHighlight();
+      _confirmBranchPopupSelection();
+    });
+
+    var docHandler = function (ev) {
+      if (popup.contains(ev.target)) return;
+      _dismissHistoryBranchPopup();
+    };
+    popup._docHandler = docHandler;
+    document.addEventListener('mousedown', docHandler, true);
+
+    popup.focus();
+  }
+
+  function _updateBranchPopupHighlight() {
+    if (!_historyBranchPopup) return;
+    var items = _historyBranchPopup.querySelectorAll('.live-wysiwyg-history-branch-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('highlighted', i === _historyBranchPopupHighlight);
+    }
+  }
+
+  function _resetBranchPopupTimer() {
+    // No-op: popup persists until typing or explicit dismiss
+  }
+
+  function _confirmBranchPopupSelection() {
+    if (!_historyBranchPopup || _historyBranchPopupNodeId === null) return;
+    var items = _historyBranchPopup.querySelectorAll('.live-wysiwyg-history-branch-item');
+    var selectedItem = items[_historyBranchPopupHighlight];
+    if (!selectedItem) { _dismissHistoryBranchPopup(); return; }
+    if (selectedItem.classList.contains('show-all-history')) {
+      _dismissHistoryBranchPopup();
+      _enterHistoryMode();
+      return;
+    }
+    var node = _historyNodes[_historyBranchPopupNodeId];
+    if (!node) { _dismissHistoryBranchPopup(); return; }
+    var selectedChildId = parseInt(selectedItem.getAttribute('data-child-id'), 10);
+    if (selectedChildId === node.activeChildId) {
+      _dismissHistoryBranchPopup();
+      return;
+    }
+    _contentUndo();
+    _switchHistoryBranch(_historyBranchPopupNodeId, selectedChildId);
+    _dismissHistoryBranchPopup();
+    _contentRedo();
+  }
+
+  // --- Way 2: History Mode — Full-Screen Document History Overlay (Layer 4) ---
+
+  function _enterHistoryMode() {
+    if (_historyModeActive) return;
+    if (_mermaidModeActive) return;
+    _historyModeActive = true;
+    _historyPreviewCache = {};
+    _historyDagSelectedNodeId = null;
+    _historyDagExpandedGroups = {};
+    _historyDagActiveBranchKey = null;
+    _historyDagVtreeSelectedBranch = {};
+    _historyDagAnimatingGroup = null;
+    _historyDagViewMode = 'detailed';
+    _buildHistoryOverlay();
+  }
+
+  function _exitHistoryMode() {
+    if (!_historyModeActive) return;
+    _historyModeActive = false;
+    _dismissHistoryFullsizePreview();
+    if (_historyOverlay && _historyOverlay.parentNode) {
+      _historyOverlay.parentNode.removeChild(_historyOverlay);
+    }
+    _historyOverlay = null;
+    _historyDagSelectedNodeId = null;
+    _historyPreviewCache = {};
+  }
+
+  function _buildHistoryOverlay() {
+    if (_historyOverlay) _exitHistoryMode();
+
+    var overlay = document.createElement('div');
+    overlay.className = 'live-wysiwyg-history-overlay';
+    overlay.setAttribute('tabindex', '-1');
+
+    var backdrop = document.createElement('div');
+    backdrop.className = 'live-wysiwyg-history-backdrop';
+    backdrop.addEventListener('click', function () { _exitHistoryMode(); });
+    overlay.appendChild(backdrop);
+
+    var modal = document.createElement('div');
+    modal.className = 'live-wysiwyg-history-modal';
+
+    var modalHeader = document.createElement('div');
+    modalHeader.className = 'live-wysiwyg-history-modal-header';
+    var title = document.createElement('h2');
+    title.textContent = 'Document History';
+    modalHeader.appendChild(title);
+    var toggleBtn = document.createElement('button');
+    toggleBtn.className = 'live-wysiwyg-history-toggle-view-btn';
+    toggleBtn.textContent = _historyDagViewMode === 'organic' ? 'Detailed View' : 'Tree View';
+    toggleBtn.title = 'Switch between detailed and compact tree view';
+    toggleBtn.addEventListener('click', function () {
+      _historyDagViewMode = _historyDagViewMode === 'organic' ? 'detailed' : 'organic';
+      toggleBtn.textContent = _historyDagViewMode === 'organic' ? 'Detailed View' : 'Tree View';
+      var dagC = modal.querySelector('.live-wysiwyg-history-dag-container');
+      if (dagC) {
+        dagC.classList.add('live-wysiwyg-dag-transitioning');
+        _renderDag(dagC);
+        setTimeout(function () { dagC.classList.remove('live-wysiwyg-dag-transitioning'); }, 350);
+      }
+    });
+    modalHeader.appendChild(toggleBtn);
+
+    var closeBtn = document.createElement('button');
+    closeBtn.className = 'live-wysiwyg-history-close-btn';
+    closeBtn.textContent = '\u00D7';
+    closeBtn.title = 'Close';
+    closeBtn.addEventListener('click', function () { _exitHistoryMode(); });
+    modalHeader.appendChild(closeBtn);
+    modal.appendChild(modalHeader);
+
+    var body = document.createElement('div');
+    body.className = 'live-wysiwyg-history-modal-body';
+
+    var dagContainer = document.createElement('div');
+    dagContainer.className = 'live-wysiwyg-history-dag-container';
+    body.appendChild(dagContainer);
+
+    var previewPanel = document.createElement('div');
+    previewPanel.className = 'live-wysiwyg-history-preview-panel';
+    body.appendChild(previewPanel);
+
+    modal.appendChild(body);
+    overlay.appendChild(modal);
+
+    var appendTarget = _focusOverlay || document.body;
+    appendTarget.appendChild(overlay);
+    _historyOverlay = overlay;
+
+    _renderDag(dagContainer);
+    _attachHistoryOverlayKeyboard(overlay);
+    overlay.focus();
+  }
+
+  // --- Container Detection & Grouping ---
+
+  function _detectEditContainer(lines, diff) {
+    if (!lines || !diff || !diff.ops || diff.ops.length === 0) return [];
+    var editStart = Infinity, editEnd = -1;
+    for (var i = 0; i < diff.ops.length; i++) {
+      var op = diff.ops[i];
+      var opLine = op.type === 'insert' ? (op.afterLine != null ? op.afterLine : 0) : (op.line || 0);
+      if (opLine < editStart) editStart = opLine;
+      var opEnd = opLine;
+      if (op.type === 'replace') opEnd = opLine + Math.max(op.count, op['new'].length) - 1;
+      else if (op.type === 'insert') opEnd = opLine + op.lines.length - 1;
+      else if (op.type === 'delete') opEnd = opLine + op.count - 1;
+      if (opEnd > editEnd) editEnd = opEnd;
+    }
+    if (editStart === Infinity) return [];
+
+    var containers = [];
+    var inFence = false, fenceStart = -1, fenceLang = '';
+    var listStack = [];
+    var admonitionStack = [];
+    var blockquoteStart = -1, blockquoteActive = false;
+
+    for (var L = 0; L < lines.length; L++) {
+      var ln = lines[L];
+      if (/^(`{3,}|~{3,})/.test(ln) && !inFence) {
+        inFence = true;
+        fenceStart = L;
+        fenceLang = ln.replace(/^(`{3,}|~{3,})\s*/, '').split(/\s/)[0] || '';
+        continue;
+      }
+      if (inFence && /^(`{3,}|~{3,})\s*$/.test(ln)) {
+        if (editStart <= L && editEnd >= fenceStart) {
+          var label = fenceLang === 'mermaid' ? 'mermaid diagram'
+            : fenceLang ? fenceLang + ' code block' : 'code block';
+          containers.push({ type: 'code', lang: fenceLang, label: label, startLine: fenceStart, endLine: L });
+        }
+        inFence = false;
+        fenceStart = -1;
+        fenceLang = '';
+        continue;
+      }
+      if (inFence) continue;
+
+      if (/^(!{3}|\?{3}\+?)\s/.test(ln)) {
+        var admType = ln.replace(/^(?:!{3}|\?{3}\+?)\s+/, '').split(/\s/)[0] || 'note';
+        var admEnd = L;
+        for (var aL = L + 1; aL < lines.length; aL++) {
+          if (/^\S/.test(lines[aL]) && !/^\s/.test(lines[aL])) break;
+          if (lines[aL].trim() === '' && aL + 1 < lines.length && /^\S/.test(lines[aL + 1]) && !/^\s/.test(lines[aL + 1])) {
+            admEnd = aL;
+            break;
+          }
+          admEnd = aL;
+        }
+        if (editStart <= admEnd && editEnd >= L) {
+          containers.push({ type: 'admonition', label: admType + ' admonition', startLine: L, endLine: admEnd });
+        }
+      }
+
+      if (/^>\s/.test(ln)) {
+        if (!blockquoteActive) {
+          blockquoteStart = L;
+          blockquoteActive = true;
+        }
+      } else if (blockquoteActive) {
+        var bqEnd = L - 1;
+        if (editStart <= bqEnd && editEnd >= blockquoteStart) {
+          containers.push({ type: 'blockquote', label: 'blockquote', startLine: blockquoteStart, endLine: bqEnd });
+        }
+        blockquoteActive = false;
+      }
+
+      if (/^(\s*[-*+]|\s*\d+\.)\s/.test(ln)) {
+        if (listStack.length === 0 || L > listStack[listStack.length - 1].end + 1) {
+          listStack.push({ start: L, end: L });
+        } else {
+          listStack[listStack.length - 1].end = L;
+        }
+      } else if (listStack.length > 0 && ln.trim() !== '') {
+        if (!/^\s/.test(ln)) {
+          var lst = listStack[listStack.length - 1];
+          if (editStart <= lst.end && editEnd >= lst.start) {
+            containers.push({ type: 'list', label: 'list', startLine: lst.start, endLine: lst.end });
+          }
+          listStack = [];
+        } else if (listStack.length > 0) {
+          listStack[listStack.length - 1].end = L;
+        }
+      }
+    }
+
+    if (blockquoteActive) {
+      var finalBqEnd = lines.length - 1;
+      if (editStart <= finalBqEnd && editEnd >= blockquoteStart) {
+        containers.push({ type: 'blockquote', label: 'blockquote', startLine: blockquoteStart, endLine: finalBqEnd });
+      }
+    }
+    if (inFence) {
+      if (editStart <= lines.length - 1 && editEnd >= fenceStart) {
+        var pendingLabel = fenceLang === 'mermaid' ? 'mermaid diagram'
+          : fenceLang ? fenceLang + ' code block' : 'code block';
+        containers.push({ type: 'code', lang: fenceLang, label: pendingLabel, startLine: fenceStart, endLine: lines.length - 1 });
+      }
+    }
+    for (var ls = 0; ls < listStack.length; ls++) {
+      var lItem = listStack[ls];
+      if (editStart <= lItem.end && editEnd >= lItem.start) {
+        containers.push({ type: 'list', label: 'list', startLine: lItem.start, endLine: lItem.end });
+      }
+    }
+
+    containers.sort(function (a, b) { return (a.startLine - b.startLine) || (b.endLine - a.endLine); });
+    return containers;
+  }
+
+  function _computeContainerGroups(pathNodeIds) {
+    if (!pathNodeIds || pathNodeIds.length === 0) return [];
+    var result = [];
+    var currentLines = _historyRootMd ? _historyRootMd.split('\n') : [];
+
+    var pending = null;
+
+    for (var i = 0; i < pathNodeIds.length; i++) {
+      var nid = pathNodeIds[i];
+      var node = _historyNodes[nid];
+      if (!node) {
+        if (pending) { result.push(pending); pending = null; }
+        result.push({ type: null, label: null, nodeIds: [nid] });
+        continue;
+      }
+      if (node.parentId === null) {
+        if (pending) { result.push(pending); pending = null; }
+        result.push({ type: null, label: null, nodeIds: [nid] });
+        if (node.diff) currentLines = _applyDiff(currentLines, node.diff);
+        continue;
+      }
+
+      var containers = [];
+      if (node.diff) {
+        containers = _detectEditContainer(currentLines, node.diff);
+      }
+
+      var innermost = containers.length > 0 ? containers[containers.length - 1] : null;
+      var containerKey = innermost ? (innermost.type + ':' + innermost.startLine) : null;
+
+      var keyMatch = false;
+      if (pending && containerKey && pending.type === innermost.type) {
+        var prevStart = parseInt(pending.key.split(':')[1], 10);
+        keyMatch = Math.abs(innermost.startLine - prevStart) <= 5;
+      }
+
+      if (pending && keyMatch) {
+        pending.nodeIds.push(nid);
+        pending.containers = containers;
+        pending.key = containerKey;
+      } else {
+        if (pending) result.push(pending);
+        if (containerKey) {
+          pending = {
+            type: innermost.type,
+            label: innermost.label,
+            key: containerKey,
+            nodeIds: [nid],
+            containers: containers
+          };
+        } else {
+          pending = null;
+          result.push({ type: null, label: null, nodeIds: [nid] });
+        }
+      }
+
+      if (node.diff) currentLines = _applyDiff(currentLines, node.diff);
+    }
+    if (pending) result.push(pending);
+
+    return result;
+  }
+
+  // --- DAG SVG Helpers ---
+
+  function _createCrumpleSvg() {
+    var ns = 'http://www.w3.org/2000/svg';
+    var svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('width', '40');
+    svg.setAttribute('height', '14');
+    svg.setAttribute('viewBox', '0 0 40 14');
+    svg.setAttribute('class', 'live-wysiwyg-dag-crumple-svg');
+    var p = document.createElementNS(ns, 'path');
+    p.setAttribute('d', 'M1 7 L6 2 L12 12 L18 2 L24 12 L30 2 L35 7 L39 7');
+    p.setAttribute('stroke', 'currentColor');
+    p.setAttribute('stroke-width', '2');
+    p.setAttribute('stroke-linecap', 'round');
+    p.setAttribute('stroke-linejoin', 'round');
+    p.setAttribute('fill', 'none');
+    svg.appendChild(p);
+    return svg;
+  }
+
+  function _createVtreeForkSvg() {
+    var ns = 'http://www.w3.org/2000/svg';
+    var svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('width', '22');
+    svg.setAttribute('height', '20');
+    svg.setAttribute('viewBox', '0 0 22 20');
+    svg.setAttribute('class', 'live-wysiwyg-dag-vtree-svg');
+    var makeArrow = function (d) {
+      var p = document.createElementNS(ns, 'path');
+      p.setAttribute('d', d);
+      p.setAttribute('stroke', 'currentColor');
+      p.setAttribute('stroke-width', '1.5');
+      p.setAttribute('stroke-linecap', 'round');
+      p.setAttribute('stroke-dasharray', '3 2');
+      p.setAttribute('fill', 'none');
+      return p;
+    };
+    svg.appendChild(makeArrow('M1 10 L18 10'));
+    svg.appendChild(makeArrow('M1 10 L14 3'));
+    svg.appendChild(makeArrow('M1 10 L14 17'));
+    var makeHead = function (x, y, angle) {
+      var head = document.createElementNS(ns, 'path');
+      var rad = angle * Math.PI / 180;
+      var dx1 = -5 * Math.cos(rad) - 3 * Math.sin(rad);
+      var dy1 = -5 * Math.sin(rad) + 3 * Math.cos(rad);
+      var dx2 = -5 * Math.cos(rad) + 3 * Math.sin(rad);
+      var dy2 = -5 * Math.sin(rad) - 3 * Math.cos(rad);
+      head.setAttribute('d', 'M' + (x + dx1) + ' ' + (y + dy1) + ' L' + x + ' ' + y + ' L' + (x + dx2) + ' ' + (y + dy2));
+      head.setAttribute('stroke', 'currentColor');
+      head.setAttribute('stroke-width', '1.5');
+      head.setAttribute('stroke-linecap', 'round');
+      head.setAttribute('stroke-linejoin', 'round');
+      head.setAttribute('fill', 'none');
+      return head;
+    };
+    svg.appendChild(makeHead(18, 10, 0));
+    svg.appendChild(makeHead(14, 3, -28));
+    svg.appendChild(makeHead(14, 17, 28));
+    return svg;
+  }
+
+  // --- DAG Layout Algorithm ---
+
+  function _countSubtreeNodes(nodeId) {
+    var node = _historyNodes[nodeId];
+    if (!node) return 0;
+    var count = 1;
+    for (var i = 0; i < node.children.length; i++) {
+      count += _countSubtreeNodes(node.children[i]);
+    }
+    return count;
+  }
+
+  function _computeDagLayout() {
+    var rootId = null;
+    var ids = Object.keys(_historyNodes);
+    for (var i = 0; i < ids.length; i++) {
+      var n = _historyNodes[ids[i]];
+      if (n.parentId === null) { rootId = n.id; break; }
+    }
+    if (rootId === null) return { nodes: [], edges: [], width: 0, height: 0, groups: [] };
+
+    var NODE_W = 300;
+    var NODE_H = 60;
+    var CRUMPLE_H = 40;
+    var H_GAP = 28;
+    var V_GAP = 20;
+
+    // === PHASE 1: Full tree layout (bottom-to-top) ===
+
+    // 1a. Build active path: root → current → latest active leaf
+    // First, find path from root to _historyCurrentId
+    var rootToCurrent = [];
+    var walkBack = _historyCurrentId;
+    while (walkBack !== null && _historyNodes[walkBack]) {
+      rootToCurrent.push(walkBack);
+      walkBack = _historyNodes[walkBack].parentId;
+    }
+    rootToCurrent.reverse();
+
+    // Then extend forward from current via activeChildId
+    var activePath = {};
+    var activePathList = rootToCurrent.slice();
+    for (var rtc = 0; rtc < rootToCurrent.length; rtc++) {
+      activePath[rootToCurrent[rtc]] = true;
+    }
+    var fwdId = _historyCurrentId;
+    if (_historyNodes[fwdId]) {
+      fwdId = _historyNodes[fwdId].activeChildId || null;
+    }
+    while (fwdId !== null && _historyNodes[fwdId]) {
+      if (!activePath[fwdId]) {
+        activePath[fwdId] = true;
+        activePathList.push(fwdId);
+      }
+      fwdId = _historyNodes[fwdId].activeChildId || null;
+    }
+
+    // 1b. Assign rows to active path: root=row 0 (bottom), latest leaf=highest row (top)
+    var activeLen = activePathList.length;
+    var fullPositions = {};
+    for (var ap = 0; ap < activeLen; ap++) {
+      fullPositions[activePathList[ap]] = { col: 0, row: ap };
+    }
+
+    // 1c. Lay out all branch subtrees vertically
+    var maxCol = { val: 0 };
+    var colOccupied = {};
+    for (var apb = 0; apb < activeLen; apb++) {
+      var bpNode = _historyNodes[activePathList[apb]];
+      if (!bpNode) continue;
+      var nonActiveKids = [];
+      for (var bc = 0; bc < bpNode.children.length; bc++) {
+        if (!activePath[bpNode.children[bc]]) nonActiveKids.push(bpNode.children[bc]);
+      }
+      if (nonActiveKids.length === 0) continue;
+      var forkRow = fullPositions[activePathList[apb]].row;
+      for (var nk = 0; nk < nonActiveKids.length; nk++) {
+        _layoutBranchVertical(nonActiveKids[nk], 1, forkRow, fullPositions, maxCol, colOccupied);
+      }
+    }
+
+    // === PHASE 2: Crumple zones (overlay on full tree) ===
+
+    var groups = _computeContainerGroups(activePathList);
+    var hiddenByZone = {};
+    var crumpleZones = [];
+    for (var gi = 0; gi < groups.length; gi++) {
+      var grp = groups[gi];
+      if (!grp.type || grp.nodeIds.length < 2) continue;
+      var groupKey = 'g-' + grp.nodeIds[0];
+      var groupExpanded = !!_historyDagExpandedGroups[groupKey];
+      if (!groupExpanded) {
+        crumpleZones.push({
+          key: groupKey, type: grp.type, label: grp.label,
+          nodeIds: grp.nodeIds, repId: grp.nodeIds[0]
+        });
+        for (var gh = 1; gh < grp.nodeIds.length; gh++) {
+          hiddenByZone[grp.nodeIds[gh]] = groupKey;
+        }
+      }
+    }
+
+    // Build branch metadata for collapsed branch display
+    var branchMeta = {};
+    for (var apbm = 0; apbm < activeLen; apbm++) {
+      var bmNode = _historyNodes[activePathList[apbm]];
+      if (!bmNode) continue;
+      for (var bmc = 0; bmc < bmNode.children.length; bmc++) {
+        var bmChildId = bmNode.children[bmc];
+        if (!activePath[bmChildId]) {
+          branchMeta[activePathList[apbm] + '-' + bmChildId] = {
+            parentId: activePathList[apbm],
+            childId: bmChildId,
+            subtreeCount: _countSubtreeNodes(bmChildId)
+          };
+        }
+      }
+    }
+
+    // Build synthetic nodes for collapsed branches
+    var syntheticId = -100;
+    var syntheticNodes = {};
+    var branchPoints = [];
+
+    for (var apbp = 0; apbp < activeLen; apbp++) {
+      var bpNd = _historyNodes[activePathList[apbp]];
+      if (!bpNd || bpNd.children.length <= 1) continue;
+      var nacList = [];
+      for (var nac = 0; nac < bpNd.children.length; nac++) {
+        if (!activePath[bpNd.children[nac]]) nacList.push(bpNd.children[nac]);
+      }
+      if (nacList.length === 0) continue;
+      var bpKey = 'bp-' + activePathList[apbp];
+      var parentRow = fullPositions[activePathList[apbp]].row;
+      branchPoints.push({
+        parentId: activePathList[apbp], parentRow: parentRow,
+        children: nacList, isVtree: nacList.length >= 2, bpKey: bpKey
+      });
+    }
+
+    // Determine visible rows for compact rendering
+    var visibleRows = {};
+    for (var vap = 0; vap < activeLen; vap++) {
+      var vapId = activePathList[vap];
+      if (!hiddenByZone[vapId]) {
+        visibleRows[fullPositions[vapId].row] = true;
+      }
+    }
+    for (var vz = 0; vz < crumpleZones.length; vz++) {
+      visibleRows[fullPositions[crumpleZones[vz].repId].row] = true;
+    }
+
+    // For expanded branches, mark their rows visible
+    for (var bpi = 0; bpi < branchPoints.length; bpi++) {
+      var bpInfo = branchPoints[bpi];
+      var isExpanded = false;
+      if (bpInfo.isVtree) {
+        if (_historyDagActiveBranchKey === bpInfo.bpKey) isExpanded = true;
+      } else {
+        var sKey = bpInfo.parentId + '-' + bpInfo.children[0];
+        if (_historyDagActiveBranchKey === sKey) isExpanded = true;
+      }
+      if (isExpanded) {
+        var expandChild = bpInfo.isVtree
+          ? (_historyDagVtreeSelectedBranch[bpInfo.bpKey] || null)
+          : bpInfo.children[0];
+        if (expandChild && fullPositions[expandChild]) {
+          var stack = [expandChild];
+          while (stack.length > 0) {
+            var sid = stack.pop();
+            if (fullPositions[sid]) visibleRows[fullPositions[sid].row] = true;
+            var snd = _historyNodes[sid];
+            if (snd) {
+              for (var sc = 0; sc < snd.children.length; sc++) stack.push(snd.children[sc]);
+            }
+          }
+        }
+      }
+    }
+
+    // Also mark synthetic node rows and vtree option rows
+    for (var bpi2 = 0; bpi2 < branchPoints.length; bpi2++) {
+      var bp2 = branchPoints[bpi2];
+      visibleRows[bp2.parentRow] = true;
+      if (bp2.isVtree && _historyDagActiveBranchKey === bp2.bpKey && !_historyDagVtreeSelectedBranch[bp2.bpKey]) {
+        for (var vopt = 0; vopt < bp2.children.length; vopt++) {
+          visibleRows[bp2.parentRow + vopt + 1] = true;
+        }
+      }
+    }
+
+    // Compact row mapping: map full rows to compact sequential rows, skipping hidden
+    var allRows = Object.keys(visibleRows).map(Number).sort(function (a, b) { return a - b; });
+    var compactMap = {};
+    for (var cr = 0; cr < allRows.length; cr++) {
+      compactMap[allRows[cr]] = cr;
+    }
+    var totalCompactRows = allRows.length;
+
+    // Build synthetic positioned nodes
+    for (var bps = 0; bps < branchPoints.length; bps++) {
+      var bpsInfo = branchPoints[bps];
+      var synRow2 = bpsInfo.parentRow;
+      if (bpsInfo.isVtree) {
+        var vtreeId = syntheticId--;
+        syntheticNodes[vtreeId] = {
+          isVtreeFork: true,
+          vtreeParentId: bpsInfo.parentId,
+          vtreeChildIds: bpsInfo.children,
+          vtreeBpKey: bpsInfo.bpKey
+        };
+        fullPositions[vtreeId] = { col: 1, row: synRow2 };
+        if (1 > maxCol.val) maxCol.val = 1;
+
+        var selectedChildId = _historyDagVtreeSelectedBranch[bpsInfo.bpKey] || null;
+        var isThisActive = (_historyDagActiveBranchKey === bpsInfo.bpKey);
+        if (isThisActive && !selectedChildId) {
+          for (var vci = 0; vci < bpsInfo.children.length; vci++) {
+            var pickerId = syntheticId--;
+            syntheticNodes[pickerId] = {
+              isVtreeOption: true,
+              vtreeBpKey: bpsInfo.bpKey,
+              optionChildId: bpsInfo.children[vci],
+              optionSummary: _historyNodes[bpsInfo.children[vci]]
+                ? (_historyNodes[bpsInfo.children[vci]].summary || 'edit')
+                : 'edit',
+              optionCount: branchMeta[bpsInfo.parentId + '-' + bpsInfo.children[vci]]
+                ? branchMeta[bpsInfo.parentId + '-' + bpsInfo.children[vci]].subtreeCount
+                : 1
+            };
+            fullPositions[pickerId] = { col: 2, row: synRow2 + vci + 1 };
+            if (2 > maxCol.val) maxCol.val = 2;
+          }
+        }
+      } else {
+        var brChild = bpsInfo.children[0];
+        var singleKey = bpsInfo.parentId + '-' + brChild;
+        var singleId = syntheticId--;
+        syntheticNodes[singleId] = {
+          isBranchCrumple: true,
+          branchKey: singleKey,
+          branchChildId: brChild,
+          branchCount: branchMeta[singleKey] ? branchMeta[singleKey].subtreeCount : 1
+        };
+        fullPositions[singleId] = { col: 1, row: synRow2 };
+        if (1 > maxCol.val) maxCol.val = 1;
+      }
+    }
+
+    // === PHASE 3: Build layout nodes and edges ===
+
+    var layoutNodes = [];
+    var edges = [];
+    var posKeys = Object.keys(fullPositions);
+
+    for (var p = 0; p < posKeys.length; p++) {
+      var lnid = parseInt(posKeys[p], 10);
+      var pos = fullPositions[lnid];
+      var nd = _historyNodes[lnid];
+      var syn = syntheticNodes[lnid] || null;
+      var isOnActive = !!activePath[lnid];
+      var isHidden = !!hiddenByZone[lnid];
+
+      // Check if this branch node is in an expanded branch
+      var isBranchNodeVisible = false;
+      if (!isOnActive && nd && !syn) {
+        for (var ebp = 0; ebp < branchPoints.length; ebp++) {
+          var ebInfo = branchPoints[ebp];
+          var ebExpanded = false;
+          var ebChildRoot = null;
+          if (ebInfo.isVtree) {
+            if (_historyDagActiveBranchKey === ebInfo.bpKey) {
+              ebChildRoot = _historyDagVtreeSelectedBranch[ebInfo.bpKey] || null;
+              ebExpanded = !!ebChildRoot;
+            }
+          } else {
+            var ebKey = ebInfo.parentId + '-' + ebInfo.children[0];
+            if (_historyDagActiveBranchKey === ebKey) {
+              ebChildRoot = ebInfo.children[0];
+              ebExpanded = true;
+            }
+          }
+          if (ebExpanded && ebChildRoot) {
+            var checkStack = [ebChildRoot];
+            while (checkStack.length > 0) {
+              var checkId = checkStack.pop();
+              if (checkId === lnid) { isBranchNodeVisible = true; break; }
+              var checkNd = _historyNodes[checkId];
+              if (checkNd) {
+                for (var csc = 0; csc < checkNd.children.length; csc++) checkStack.push(checkNd.children[csc]);
+              }
+            }
+            if (isBranchNodeVisible) break;
+          }
+        }
+      }
+
+      var skipRender = isHidden || (!isOnActive && !syn && !isBranchNodeVisible);
+      if (skipRender && !syn) continue;
+
+      var compactRow = compactMap[pos.row];
+      if (compactRow === undefined) compactRow = pos.row;
+      var displayRow = totalCompactRows - 1 - compactRow;
+
+      var isCrumpleNode = false;
+      var crInfo = null;
+      for (var czi = 0; czi < crumpleZones.length; czi++) {
+        if (crumpleZones[czi].repId === lnid) {
+          isCrumpleNode = true;
+          crInfo = crumpleZones[czi];
+          break;
+        }
+      }
+
+      var nodeH = (isCrumpleNode || (syn && (syn.isBranchCrumple || syn.isVtreeFork || syn.isVtreeOption))) ? CRUMPLE_H : NODE_H;
+
+      layoutNodes.push({
+        id: lnid,
+        x: pos.col * (NODE_W + H_GAP) + NODE_W / 2,
+        y: displayRow * (NODE_H + V_GAP) + NODE_H / 2,
+        row: pos.row,
+        displayRow: displayRow,
+        col: pos.col,
+        onActivePath: isOnActive,
+        isCurrent: lnid === _historyCurrentId,
+        isBranch: (nd && nd.children.length > 1),
+        isCrumple: isCrumpleNode,
+        crumpleKey: crInfo ? crInfo.key : null,
+        crumpleType: crInfo ? crInfo.type : null,
+        crumpleLabel: crInfo ? crInfo.label : null,
+        crumpleCount: crInfo ? crInfo.nodeIds.length : 0,
+        crumpleNodeIds: crInfo ? crInfo.nodeIds : null,
+        isVtreeFork: syn ? !!syn.isVtreeFork : false,
+        vtreeParentId: syn ? syn.vtreeParentId || null : null,
+        vtreeChildIds: syn ? syn.vtreeChildIds || null : null,
+        vtreeBpKey: syn ? syn.vtreeBpKey || null : null,
+        isVtreeOption: syn ? !!syn.isVtreeOption : false,
+        optionChildId: syn ? syn.optionChildId || null : null,
+        optionSummary: syn ? syn.optionSummary || null : null,
+        optionCount: syn ? syn.optionCount || 0 : 0,
+        isBranchCrumple: syn ? !!syn.isBranchCrumple : false,
+        branchKey: syn ? syn.branchKey || null : null,
+        branchChildId: syn ? syn.branchChildId || null : null,
+        branchCount: syn ? syn.branchCount || 0 : 0,
+        isSynthetic: !!syn
+      });
+    }
+
+    layoutNodes.sort(function (a, b) { return a.displayRow - b.displayRow; });
+
+    // Proper Y positioning with row height awareness
+    var rowMaxH = {};
+    for (var rhi = 0; rhi < layoutNodes.length; rhi++) {
+      var rhLn = layoutNodes[rhi];
+      var rhH = (rhLn.isCrumple || rhLn.isBranchCrumple || rhLn.isVtreeFork || rhLn.isVtreeOption) ? CRUMPLE_H : NODE_H;
+      if (rowMaxH[rhLn.displayRow] === undefined || rhH > rowMaxH[rhLn.displayRow]) {
+        rowMaxH[rhLn.displayRow] = rhH;
+      }
+    }
+    var sortedDisplayRows = Object.keys(rowMaxH).map(Number).sort(function (a, b) { return a - b; });
+    var yAccum = 0;
+    var rowYMap = {};
+    for (var sri = 0; sri < sortedDisplayRows.length; sri++) {
+      var rNum = sortedDisplayRows[sri];
+      var rH = rowMaxH[rNum];
+      if (sri > 0) yAccum += V_GAP;
+      yAccum += rH / 2;
+      rowYMap[rNum] = yAccum;
+      yAccum += rH / 2;
+    }
+    for (var yi = 0; yi < layoutNodes.length; yi++) {
+      var lnY = layoutNodes[yi];
+      lnY.y = rowYMap[lnY.displayRow] !== undefined ? rowYMap[lnY.displayRow] : lnY.y;
+    }
+
+    // Build lookup for edge drawing
+    var lnById = {};
+    for (var lni = 0; lni < layoutNodes.length; lni++) {
+      lnById[layoutNodes[lni].id] = layoutNodes[lni];
+    }
+
+    // Draw edges between visible parent-child pairs (children are above parents)
+    for (var ei = 0; ei < layoutNodes.length; ei++) {
+      var eln = layoutNodes[ei];
+      var eNd = _historyNodes[eln.id];
+      if (!eNd) continue;
+      for (var eci = 0; eci < eNd.children.length; eci++) {
+        var childLn = lnById[eNd.children[eci]];
+        if (!childLn) continue;
+        var yOff1 = (eln.isCrumple || eln.isBranchCrumple) ? 14 : 18;
+        var yOff2 = (childLn.isCrumple || childLn.isBranchCrumple) ? 14 : 18;
+        edges.push({
+          x1: eln.x, y1: eln.y - yOff1,
+          x2: childLn.x, y2: childLn.y + yOff2,
+          active: eln.onActivePath && childLn.onActivePath,
+          collapsed: false
+        });
+      }
+    }
+
+    // Edges from synthetic nodes (upward: synthetic → options/branch children above)
+    for (var sei = 0; sei < layoutNodes.length; sei++) {
+      var seln = layoutNodes[sei];
+      if (seln.isVtreeFork) {
+        for (var voi = 0; voi < layoutNodes.length; voi++) {
+          var voLn = layoutNodes[voi];
+          if (voLn.isVtreeOption && voLn.vtreeBpKey === seln.vtreeBpKey) {
+            edges.push({ x1: seln.x, y1: seln.y - 14, x2: voLn.x, y2: voLn.y + 14, active: false, collapsed: false });
+          }
+        }
+        var vtreeSelChild = _historyDagVtreeSelectedBranch[seln.vtreeBpKey];
+        if (vtreeSelChild && lnById[vtreeSelChild]) {
+          var selLn = lnById[vtreeSelChild];
+          edges.push({ x1: seln.x, y1: seln.y - 14, x2: selLn.x, y2: selLn.y + 18, active: false, collapsed: false });
+        }
+      }
+      if (seln.isBranchCrumple && _historyDagActiveBranchKey === seln.branchKey) {
+        var brFirstLn = lnById[seln.branchChildId];
+        if (brFirstLn) {
+          edges.push({ x1: seln.x, y1: seln.y - 14, x2: brFirstLn.x, y2: brFirstLn.y + 18, active: false, collapsed: false });
+        }
+      }
+    }
+
+    // Edges from active-path fork points to synthetic branch entries
+    for (var bpe = 0; bpe < branchPoints.length; bpe++) {
+      var bpeInfo = branchPoints[bpe];
+      var parentLn = lnById[bpeInfo.parentId];
+      if (!parentLn) {
+        for (var czl = 0; czl < crumpleZones.length; czl++) {
+          for (var czn = 0; czn < crumpleZones[czl].nodeIds.length; czn++) {
+            if (crumpleZones[czl].nodeIds[czn] === bpeInfo.parentId) {
+              parentLn = lnById[crumpleZones[czl].repId];
+              break;
+            }
+          }
+          if (parentLn) break;
+        }
+      }
+      if (!parentLn) continue;
+      var entryLn = null;
+      for (var eli2 = 0; eli2 < layoutNodes.length; eli2++) {
+        var cand = layoutNodes[eli2];
+        if (bpeInfo.isVtree && cand.isVtreeFork && cand.vtreeBpKey === bpeInfo.bpKey) { entryLn = cand; break; }
+        if (!bpeInfo.isVtree && cand.isBranchCrumple && cand.branchKey === (bpeInfo.parentId + '-' + bpeInfo.children[0])) { entryLn = cand; break; }
+      }
+      if (entryLn) {
+        edges.push({ x1: parentLn.x, y1: parentLn.y, x2: entryLn.x, y2: entryLn.y, active: false, collapsed: false });
+      }
+    }
+
+    // Active-path edge continuity through crumple zones
+    var visibleApIds = [];
+    for (var vapi = 0; vapi < activeLen; vapi++) {
+      if (lnById[activePathList[vapi]]) visibleApIds.push(activePathList[vapi]);
+    }
+    for (var vapei = 0; vapei < visibleApIds.length - 1; vapei++) {
+      var vapFrom = visibleApIds[vapei];
+      var vapTo = visibleApIds[vapei + 1];
+      var vapNd = _historyNodes[vapFrom];
+      var isDirect = false;
+      if (vapNd) {
+        for (var vdc = 0; vdc < vapNd.children.length; vdc++) {
+          if (vapNd.children[vdc] === vapTo) { isDirect = true; break; }
+        }
+      }
+      if (isDirect) continue;
+      var fLn = lnById[vapFrom];
+      var tLn = lnById[vapTo];
+      if (fLn && tLn) {
+        var fOff = (fLn.isCrumple || fLn.isBranchCrumple) ? 14 : 18;
+        var tOff = (tLn.isCrumple || tLn.isBranchCrumple) ? 14 : 18;
+        edges.push({ x1: fLn.x, y1: fLn.y - fOff, x2: tLn.x, y2: tLn.y + tOff, active: true, collapsed: false });
+      }
+    }
+
+    var maxY = 0;
+    for (var myi = 0; myi < layoutNodes.length; myi++) {
+      var my = layoutNodes[myi].y + NODE_H / 2;
+      if (my > maxY) maxY = my;
+    }
+    var totalW = (maxCol.val + 1) * (NODE_W + H_GAP);
+    var totalH = maxY + V_GAP;
+
+    return { nodes: layoutNodes, edges: edges, width: totalW, height: totalH, groups: groups };
+  }
+
+  function _layoutBranchVertical(nodeId, preferCol, forkRow, positions, maxCol, colOccupied) {
+    var subtree = [];
+    var stack = [nodeId];
+    while (stack.length > 0) {
+      var sid = stack.pop();
+      var snd = _historyNodes[sid];
+      if (!snd) continue;
+      subtree.push(sid);
+      for (var sc = snd.children.length - 1; sc >= 0; sc--) {
+        stack.push(snd.children[sc]);
+      }
+    }
+    var col = preferCol;
+    var hasCollision = true;
+    while (hasCollision) {
+      hasCollision = false;
+      for (var ci = 0; ci < subtree.length; ci++) {
+        var testRow = forkRow + 1 + ci;
+        var key = col + ':' + testRow;
+        if (colOccupied[key]) { hasCollision = true; break; }
+      }
+      if (hasCollision) col++;
+    }
+    if (col > maxCol.val) maxCol.val = col;
+    for (var pi = 0; pi < subtree.length; pi++) {
+      var r = forkRow + 1 + pi;
+      positions[subtree[pi]] = { col: col, row: r };
+      colOccupied[col + ':' + r] = true;
+    }
+  }
+
+  function _computeYahRoute(startX, startY, layoutNodes, currentNodeId, maxX, maxY) {
+    var PAD = 14;
+    var rects = [];
+    for (var i = 0; i < layoutNodes.length; i++) {
+      var ln = layoutNodes[i];
+      if (ln.id === currentNodeId) continue;
+      var hw = 150;
+      var hh = (ln.isCrumple || ln.isBranchCrumple || ln.isVtreeFork || ln.isVtreeOption) ? 18 : 24;
+      rects.push({ l: ln.x - hw, r: ln.x + hw, t: ln.y - hh, b: ln.y + hh });
+    }
+
+    var endX = Math.max(maxX - 80, startX + 100);
+    var pts = [{ x: startX, y: startY }];
+    var curY = startY;
+
+    var rightRects = [];
+    for (var ri = 0; ri < rects.length; ri++) {
+      if (rects[ri].r > startX && rects[ri].l < endX) rightRects.push(rects[ri]);
+    }
+    rightRects.sort(function (a, b) { return a.l - b.l; });
+
+    for (var oi = 0; oi < rightRects.length; oi++) {
+      var obs = rightRects[oi];
+      if (curY < obs.t - PAD || curY > obs.b + PAD) continue;
+
+      var aboveY = obs.t - PAD - 8;
+      var belowY = obs.b + PAD + 8;
+      var newY;
+      if (aboveY < 10) newY = belowY;
+      else if (belowY > maxY - 10) newY = aboveY;
+      else newY = (Math.abs(curY - aboveY) <= Math.abs(curY - belowY)) ? aboveY : belowY;
+
+      var approachX = Math.max(obs.l - PAD - 20, startX + 10);
+      pts.push({ x: approachX, y: curY });
+      pts.push({ x: (obs.l + obs.r) / 2, y: newY });
+      pts.push({ x: obs.r + PAD + 20, y: newY });
+      curY = newY;
+    }
+
+    pts.push({ x: endX, y: curY });
+    return { points: pts, endY: curY };
+  }
+
+  function _yahPointsToPath(pts) {
+    if (pts.length < 2) return '';
+    var d = 'M' + pts[0].x.toFixed(1) + ' ' + pts[0].y.toFixed(1);
+    for (var i = 1; i < pts.length; i++) {
+      var p = pts[i - 1], c = pts[i];
+      if (Math.abs(p.y - c.y) < 1) {
+        d += ' L' + c.x.toFixed(1) + ' ' + c.y.toFixed(1);
+      } else {
+        var mx = (p.x + c.x) / 2;
+        d += ' C' + mx.toFixed(1) + ' ' + p.y.toFixed(1) + ', ' +
+          mx.toFixed(1) + ' ' + c.y.toFixed(1) + ', ' +
+          c.x.toFixed(1) + ' ' + c.y.toFixed(1);
+      }
+    }
+    return d;
+  }
+
+  function _computeOrganicLayout() {
+    var rootId = null;
+    var ids = Object.keys(_historyNodes);
+    for (var i = 0; i < ids.length; i++) {
+      if (_historyNodes[ids[i]].parentId === null) { rootId = _historyNodes[ids[i]].id; break; }
+    }
+    if (rootId === null) return { nodes: [], edges: [], width: 0, height: 0 };
+
+    var DOT_R = 5;
+    var DOT_GAP = 6;
+    var STEP = DOT_R * 2 + DOT_GAP;
+
+    var rootToCurrent = [];
+    var walkBack = _historyCurrentId;
+    while (walkBack !== null && _historyNodes[walkBack]) {
+      rootToCurrent.push(walkBack);
+      walkBack = _historyNodes[walkBack].parentId;
+    }
+    rootToCurrent.reverse();
+
+    var activePath = {};
+    var activePathList = rootToCurrent.slice();
+    for (var rtc = 0; rtc < rootToCurrent.length; rtc++) {
+      activePath[rootToCurrent[rtc]] = true;
+    }
+    var fwdId = _historyCurrentId;
+    if (_historyNodes[fwdId]) {
+      fwdId = _historyNodes[fwdId].activeChildId || null;
+    }
+    while (fwdId !== null && _historyNodes[fwdId]) {
+      if (!activePath[fwdId]) {
+        activePath[fwdId] = true;
+        activePathList.push(fwdId);
+      }
+      fwdId = _historyNodes[fwdId].activeChildId || null;
+    }
+
+    var positions = {};
+    var allNodes = [];
+    var edges = [];
+    var centerX = 200;
+    var activeLen = activePathList.length;
+
+    for (var ap = 0; ap < activeLen; ap++) {
+      var row = activeLen - 1 - ap;
+      positions[activePathList[ap]] = { x: centerX, y: row * STEP + STEP };
+      allNodes.push(activePathList[ap]);
+    }
+
+    var branchQueue = [];
+    for (var apb = 0; apb < activeLen; apb++) {
+      var bpNode = _historyNodes[activePathList[apb]];
+      if (!bpNode) continue;
+      var leftNext = true;
+      for (var bc = 0; bc < bpNode.children.length; bc++) {
+        if (!activePath[bpNode.children[bc]]) {
+          branchQueue.push({
+            nodeId: bpNode.children[bc],
+            parentPos: positions[activePathList[apb]],
+            side: leftNext ? -1 : 1,
+            depth: 1
+          });
+          leftNext = !leftNext;
+        }
+      }
+    }
+
+    while (branchQueue.length > 0) {
+      var item = branchQueue.shift();
+      var nd = _historyNodes[item.nodeId];
+      if (!nd || positions[item.nodeId]) continue;
+      var xOff = item.side * item.depth * STEP;
+      var yOff = -STEP;
+      positions[item.nodeId] = {
+        x: item.parentPos.x + xOff,
+        y: item.parentPos.y + yOff
+      };
+      allNodes.push(item.nodeId);
+      var childSide = item.side;
+      for (var cc = 0; cc < nd.children.length; cc++) {
+        branchQueue.push({
+          nodeId: nd.children[cc],
+          parentPos: positions[item.nodeId],
+          side: childSide,
+          depth: 1
+        });
+        childSide = -childSide;
+      }
+    }
+
+    var layoutNodes = [];
+    var minX = Infinity, maxX = 0, minY = Infinity, maxY = 0;
+    for (var an = 0; an < allNodes.length; an++) {
+      var nid = allNodes[an];
+      var pos = positions[nid];
+      if (!pos) continue;
+      var nd2 = _historyNodes[nid];
+      layoutNodes.push({
+        id: nid,
+        x: pos.x,
+        y: pos.y,
+        onActivePath: !!activePath[nid],
+        isCurrent: nid === _historyCurrentId,
+        summary: nd2 ? (nd2.summary || (nd2.parentId === null ? 'initial' : 'edit')) : 'edit'
+      });
+      if (pos.x < minX) minX = pos.x;
+      if (pos.x > maxX) maxX = pos.x;
+      if (pos.y < minY) minY = pos.y;
+      if (pos.y > maxY) maxY = pos.y;
+
+      if (nd2) {
+        for (var ec = 0; ec < nd2.children.length; ec++) {
+          var cpos = positions[nd2.children[ec]];
+          if (cpos) {
+            edges.push({
+              x1: pos.x, y1: pos.y,
+              x2: cpos.x, y2: cpos.y,
+              active: !!activePath[nid] && !!activePath[nd2.children[ec]]
+            });
+          }
+        }
+      }
+    }
+
+    var pad = 30;
+    for (var shi = 0; shi < layoutNodes.length; shi++) {
+      layoutNodes[shi].x -= (minX - pad);
+      layoutNodes[shi].y -= (minY - pad);
+    }
+    for (var she = 0; she < edges.length; she++) {
+      edges[she].x1 -= (minX - pad);
+      edges[she].y1 -= (minY - pad);
+      edges[she].x2 -= (minX - pad);
+      edges[she].y2 -= (minY - pad);
+    }
+
+    return {
+      nodes: layoutNodes,
+      edges: edges,
+      width: maxX - minX + pad * 2,
+      height: maxY - minY + pad * 2
+    };
+  }
+
+  function _renderOrganicDag(container) {
+    container.innerHTML = '';
+    var layout = _computeOrganicLayout();
+    if (layout.nodes.length === 0) {
+      container.textContent = 'No history';
+      return;
+    }
+
+    var wrapper = document.createElement('div');
+    wrapper.className = 'live-wysiwyg-organic-wrapper';
+    wrapper.style.position = 'relative';
+    wrapper.style.width = Math.max(layout.width, 400) + 'px';
+    wrapper.style.height = layout.height + 'px';
+    wrapper.style.minWidth = '100%';
+
+    var svgNs = 'http://www.w3.org/2000/svg';
+    var svg = document.createElementNS(svgNs, 'svg');
+    svg.setAttribute('class', 'live-wysiwyg-organic-svg');
+    svg.setAttribute('width', Math.max(layout.width, 400));
+    svg.setAttribute('height', layout.height);
+    svg.style.position = 'absolute';
+    svg.style.top = '0';
+    svg.style.left = '0';
+
+    for (var e = 0; e < layout.edges.length; e++) {
+      var edge = layout.edges[e];
+      var ePath = document.createElementNS(svgNs, 'path');
+      var d;
+      if (Math.abs(edge.x1 - edge.x2) < 1) {
+        d = 'M' + edge.x1 + ' ' + edge.y1 + ' L' + edge.x2 + ' ' + edge.y2;
+      } else {
+        var eMidY = (edge.y1 + edge.y2) / 2;
+        d = 'M' + edge.x1 + ' ' + edge.y1 +
+          ' C' + edge.x1 + ' ' + eMidY + ', ' + edge.x2 + ' ' + eMidY + ', ' + edge.x2 + ' ' + edge.y2;
+      }
+      ePath.setAttribute('d', d);
+      ePath.setAttribute('class', edge.active ? 'live-wysiwyg-organic-edge-active' : 'live-wysiwyg-organic-edge');
+      svg.appendChild(ePath);
+    }
+    wrapper.appendChild(svg);
+
+    for (var ni = 0; ni < layout.nodes.length; ni++) {
+      var ln = layout.nodes[ni];
+      var dot = document.createElement('div');
+      dot.className = 'live-wysiwyg-organic-dot';
+      if (ln.onActivePath) dot.classList.add('active-path');
+      if (ln.isCurrent) dot.classList.add('current');
+      dot.style.position = 'absolute';
+      dot.style.left = (ln.x - 5) + 'px';
+      dot.style.top = (ln.y - 5) + 'px';
+      dot.setAttribute('data-node-id', ln.id);
+      dot.title = ln.summary;
+
+      (function (nodeId) {
+        dot.addEventListener('click', function (ev) {
+          if (ev.detail === 2) return;
+          _selectDagNode(nodeId);
+        });
+        dot.addEventListener('dblclick', function () {
+          _restoreToHistoryNode(nodeId);
+          _exitHistoryMode();
+        });
+      })(ln.id);
+
+      wrapper.appendChild(dot);
+    }
+
+    container.appendChild(wrapper);
+
+    var currentDot = container.querySelector('.live-wysiwyg-organic-dot.current');
+    if (currentDot) {
+      currentDot.scrollIntoView({ block: 'center', inline: 'center', behavior: 'auto' });
+    }
+  }
+
+  function _renderDag(container, opts) {
+    if (_historyDagViewMode === 'organic') {
+      _renderOrganicDag(container);
+      return;
+    }
+    var skipAutoScroll = opts && opts.skipAutoScroll;
+    container.innerHTML = '';
+    var layout = _computeDagLayout();
+    if (layout.nodes.length === 0) {
+      container.textContent = 'No history';
+      return;
+    }
+
+    var yahLabelExtra = 180;
+    var wrapperW = Math.max(layout.width + yahLabelExtra, 400);
+
+    var wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.width = wrapperW + 'px';
+    wrapper.style.height = layout.height + 'px';
+    wrapper.style.minWidth = '100%';
+
+    var svgNs = 'http://www.w3.org/2000/svg';
+    var svg = document.createElementNS(svgNs, 'svg');
+    svg.setAttribute('class', 'live-wysiwyg-history-dag-svg');
+    svg.setAttribute('width', wrapperW);
+    svg.setAttribute('height', layout.height);
+    svg.style.position = 'absolute';
+    svg.style.top = '0';
+    svg.style.left = '0';
+
+    for (var e = 0; e < layout.edges.length; e++) {
+      var edge = layout.edges[e];
+      if (edge.collapsed) continue;
+      var ePath = document.createElementNS(svgNs, 'path');
+      var d;
+      if (Math.abs(edge.x1 - edge.x2) < 1) {
+        d = 'M' + edge.x1 + ' ' + edge.y1 + ' L' + edge.x2 + ' ' + edge.y2;
+      } else {
+        var eMidY = (edge.y1 + edge.y2) / 2;
+        d = 'M' + edge.x1 + ' ' + edge.y1 +
+          ' C' + edge.x1 + ' ' + eMidY + ', ' + edge.x2 + ' ' + eMidY + ', ' + edge.x2 + ' ' + edge.y2;
+      }
+      ePath.setAttribute('d', d);
+      ePath.setAttribute('class', edge.active ? 'live-wysiwyg-dag-edge-active' : 'live-wysiwyg-dag-edge');
+      svg.appendChild(ePath);
+    }
+    wrapper.appendChild(svg);
+
+    var currentLn = null;
+    for (var ci = 0; ci < layout.nodes.length; ci++) {
+      if (layout.nodes[ci].isCurrent) { currentLn = layout.nodes[ci]; break; }
+    }
+    var yahRoute = null;
+    if (currentLn) {
+      var yahStartX = currentLn.x + 150 + 4;
+      var yahStartY = currentLn.y;
+      var svgW = parseInt(svg.getAttribute('width'), 10) || layout.width;
+      var svgH = parseInt(svg.getAttribute('height'), 10) || layout.height;
+      yahRoute = _computeYahRoute(yahStartX, yahStartY, layout.nodes, currentLn.id, svgW, svgH);
+
+      var yahPathD = _yahPointsToPath(yahRoute.points);
+      if (yahPathD) {
+        var yahPath = document.createElementNS(svgNs, 'path');
+        yahPath.setAttribute('d', yahPathD);
+        yahPath.setAttribute('class', 'live-wysiwyg-dag-yah-path');
+        svg.appendChild(yahPath);
+
+        var arrowSize = 14;
+        var arrowTip = yahRoute.points[0];
+        var arrowD = 'M' + (arrowTip.x - 2).toFixed(1) + ' ' + arrowTip.y.toFixed(1) +
+          ' L' + (arrowTip.x + arrowSize).toFixed(1) + ' ' + (arrowTip.y - arrowSize * 0.55).toFixed(1) +
+          ' L' + (arrowTip.x + arrowSize).toFixed(1) + ' ' + (arrowTip.y + arrowSize * 0.55).toFixed(1) + ' Z';
+        var yahArrow = document.createElementNS(svgNs, 'path');
+        yahArrow.setAttribute('d', arrowD);
+        yahArrow.setAttribute('class', 'live-wysiwyg-dag-yah-arrowhead');
+        svg.appendChild(yahArrow);
+      }
+    }
+
+    var nodesLayer = document.createElement('div');
+    nodesLayer.className = 'live-wysiwyg-history-dag-nodes';
+    nodesLayer.style.position = 'absolute';
+    nodesLayer.style.top = '0';
+    nodesLayer.style.left = '0';
+
+    var animatingKey = _historyDagAnimatingGroup;
+    _historyDagAnimatingGroup = null;
+    var animIdx = 0;
+
+    for (var ni = 0; ni < layout.nodes.length; ni++) {
+      var ln = layout.nodes[ni];
+      var nodeData = _historyNodes[ln.id];
+      var el;
+
+      if (ln.isCrumple) {
+        el = document.createElement('div');
+        el.className = 'live-wysiwyg-dag-crumple';
+        if (ln.crumpleType) el.setAttribute('data-container-type', ln.crumpleType);
+        el.style.position = 'absolute';
+        el.style.left = (ln.x - 150) + 'px';
+        el.style.top = (ln.y - 18) + 'px';
+        el.appendChild(_createCrumpleSvg());
+        var crLabel = document.createElement('span');
+        crLabel.className = 'live-wysiwyg-dag-crumple-label';
+        crLabel.textContent = ln.crumpleLabel + ' (' + ln.crumpleCount + ' edits)';
+        el.appendChild(crLabel);
+        (function (key, dagContainer) {
+          el.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            _historyDagAnimatingGroup = key;
+            _historyDagExpandedGroups[key] = true;
+            _renderDag(dagContainer);
+          });
+        })(ln.crumpleKey, container);
+        nodesLayer.appendChild(el);
+        continue;
+      }
+
+      if (ln.isVtreeFork) {
+        el = document.createElement('div');
+        el.className = 'live-wysiwyg-dag-vtree-fork';
+        el.style.position = 'absolute';
+        el.style.left = (ln.x - 150) + 'px';
+        el.style.top = (ln.y - 18) + 'px';
+        el.appendChild(_createVtreeForkSvg());
+        var vtLabel = document.createElement('span');
+        vtLabel.className = 'live-wysiwyg-dag-vtree-label';
+        vtLabel.textContent = 'Multiple histories (' + (ln.vtreeChildIds ? ln.vtreeChildIds.length : 0) + ')';
+        el.appendChild(vtLabel);
+        (function (bpKey, dagContainer) {
+          el.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            if (_historyDagActiveBranchKey === bpKey) {
+              _historyDagActiveBranchKey = null;
+              _historyDagVtreeSelectedBranch[bpKey] = null;
+            } else {
+              _historyDagActiveBranchKey = bpKey;
+              _historyDagVtreeSelectedBranch[bpKey] = null;
+            }
+            _renderDag(dagContainer);
+          });
+        })(ln.vtreeBpKey, container);
+        if (_historyDagActiveBranchKey === ln.vtreeBpKey) el.classList.add('active');
+        nodesLayer.appendChild(el);
+        continue;
+      }
+
+      if (ln.isVtreeOption) {
+        el = document.createElement('div');
+        el.className = 'live-wysiwyg-dag-vtree-option';
+        el.style.position = 'absolute';
+        el.style.left = (ln.x - 150) + 'px';
+        el.style.top = (ln.y - 18) + 'px';
+        var optIcon = _createCrumpleSvg();
+        el.appendChild(optIcon);
+        var optLabel = document.createElement('span');
+        optLabel.className = 'live-wysiwyg-dag-vtree-option-label';
+        optLabel.textContent = ln.optionSummary + ' (' + ln.optionCount + ' edits)';
+        el.appendChild(optLabel);
+        (function (bpKey, childId, dagContainer) {
+          el.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            _historyDagVtreeSelectedBranch[bpKey] = childId;
+            _historyDagAnimatingGroup = bpKey;
+            _renderDag(dagContainer);
+          });
+        })(ln.vtreeBpKey, ln.optionChildId, container);
+        nodesLayer.appendChild(el);
+        continue;
+      }
+
+      if (ln.isBranchCrumple) {
+        el = document.createElement('div');
+        el.className = 'live-wysiwyg-dag-crumple branch-crumple';
+        el.style.position = 'absolute';
+        el.style.left = (ln.x - 150) + 'px';
+        el.style.top = (ln.y - 18) + 'px';
+        el.appendChild(_createCrumpleSvg());
+        var brLabel = document.createElement('span');
+        brLabel.className = 'live-wysiwyg-dag-crumple-label';
+        var brChildNode = _historyNodes[ln.branchChildId];
+        brLabel.textContent = (brChildNode ? (brChildNode.summary || 'edit') : 'edit') + ' (' + ln.branchCount + ' edits)';
+        el.appendChild(brLabel);
+        (function (brKey, dagContainer) {
+          el.addEventListener('click', function (ev) {
+            ev.stopPropagation();
+            if (_historyDagActiveBranchKey === brKey) {
+              _historyDagActiveBranchKey = null;
+            } else {
+              _historyDagActiveBranchKey = brKey;
+            }
+            _historyDagAnimatingGroup = brKey;
+            _renderDag(dagContainer);
+          });
+        })(ln.branchKey, container);
+        if (_historyDagActiveBranchKey === ln.branchKey) el.classList.add('active');
+        nodesLayer.appendChild(el);
+        continue;
+      }
+
+      el = document.createElement('div');
+      el.className = 'live-wysiwyg-history-dag-node';
+      if (ln.isCurrent) el.classList.add('current');
+      if (ln.onActivePath) el.classList.add('active-path');
+      if (ln.isBranch) el.classList.add('branch-point');
+      if (ln.id === _historyDagSelectedNodeId) el.classList.add('selected');
+      el.setAttribute('data-node-id', ln.id);
+      el.style.position = 'absolute';
+      el.style.left = (ln.x - 150) + 'px';
+      el.style.top = (ln.y - 24) + 'px';
+
+      if (animatingKey && ln.crumpleKey === undefined && !ln.isSynthetic) {
+        var isInAnimGroup = false;
+        for (var agi = 0; agi < layout.groups.length; agi++) {
+          var ag = layout.groups[agi];
+          var agKey = 'g-' + ag.nodeIds[0];
+          if (agKey === animatingKey) {
+            for (var agn = 0; agn < ag.nodeIds.length; agn++) {
+              if (ag.nodeIds[agn] === ln.id) { isInAnimGroup = true; break; }
+            }
+            break;
+          }
+        }
+        if (isInAnimGroup) {
+          el.classList.add('group-enter');
+          el.style.animationDelay = (animIdx * 50) + 'ms';
+          animIdx++;
+        }
+      }
+
+      var dot = document.createElement('span');
+      dot.className = 'live-wysiwyg-dag-dot';
+      el.appendChild(dot);
+
+      var info = document.createElement('span');
+      info.className = 'live-wysiwyg-dag-info';
+      var summaryText = nodeData ? (nodeData.summary || (nodeData.parentId === null ? 'initial content' : 'edit')) : 'edit';
+      info.textContent = summaryText;
+      el.appendChild(info);
+
+      var ts = document.createElement('span');
+      ts.className = 'live-wysiwyg-dag-time';
+      ts.textContent = nodeData ? _formatRelativeTime(nodeData.timestamp) : '';
+      el.appendChild(ts);
+
+      (function (nodeId, nodeEl) {
+        var hoverTimer = null;
+        nodeEl.addEventListener('mouseenter', function () {
+          hoverTimer = setTimeout(function () {
+            _showDagHoverPreview(nodeId, nodeEl);
+          }, 200);
+        });
+        nodeEl.addEventListener('mouseleave', function () {
+          if (hoverTimer) clearTimeout(hoverTimer);
+          _dismissDagHoverPreview();
+        });
+        nodeEl.addEventListener('click', function (ev) {
+          if (ev.detail === 2) return;
+          _selectDagNode(nodeId);
+        });
+        nodeEl.addEventListener('dblclick', function () {
+          _restoreToHistoryNode(nodeId);
+          _exitHistoryMode();
+        });
+      })(ln.id, el);
+
+      nodesLayer.appendChild(el);
+    }
+
+    // Block context dotted outlines for all container groups
+    if (layout.groups) {
+      for (var ogi = 0; ogi < layout.groups.length; ogi++) {
+        var og = layout.groups[ogi];
+        if (!og.type) continue;
+        var isActiveGroup = false;
+        for (var ogn = 0; ogn < og.nodeIds.length; ogn++) {
+          if (og.nodeIds[ogn] === _historyCurrentId) { isActiveGroup = true; break; }
+        }
+        var outlineTop = Infinity, outlineBottom = 0;
+        var outlineLeftX = Infinity;
+        for (var oli = 0; oli < layout.nodes.length; oli++) {
+          var oln = layout.nodes[oli];
+          if (oln.col !== 0) continue;
+          var isInGroup = false;
+          for (var oin = 0; oin < og.nodeIds.length; oin++) {
+            if (og.nodeIds[oin] === oln.id) { isInGroup = true; break; }
+          }
+          if (isInGroup || oln.isCrumple) {
+            if (oln.isCrumple && oln.crumpleNodeIds) {
+              var crumpOverlap = false;
+              for (var coi = 0; coi < oln.crumpleNodeIds.length; coi++) {
+                for (var coj = 0; coj < og.nodeIds.length; coj++) {
+                  if (oln.crumpleNodeIds[coi] === og.nodeIds[coj]) { crumpOverlap = true; break; }
+                }
+                if (crumpOverlap) break;
+              }
+              if (!crumpOverlap) continue;
+            }
+            var nodeTop2 = oln.y - 24;
+            var nodeBot2 = oln.y + 24;
+            if (nodeTop2 < outlineTop) outlineTop = nodeTop2;
+            if (nodeBot2 > outlineBottom) outlineBottom = nodeBot2;
+            var nodeLeft = oln.x - 150;
+            if (nodeLeft < outlineLeftX) outlineLeftX = nodeLeft;
+          }
+        }
+        if (outlineTop < outlineBottom) {
+          var outlineEl = document.createElement('div');
+          outlineEl.className = 'live-wysiwyg-dag-block-outline';
+          if (!isActiveGroup) outlineEl.classList.add('inactive');
+          if (og.type) outlineEl.setAttribute('data-container-type', og.type);
+          outlineEl.style.position = 'absolute';
+          outlineEl.style.left = (outlineLeftX - 8) + 'px';
+          outlineEl.style.top = (outlineTop - 6) + 'px';
+          outlineEl.style.width = '316px';
+          outlineEl.style.height = (outlineBottom - outlineTop + 12) + 'px';
+          var outlineTitle = document.createElement('span');
+          outlineTitle.className = 'live-wysiwyg-dag-block-outline-title';
+          outlineTitle.textContent = og.label;
+          outlineEl.appendChild(outlineTitle);
+          nodesLayer.insertBefore(outlineEl, nodesLayer.firstChild);
+        }
+      }
+    }
+
+    wrapper.appendChild(nodesLayer);
+    container.appendChild(wrapper);
+
+    if (yahRoute) {
+      var yahEndPt = yahRoute.points[yahRoute.points.length - 1];
+      var yahLabel = document.createElement('div');
+      yahLabel.className = 'live-wysiwyg-dag-you-are-here-label';
+      yahLabel.style.position = 'absolute';
+      yahLabel.style.top = (yahEndPt.y - 12) + 'px';
+      yahLabel.style.left = (yahEndPt.x + 4) + 'px';
+      var yahArrowIcon = document.createElementNS(svgNs, 'svg');
+      yahArrowIcon.setAttribute('width', '10');
+      yahArrowIcon.setAttribute('height', '12');
+      yahArrowIcon.setAttribute('viewBox', '0 0 10 12');
+      var yahTriIcon = document.createElementNS(svgNs, 'path');
+      yahTriIcon.setAttribute('d', 'M9 1 L1 6 L9 11Z');
+      yahTriIcon.setAttribute('fill', 'currentColor');
+      yahArrowIcon.appendChild(yahTriIcon);
+      yahLabel.appendChild(yahArrowIcon);
+      var yahTxt = document.createElement('span');
+      yahTxt.textContent = 'You Are Here';
+      yahLabel.appendChild(yahTxt);
+      wrapper.appendChild(yahLabel);
+
+      var yahSvgPath = svg.querySelector('.live-wysiwyg-dag-yah-path');
+      var yahDefaultLeft = yahEndPt.x + 4;
+      var yahLabelW = 130;
+      (function (lbl, svgPathEl, routePts, defLeft, lblW, dagCont) {
+        function clampYah() {
+          var visRight = dagCont.scrollLeft + dagCont.clientWidth - 8;
+          var newEndX = visRight - lblW - 4;
+          if (newEndX >= defLeft) newEndX = defLeft;
+          if (newEndX < routePts[0].x + 20) newEndX = routePts[0].x + 20;
+          lbl.style.left = (newEndX + 4) + 'px';
+
+          if (svgPathEl) {
+            var truncPts = [];
+            for (var ti = 0; ti < routePts.length - 1; ti++) {
+              if (routePts[ti].x <= newEndX) truncPts.push(routePts[ti]);
+              else break;
+            }
+            truncPts.push({ x: newEndX, y: truncPts.length > 0 ? truncPts[truncPts.length - 1].y : routePts[0].y });
+            svgPathEl.setAttribute('d', _yahPointsToPath(truncPts));
+          }
+        }
+        dagCont.addEventListener('scroll', clampYah);
+        var resObs = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(clampYah) : null;
+        if (resObs) resObs.observe(dagCont);
+        clampYah();
+      })(yahLabel, yahSvgPath, yahRoute.points, yahDefaultLeft, yahLabelW, container);
+    }
+
+    if (!skipAutoScroll) {
+      var currentEl = container.querySelector('.live-wysiwyg-history-dag-node.current');
+      if (currentEl) {
+        currentEl.scrollIntoView({ block: 'center', inline: 'center', behavior: 'auto' });
+      }
+    }
+  }
+
+  // --- Hover Preview ---
+
+  var _dagHoverPreviewEl = null;
+
+  function _dismissDagHoverPreview() {
+    if (_dagHoverPreviewEl && _dagHoverPreviewEl.parentNode) {
+      _dagHoverPreviewEl.parentNode.removeChild(_dagHoverPreviewEl);
+    }
+    _dagHoverPreviewEl = null;
+  }
+
+  function _showDagHoverPreview(nodeId, anchorEl) {
+    _dismissDagHoverPreview();
+    var md = _historyPreviewCache[nodeId];
+    if (!md) {
+      md = _reconstructContentAtNode(nodeId);
+      if (md !== null) _historyPreviewCache[nodeId] = md;
+    }
+    if (md === null) return;
+
+    var tooltip = document.createElement('div');
+    tooltip.className = 'live-wysiwyg-history-hover-preview';
+
+    var snippetEl = document.createElement('div');
+    snippetEl.className = 'live-wysiwyg-history-hover-snippet';
+    var snippetBody = _stripFrontmatterForPreview(md);
+    var snippetLines = snippetBody.split('\n').slice(0, 3).join('\n');
+    snippetEl.textContent = snippetLines;
+    tooltip.appendChild(snippetEl);
+
+    var rendered = document.createElement('div');
+    rendered.className = 'live-wysiwyg-history-hover-rendered';
+    rendered.innerHTML = _renderMarkdownPreview(md);
+    tooltip.appendChild(rendered);
+
+    var fullBtn = document.createElement('button');
+    fullBtn.className = 'live-wysiwyg-history-hover-fullscreen-btn';
+    fullBtn.textContent = 'Full Screen';
+    fullBtn.addEventListener('click', function (ev) {
+      ev.stopPropagation();
+      _showHistoryFullsizePreview(nodeId);
+    });
+    tooltip.appendChild(fullBtn);
+
+    var rect = anchorEl.getBoundingClientRect();
+    tooltip.style.position = 'fixed';
+    tooltip.style.left = (rect.right + 8) + 'px';
+    tooltip.style.top = rect.top + 'px';
+    tooltip.style.zIndex = '99999';
+
+    if (rect.right + 320 > window.innerWidth) {
+      tooltip.style.left = '';
+      tooltip.style.right = (window.innerWidth - rect.left + 8) + 'px';
+    }
+
+    var appendTarget = _historyOverlay || _focusOverlay || document.body;
+    appendTarget.appendChild(tooltip);
+    _dagHoverPreviewEl = tooltip;
+  }
+
+  // --- Click Selection & Preview Panel ---
+
+  function _selectDagNode(nodeId) {
+    _historyDagSelectedNodeId = nodeId;
+    if (_historyOverlay) {
+      var allNodes = _historyOverlay.querySelectorAll('.live-wysiwyg-history-dag-node');
+      for (var i = 0; i < allNodes.length; i++) {
+        allNodes[i].classList.toggle('selected', parseInt(allNodes[i].getAttribute('data-node-id'), 10) === nodeId);
+      }
+    }
+    _updatePreviewPanel(nodeId);
+  }
+
+  function _updatePreviewPanel(nodeId) {
+    if (!_historyOverlay) return;
+    var panel = _historyOverlay.querySelector('.live-wysiwyg-history-preview-panel');
+    if (!panel) return;
+    var wasAlreadyOpen = panel.classList.contains('open');
+    panel.innerHTML = '';
+
+    var md = _historyPreviewCache[nodeId];
+    if (!md) {
+      md = _reconstructContentAtNode(nodeId);
+      if (md !== null) _historyPreviewCache[nodeId] = md;
+    }
+    if (md === null) {
+      panel.textContent = 'Cannot reconstruct content';
+      panel.classList.add('open');
+      return;
+    }
+    panel.classList.add('open');
+
+    if (!wasAlreadyOpen) {
+      var dagC = _historyOverlay.querySelector('.live-wysiwyg-history-dag-container');
+      if (dagC) {
+        var onTransEnd = function (ev) {
+          if (ev.target !== panel) return;
+          panel.removeEventListener('transitionend', onTransEnd);
+          _renderDag(dagC, { skipAutoScroll: true });
+        };
+        panel.addEventListener('transitionend', onTransEnd);
+      }
+    }
+
+    var nodeData = _historyNodes[nodeId];
+    var panelHeader = document.createElement('div');
+    panelHeader.className = 'live-wysiwyg-history-preview-header';
+    var summaryEl = document.createElement('span');
+    summaryEl.textContent = (nodeData ? (nodeData.summary || 'edit') : 'edit') +
+      (nodeData ? ' \u2014 ' + _formatRelativeTime(nodeData.timestamp) : '');
+    panelHeader.appendChild(summaryEl);
+
+    var fullBtn = document.createElement('button');
+    fullBtn.className = 'live-wysiwyg-history-preview-fullscreen-btn';
+    fullBtn.textContent = 'Full Screen';
+    fullBtn.addEventListener('click', function () {
+      _showHistoryFullsizePreview(nodeId);
+    });
+    panelHeader.appendChild(fullBtn);
+
+    var restoreBtn = document.createElement('button');
+    restoreBtn.className = 'live-wysiwyg-history-preview-restore-btn';
+    restoreBtn.textContent = 'Restore';
+    restoreBtn.addEventListener('click', function () {
+      _restoreToHistoryNode(nodeId);
+      _exitHistoryMode();
+    });
+    panelHeader.appendChild(restoreBtn);
+    panel.appendChild(panelHeader);
+
+    var content = document.createElement('div');
+    content.className = 'live-wysiwyg-history-preview-content';
+    content.setAttribute('contenteditable', 'false');
+    var panelBody = _stripFrontmatterForPreview(md);
+    if (wysiwygEditor && wysiwygEditor._markdownToHtml) {
+      content.innerHTML = wysiwygEditor._markdownToHtml(panelBody);
+    } else {
+      content.innerHTML = _renderMarkdownPreview(md);
+    }
+    _enhancePreviewContent(content);
+    _applyDiffHighlightToPreview(content, nodeData, md);
+    panel.appendChild(content);
+  }
+
+  function _applyDiffHighlightToPreview(contentEl, nodeData, md) {
+    if (!nodeData || !nodeData.diff || !nodeData.diff.ops) return;
+    var body = _stripFrontmatterForPreview(md);
+    var bodyLines = body.split('\n');
+    var changedLines = {};
+    var diff = nodeData.diff;
+    var fmOffset = md.length - body.length > 0 ? md.substring(0, md.length - body.length).split('\n').length - 1 : 0;
+
+    for (var oi = 0; oi < diff.ops.length; oi++) {
+      var op = diff.ops[oi];
+      if (op.type === 'insert') {
+        var insStart = op.afterLine - fmOffset;
+        for (var il = 0; il < op.lines.length; il++) {
+          changedLines[insStart + il] = true;
+        }
+      } else if (op.type === 'replace') {
+        var repStart = op.line - fmOffset;
+        for (var rl = 0; rl < op['new'].length; rl++) {
+          changedLines[repStart + rl] = true;
+        }
+      }
+    }
+
+    var hasChanges = false;
+    for (var k in changedLines) { hasChanges = true; break; }
+    if (!hasChanges) return;
+
+    // Map markdown lines to top-level block elements
+    var blocks = [];
+    for (var ci = 0; ci < contentEl.children.length; ci++) {
+      var child = contentEl.children[ci];
+      if (child.nodeType === 1) blocks.push(child);
+    }
+
+    var mdLine = 0;
+    for (var bi = 0; bi < blocks.length; bi++) {
+      var block = blocks[bi];
+      var blockText = block.textContent || '';
+      var blockLineCount = (blockText.match(/\n/g) || []).length + 1;
+
+      // Scan past blank lines between blocks
+      while (mdLine < bodyLines.length && bodyLines[mdLine] !== undefined && bodyLines[mdLine].trim() === '') {
+        mdLine++;
+      }
+
+      var blockStart = mdLine;
+      // Estimate how many markdown source lines this block spans
+      var srcLines = 0;
+      var tmpLine = mdLine;
+      while (tmpLine < bodyLines.length && srcLines < blockLineCount + 4) {
+        if (bodyLines[tmpLine].trim() === '' && srcLines >= blockLineCount) break;
+        tmpLine++;
+        srcLines++;
+      }
+      var blockEnd = tmpLine;
+      mdLine = blockEnd;
+
+      // Check if any changed line overlaps this block's source range
+      var overlaps = false;
+      for (var cl = blockStart; cl < blockEnd; cl++) {
+        if (changedLines[cl]) { overlaps = true; break; }
+      }
+      if (overlaps) {
+        block.classList.add('live-wysiwyg-diff-highlight');
+      }
+    }
+  }
+
+  // --- Way 3: Full-Size Readonly Preview ---
+
+  function _dismissHistoryFullsizePreview() {
+    if (_historyFullsizePreview && _historyFullsizePreview.parentNode) {
+      _historyFullsizePreview.parentNode.removeChild(_historyFullsizePreview);
+    }
+    _historyFullsizePreview = null;
+    if (_historyOverlay) _historyOverlay.focus();
+  }
+
+  function _enhancePreviewContent(container) {
+    var pres = container.querySelectorAll('pre');
+    for (var i = 0; i < pres.length; i++) {
+      var pre = pres[i];
+      var codeEl = pre.querySelector('code');
+      if (!codeEl) continue;
+      var langClass = (codeEl.className || '').match(/language-(\S+)/);
+      var lang = langClass ? langClass[1] : '';
+      if (lang === 'mermaid') {
+        var mermaidCode = codeEl.textContent || '';
+        if (mermaidCode.trim()) {
+          var mWrapper = document.createElement('div');
+          mWrapper.className = 'md-mermaid-block';
+          mWrapper.setAttribute('contenteditable', 'false');
+          var mPreview = document.createElement('div');
+          mPreview.className = 'md-mermaid-preview';
+          mWrapper.appendChild(mPreview);
+          pre.parentNode.insertBefore(mWrapper, pre);
+          pre.style.display = 'none';
+          mWrapper.appendChild(pre);
+          (function (pv, code) {
+            _loadMermaidJs(function () { _renderMermaidPreview(pv, code); });
+          })(mPreview, mermaidCode);
+        }
+      } else if (lang) {
+        pre.setAttribute('data-lang', lang);
+        var codeBlockWrapper = document.createElement('div');
+        codeBlockWrapper.className = 'md-code-block';
+        var langBar = document.createElement('div');
+        langBar.className = 'md-code-lang';
+        langBar.setAttribute('contenteditable', 'false');
+        langBar.textContent = lang;
+        codeBlockWrapper.appendChild(langBar);
+        pre.parentNode.insertBefore(codeBlockWrapper, pre);
+        codeBlockWrapper.appendChild(pre);
+      }
+    }
+    var admonitions = container.querySelectorAll('.admonition');
+    for (var a = 0; a < admonitions.length; a++) {
+      admonitions[a].removeAttribute('contenteditable');
+    }
+    var btns = container.querySelectorAll('.md-admonition-settings-btn, .md-mermaid-expand-btn, .md-code-block .md-code-lang[contenteditable]');
+    for (var b = 0; b < btns.length; b++) {
+      if (btns[b].classList.contains('md-admonition-settings-btn') ||
+          btns[b].classList.contains('md-mermaid-expand-btn')) {
+        btns[b].parentNode.removeChild(btns[b]);
+      } else {
+        btns[b].setAttribute('contenteditable', 'false');
+      }
+    }
+    var editables = container.querySelectorAll('[contenteditable="true"]');
+    for (var e = 0; e < editables.length; e++) {
+      editables[e].setAttribute('contenteditable', 'false');
+    }
+  }
+
+  function _showHistoryFullsizePreview(nodeId) {
+    _dismissHistoryFullsizePreview();
+    _dismissDagHoverPreview();
+
+    var md = _historyPreviewCache[nodeId];
+    if (!md) {
+      md = _reconstructContentAtNode(nodeId);
+      if (md !== null) _historyPreviewCache[nodeId] = md;
+    }
+    if (md === null) return;
+
+    var nodeData = _historyNodes[nodeId];
+    var preview = document.createElement('div');
+    preview.className = 'live-wysiwyg-history-fullsize-preview';
+    preview.setAttribute('tabindex', '-1');
+
+    var fsHeader = document.createElement('div');
+    fsHeader.className = 'live-wysiwyg-history-fullsize-header';
+    var fsTitle = document.createElement('span');
+    fsTitle.textContent = 'Preview: ' + (nodeData ? (nodeData.summary || 'edit') : 'edit') +
+      (nodeData ? ' \u2014 ' + _formatRelativeTime(nodeData.timestamp) : '');
+    fsHeader.appendChild(fsTitle);
+
+    var fsRestoreBtn = document.createElement('button');
+    fsRestoreBtn.className = 'live-wysiwyg-history-fullsize-restore-btn';
+    fsRestoreBtn.textContent = 'Restore to this point';
+    fsRestoreBtn.addEventListener('click', function () {
+      _restoreToHistoryNode(nodeId);
+      _dismissHistoryFullsizePreview();
+      _exitHistoryMode();
+    });
+    fsHeader.appendChild(fsRestoreBtn);
+
+    var fsCloseBtn = document.createElement('button');
+    fsCloseBtn.className = 'live-wysiwyg-history-fullsize-close-btn';
+    fsCloseBtn.textContent = 'Close';
+    fsCloseBtn.addEventListener('click', function () {
+      _dismissHistoryFullsizePreview();
+    });
+    fsHeader.appendChild(fsCloseBtn);
+    preview.appendChild(fsHeader);
+
+    var fsBody = document.createElement('div');
+    fsBody.className = 'live-wysiwyg-history-fullsize-body';
+    var fsContent = document.createElement('div');
+    fsContent.className = 'live-wysiwyg-history-fullsize-content';
+    fsContent.setAttribute('contenteditable', 'false');
+    var previewBody = _stripFrontmatterForPreview(md);
+    if (wysiwygEditor && wysiwygEditor._markdownToHtml) {
+      fsContent.innerHTML = wysiwygEditor._markdownToHtml(previewBody);
+    } else {
+      fsContent.innerHTML = _renderMarkdownPreview(md);
+    }
+    _enhancePreviewContent(fsContent);
+    fsBody.appendChild(fsContent);
+    preview.appendChild(fsBody);
+
+    preview.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        e.preventDefault(); e.stopPropagation();
+        _dismissHistoryFullsizePreview();
+      } else if (e.key === 'Enter') {
+        e.preventDefault(); e.stopPropagation();
+        _restoreToHistoryNode(nodeId);
+        _dismissHistoryFullsizePreview();
+        _exitHistoryMode();
+      }
+    });
+
+    var appendTarget = _historyOverlay || _focusOverlay || document.body;
+    appendTarget.appendChild(preview);
+    _historyFullsizePreview = preview;
+    preview.focus();
+  }
+
+  // --- Content Restoration from DAG ---
+
+  function _restoreToHistoryNode(nodeId) {
+    _flushHistoryCapture();
+    var md = _reconstructContentAtNode(nodeId);
+    if (md === null) return;
+    var node = _historyNodes[nodeId];
+    _historyCurrentId = nodeId;
+    _historySetContent(md, node ? node.htmlSnapshot : null);
+    _historyLastMd = wysiwygEditor ? (wysiwygEditor.getValue() || md) : md;
+    if (node && node.cursor) {
+      _restoreHistoryCursor(node.cursor, node.diff, md, false, !!(node && node.htmlSnapshot));
+    }
+    _autoSaveAndPersistHistory();
+  }
+
+  // --- DAG Overlay Keyboard ---
+
+  function _attachHistoryOverlayKeyboard(overlay) {
+    overlay.addEventListener('keydown', function (e) {
+      if (_historyFullsizePreview) return;
+      if (e.key === 'Escape') {
+        e.preventDefault(); e.stopPropagation();
+        _exitHistoryMode();
+        return;
+      }
+      if (e.key === 'Enter' && _historyDagSelectedNodeId !== null) {
+        e.preventDefault(); e.stopPropagation();
+        _restoreToHistoryNode(_historyDagSelectedNodeId);
+        _exitHistoryMode();
+        return;
+      }
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        _navigateDag(e.key);
+      }
+    });
+  }
+
+  function _navigateDag(key) {
+    var startId = _historyDagSelectedNodeId !== null ? _historyDagSelectedNodeId : _historyCurrentId;
+    var node = _historyNodes[startId];
+    if (!node) return;
+    var targetId = null;
+    if (key === 'ArrowUp' && node.parentId !== null) {
+      targetId = node.parentId;
+    } else if (key === 'ArrowDown') {
+      if (node.activeChildId) targetId = node.activeChildId;
+      else if (node.children.length > 0) targetId = node.children[0];
+    } else if (key === 'ArrowLeft' || key === 'ArrowRight') {
+      var parent = node.parentId !== null ? _historyNodes[node.parentId] : null;
+      if (parent && parent.children.length > 1) {
+        var idx = parent.children.indexOf(startId);
+        if (key === 'ArrowLeft' && idx > 0) targetId = parent.children[idx - 1];
+        if (key === 'ArrowRight' && idx < parent.children.length - 1) targetId = parent.children[idx + 1];
+      }
+    }
+    if (targetId !== null) {
+      _selectDagNode(targetId);
+      var selectedEl = _historyOverlay ? _historyOverlay.querySelector('[data-node-id="' + targetId + '"]') : null;
+      if (selectedEl) selectedEl.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+    }
+  }
+
   function _estimateMdOffsetFromWysiwyg(ea) {
     var sel = window.getSelection();
     if (!sel || sel.rangeCount === 0 || !ea) return 0;
@@ -9792,12 +12152,41 @@
       };
     }
     if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor.editableArea) {
-      var mdOffset = _estimateMdOffsetFromWysiwyg(wysiwygEditor.editableArea);
+      var ea = wysiwygEditor.editableArea;
+      var mdOffset = _estimateMdOffsetFromWysiwyg(ea);
+      var sem = captureSemanticSelection(ea);
+      var sel = window.getSelection();
+      var blockChildIndex = -1;
+      var innerOffset = 0;
+      if (sel && sel.rangeCount > 0) {
+        var r = sel.getRangeAt(0);
+        var node = r.startContainer;
+        innerOffset = r.startOffset;
+        var block = node;
+        while (block && block.parentNode !== ea) {
+          block = block.parentNode;
+        }
+        if (block && block.parentNode === ea) {
+          for (var ci = 0; ci < ea.childNodes.length; ci++) {
+            if (ea.childNodes[ci] === block) { blockChildIndex = ci; break; }
+          }
+          if (node !== block) {
+            var w = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, null, false);
+            var tn, tpos = 0;
+            while ((tn = w.nextNode())) {
+              if (tn === node) { innerOffset = tpos + r.startOffset; break; }
+              tpos += tn.textContent.length;
+            }
+          }
+        }
+      }
       return {
         mode: 'wysiwyg',
         start: mdOffset,
         end: mdOffset,
-        semantic: captureSemanticSelection(wysiwygEditor.editableArea)
+        semantic: sem,
+        blockChildIndex: blockChildIndex,
+        innerOffset: innerOffset
       };
     }
     return null;
@@ -9879,8 +12268,45 @@
     }
   }
 
-  function _restoreHistoryCursor(cursor, diff, mdContent, isRedo) {
+  function _restoreHistoryCursor(cursor, diff, mdContent, isRedo, hasHtmlSnapshot) {
     if (!wysiwygEditor) return;
+    if (hasHtmlSnapshot && cursor && cursor.mode === 'wysiwyg' && wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor.editableArea) {
+      var ea = wysiwygEditor.editableArea;
+      ea.focus();
+      if (cursor.blockChildIndex >= 0 && cursor.blockChildIndex < ea.childNodes.length) {
+        var targetBlock = ea.childNodes[cursor.blockChildIndex];
+        try {
+          var range = document.createRange();
+          var w = document.createTreeWalker(targetBlock, NodeFilter.SHOW_TEXT, null, false);
+          var tn, tpos = 0, placed = false;
+          while ((tn = w.nextNode())) {
+            if (tpos + tn.textContent.length >= cursor.innerOffset) {
+              range.setStart(tn, Math.min(cursor.innerOffset - tpos, tn.textContent.length));
+              range.collapse(true);
+              placed = true;
+              break;
+            }
+            tpos += tn.textContent.length;
+          }
+          if (!placed) {
+            range.setStart(targetBlock, 0);
+            range.collapse(true);
+          }
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+          return;
+        } catch (ex) { /* fall through */ }
+      }
+      if (cursor.semantic && restoreSelectionFromSemantic(ea, cursor.semantic)) {
+        return;
+      }
+      if (cursor.start !== undefined) {
+        _placeCursorAtMdOffset(cursor.start, null);
+        return;
+      }
+      return;
+    }
     if (diff && mdContent) {
       var offset = _diffToMdOffset(diff, mdContent, isRedo);
       _placeCursorAtMdOffset(offset, mdContent);
@@ -9955,18 +12381,28 @@
     if (parentMd === null) return;
 
     var parent = _historyNodes[current.parentId];
+    var parentSnapshot = parent ? parent.htmlSnapshot : null;
     _historyCurrentId = current.parentId;
-    _historyLastMd = parentMd;
 
-    _historySetContent(parentMd);
-    _restoreHistoryCursor(parent ? parent.cursor : null, undoDiff, parentMd, false);
+    _historySetContent(parentMd, parentSnapshot);
+    _historyLastMd = wysiwygEditor.getValue() || parentMd;
+    _restoreHistoryCursor(parent ? parent.cursor : null, undoDiff, parentMd, false, !!parentSnapshot);
     _autoSaveAndPersistHistory();
   }
 
   function _contentRedo() {
     if (_historyCurrentId === null) return;
+
+    var preRedoNodeId = _historyCurrentId;
+    _flushHistoryCapture();
+
     var current = _historyNodes[_historyCurrentId];
-    if (!current || !current.activeChildId) return;
+    if (!current || !current.activeChildId) {
+      _showHistoryBranchPopup(_historyCurrentId);
+      return;
+    }
+
+    var isBranchPoint = current.children.length > 1;
 
     var child = _historyNodes[current.activeChildId];
     if (!child) return;
@@ -9974,17 +12410,22 @@
     var childMd = _reconstructContentAtNode(child.id);
     if (childMd === null) return;
 
+    var childSnapshot = child.htmlSnapshot || null;
     _historyCurrentId = child.id;
-    _historyLastMd = childMd;
 
-    _historySetContent(childMd);
-    _restoreHistoryCursor(child.cursor, child.diff, childMd, true);
+    _historySetContent(childMd, childSnapshot);
+    _historyLastMd = wysiwygEditor.getValue() || childMd;
+    _restoreHistoryCursor(child.cursor, child.diff, childMd, true, !!childSnapshot);
     _autoSaveAndPersistHistory();
+
+    if (isBranchPoint) {
+      _showHistoryBranchPopup(preRedoNodeId);
+    }
   }
 
-  function _historySetContent(markdown) {
+  function _historySetContent(markdown, htmlSnapshot) {
     if (!wysiwygEditor || !wysiwygEditor._historyApplyContent) return;
-    wysiwygEditor._historyApplyContent(markdown);
+    wysiwygEditor._historyApplyContent(markdown, htmlSnapshot || null);
   }
 
   function _persistContentHistory() {
@@ -14849,6 +17290,11 @@
     var actualPath = _resolveChainedRename(itemPath);
     if (_batchDeletedPaths[actualPath]) return Promise.resolve();
     var siblings = _findNavSiblings(op.item).filter(function (s) { return !_isRootIndex(s); });
+    var nwCfg = typeof liveWysiwygNavWeightConfig !== 'undefined' ? liveWysiwygNavWeightConfig : {};
+    var nwDefaults = (nwCfg.enabled && nwCfg.frontmatter_defaults) ? nwCfg.frontmatter_defaults : {};
+    var defaultIndexWeight = nwDefaults.index_weight !== undefined ? nwDefaults.index_weight
+      : (nwCfg.index_weight !== undefined ? nwCfg.index_weight : -10);
+    var defaultPageWeight = nwDefaults.weight !== undefined ? nwDefaults.weight : 0;
     function w(navItem) {
       var v = _getItemWeight(navItem);
       return v != null ? v : 0;
@@ -14861,7 +17307,8 @@
     var isIndex = actualPath.endsWith('index.md');
     return _wsGetContents(actualPath).then(function (content) {
       var fm = _parseFrontmatter(content);
-      var currentWeight = fm.fields.weight !== undefined ? fm.fields.weight : 0;
+      var currentWeight = fm.fields.weight !== undefined ? fm.fields.weight
+        : (isIndex ? defaultIndexWeight : defaultPageWeight);
       var newWeight;
       if (op.type === 'move-up') {
         if (idx > 0) {
@@ -15100,8 +17547,11 @@
     if (op.skipIndex) return Promise.resolve();
     var parentDir = op.item && op.item.src_path ? _getDir(op.item.src_path) : '';
     var indexPath = (parentDir ? parentDir + '/' : '') + op.folderName + '/index.md';
+    var sectionWeight = op.syntheticSection && op.syntheticSection.index_meta
+      ? op.syntheticSection.index_meta.weight : null;
+    if (sectionWeight == null) sectionWeight = 100;
     var indexContent = '---\ntitle: ' + _fmSerialize(op.folderTitle || op.folderName) +
-      '\nretitled: true\nempty: true\n---\nThis section covers information about ' +
+      '\nretitled: true\nempty: true\nweight: ' + sectionWeight + '\n---\nThis section covers information about ' +
       (op.folderTitle || op.folderName) + ' and its contents.\n';
     return _wsNewFile(indexPath, op.folderTitle || op.folderName).then(function () {
       return _wsSetContents(indexPath, indexContent);
@@ -20938,6 +23388,456 @@
         '}';
     }
 
+    // --- History Mode (Layer 4) CSS ---
+    css +=
+      '.live-wysiwyg-history-branch-popup{' +
+        'position:fixed;z-index:99999;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'border-radius:8px;box-shadow:0 4px 24px rgba(0,0,0,.18);' +
+        'min-width:260px;max-width:380px;padding:0;' +
+        'font-family:var(--md-text-font-family,sans-serif);font-size:.8rem;' +
+        'outline:none;' +
+      '}' +
+      '.live-wysiwyg-history-branch-header{' +
+        'display:flex;align-items:center;justify-content:space-between;' +
+        'padding:8px 12px;border-bottom:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'font-weight:600;color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-fullscreen-btn{' +
+        'background:var(--md-primary-fg-color,#4051b5);color:#fff;' +
+        'border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:.72rem;' +
+      '}' +
+      '.live-wysiwyg-history-fullscreen-btn:hover{opacity:.85;}' +
+      '.live-wysiwyg-history-branch-list{padding:4px 0;}' +
+      '.live-wysiwyg-history-branch-item{' +
+        'display:flex;flex-direction:column;padding:6px 12px;cursor:pointer;' +
+        'border-left:3px solid transparent;' +
+        'transition:background .12s;' +
+      '}' +
+      '.live-wysiwyg-history-branch-item:hover,' +
+      '.live-wysiwyg-history-branch-item.highlighted{' +
+        'background:var(--md-accent-fg-color--transparent,rgba(82,108,254,.08));' +
+      '}' +
+      '.live-wysiwyg-history-branch-item.active{' +
+        'border-left-color:var(--md-primary-fg-color,#4051b5);' +
+      '}' +
+      '.live-wysiwyg-history-branch-summary{' +
+        'font-weight:500;color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-branch-snippet{' +
+        'color:var(--md-default-fg-color--light,#666);font-size:.72rem;' +
+        'overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-top:2px;' +
+      '}' +
+      '.live-wysiwyg-history-branch-time{' +
+        'color:var(--md-default-fg-color--lighter,#999);font-size:.68rem;margin-top:1px;' +
+      '}' +
+
+      // History Mode overlay
+      '.live-wysiwyg-history-overlay{' +
+        'position:fixed;inset:0;z-index:99995;display:flex;align-items:center;justify-content:center;' +
+        'outline:none;' +
+      '}' +
+      '.live-wysiwyg-history-backdrop{' +
+        'position:absolute;inset:0;background:rgba(0,0,0,.45);' +
+      '}' +
+      '.live-wysiwyg-history-modal{' +
+        'position:relative;z-index:1;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border-radius:10px;box-shadow:0 8px 40px rgba(0,0,0,.25);' +
+        'width:92vw;max-width:1200px;height:82vh;' +
+        'display:flex;flex-direction:column;overflow:hidden;' +
+      '}' +
+      '.live-wysiwyg-history-modal-header{' +
+        'display:flex;align-items:center;justify-content:space-between;' +
+        'padding:12px 20px;border-bottom:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'flex-shrink:0;' +
+      '}' +
+      '.live-wysiwyg-history-modal-header h2{' +
+        'margin:0;font-size:1.1rem;color:var(--md-default-fg-color,#333);' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+      '}' +
+      '.live-wysiwyg-history-close-btn{' +
+        'background:none;border:none;font-size:1.5rem;cursor:pointer;' +
+        'color:var(--md-default-fg-color--light,#666);line-height:1;padding:0 4px;' +
+      '}' +
+      '.live-wysiwyg-history-close-btn:hover{color:var(--md-default-fg-color,#333);}' +
+      '.live-wysiwyg-history-modal-body{' +
+        'display:flex;flex:1;overflow:hidden;' +
+      '}' +
+      '.live-wysiwyg-history-dag-container{' +
+        'flex:1;overflow:auto;padding:20px;position:relative;' +
+        'background:var(--md-default-bg-color,#fff);' +
+      '}' +
+
+      // DAG SVG edges (smooth Bézier curves)
+      '.live-wysiwyg-dag-edge{stroke:var(--md-default-fg-color--lightest,#ccc);stroke-width:2;fill:none;}' +
+      '.live-wysiwyg-dag-edge-active{stroke:var(--md-primary-fg-color,#4051b5);stroke-width:3;fill:none;}' +
+
+      // DAG nodes
+      '.live-wysiwyg-history-dag-node{' +
+        'width:300px;height:48px;display:flex;align-items:center;gap:8px;' +
+        'padding:0 12px;border-radius:6px;cursor:pointer;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'transition:border-color .15s,box-shadow .15s;' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'position:relative;z-index:1;' +
+      '}' +
+      '.live-wysiwyg-history-dag-node:hover{' +
+        'border-color:var(--md-accent-fg-color,#7c4dff);' +
+        'box-shadow:0 2px 8px rgba(0,0,0,.1);' +
+      '}' +
+      '.live-wysiwyg-history-dag-node.selected{' +
+        'border-color:var(--md-primary-fg-color,#4051b5);' +
+        'box-shadow:0 0 0 2px var(--md-primary-fg-color--transparent,rgba(64,81,181,.25));' +
+      '}' +
+      '.live-wysiwyg-dag-dot{' +
+        'width:12px;height:12px;border-radius:50%;flex-shrink:0;' +
+        'background:var(--md-default-fg-color--lightest,#ccc);' +
+      '}' +
+      '.live-wysiwyg-history-dag-node.active-path .live-wysiwyg-dag-dot{' +
+        'background:var(--md-primary-fg-color,#4051b5);' +
+      '}' +
+      '.live-wysiwyg-history-dag-node.current .live-wysiwyg-dag-dot{' +
+        'background:var(--md-accent-fg-color,#7c4dff);' +
+        'box-shadow:0 0 0 3px var(--md-accent-fg-color--transparent,rgba(124,77,255,.3));' +
+      '}' +
+      '.live-wysiwyg-history-dag-node.branch-point .live-wysiwyg-dag-dot{' +
+        'border:2px solid var(--md-default-fg-color--light,#999);' +
+      '}' +
+      '.live-wysiwyg-dag-info{' +
+        'flex:1;overflow:hidden;text-overflow:ellipsis;' +
+        'display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;' +
+        'font-size:.75rem;line-height:1.3;color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-dag-time{' +
+        'font-size:.65rem;color:var(--md-default-fg-color--lighter,#999);white-space:nowrap;' +
+      '}' +
+
+      // "You Are Here" snaking SVG path + arrowhead + label
+      '.live-wysiwyg-dag-yah-path{' +
+        'fill:none;stroke:var(--md-accent-fg-color,#7c4dff);' +
+        'stroke-width:3;stroke-dasharray:8 5;' +
+        'pointer-events:none;' +
+      '}' +
+      '.live-wysiwyg-dag-yah-arrowhead{' +
+        'fill:var(--md-accent-fg-color,#7c4dff);pointer-events:none;' +
+      '}' +
+      '.live-wysiwyg-dag-you-are-here-label{' +
+        'display:flex;align-items:center;gap:4px;white-space:nowrap;' +
+        'color:var(--md-accent-fg-color,#7c4dff);' +
+        'font-weight:700;font-size:.73rem;' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'padding:3px 12px 3px 6px;border-radius:12px;' +
+        'border:2px solid var(--md-accent-fg-color,#7c4dff);' +
+        'pointer-events:none;z-index:2;' +
+      '}' +
+      '.live-wysiwyg-dag-you-are-here-label svg{flex-shrink:0;}' +
+
+      // Crumple icon (container groups + branch crumples)
+      '.live-wysiwyg-dag-crumple{' +
+        'width:300px;height:36px;display:flex;align-items:center;gap:8px;' +
+        'padding:0 12px;border-radius:18px;cursor:pointer;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px dashed var(--md-primary-fg-color,#4051b5);' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'transition:background .15s,border-color .15s,box-shadow .15s;' +
+        'position:relative;z-index:1;' +
+      '}' +
+      '.live-wysiwyg-dag-crumple:hover{' +
+        'background:var(--md-primary-fg-color--transparent,rgba(64,81,181,.08));' +
+        'box-shadow:0 2px 8px rgba(0,0,0,.08);' +
+      '}' +
+      '.live-wysiwyg-dag-crumple.active{' +
+        'border-style:solid;' +
+        'background:var(--md-primary-fg-color--transparent,rgba(64,81,181,.1));' +
+      '}' +
+      '.live-wysiwyg-dag-crumple-svg{flex-shrink:0;color:var(--md-primary-fg-color,#4051b5);}' +
+      '.live-wysiwyg-dag-crumple-label{' +
+        'flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;' +
+        'font-size:.7rem;font-weight:600;color:var(--md-primary-fg-color,#4051b5);' +
+      '}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="code"]{border-color:#0d7377;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="code"] .live-wysiwyg-dag-crumple-svg,' +
+      '.live-wysiwyg-dag-crumple[data-container-type="code"] .live-wysiwyg-dag-crumple-label{color:#0d7377;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="code"]:hover{background:rgba(13,115,119,.08);}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="admonition"]{border-color:#bf6900;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="admonition"] .live-wysiwyg-dag-crumple-svg,' +
+      '.live-wysiwyg-dag-crumple[data-container-type="admonition"] .live-wysiwyg-dag-crumple-label{color:#bf6900;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="admonition"]:hover{background:rgba(191,105,0,.08);}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="blockquote"]{border-color:#7b1fa2;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="blockquote"] .live-wysiwyg-dag-crumple-svg,' +
+      '.live-wysiwyg-dag-crumple[data-container-type="blockquote"] .live-wysiwyg-dag-crumple-label{color:#7b1fa2;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="blockquote"]:hover{background:rgba(123,31,162,.08);}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="list"]{border-color:#2e7d32;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="list"] .live-wysiwyg-dag-crumple-svg,' +
+      '.live-wysiwyg-dag-crumple[data-container-type="list"] .live-wysiwyg-dag-crumple-label{color:#2e7d32;}' +
+      '.live-wysiwyg-dag-crumple[data-container-type="list"]:hover{background:rgba(46,125,50,.08);}' +
+      '.live-wysiwyg-dag-crumple.branch-crumple{border-color:#b07d2b;}' +
+      '.live-wysiwyg-dag-crumple.branch-crumple .live-wysiwyg-dag-crumple-svg,' +
+      '.live-wysiwyg-dag-crumple.branch-crumple .live-wysiwyg-dag-crumple-label{color:#b07d2b;}' +
+      '.live-wysiwyg-dag-crumple.branch-crumple:hover{background:rgba(176,125,43,.08);}' +
+      '.live-wysiwyg-dag-crumple.branch-crumple.active{border-style:solid;background:rgba(176,125,43,.1);}' +
+
+      // V-tree fork icon
+      '.live-wysiwyg-dag-vtree-fork{' +
+        'width:300px;height:36px;display:flex;align-items:center;gap:8px;' +
+        'padding:0 12px;border-radius:18px;cursor:pointer;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px dashed #6d4c9f;' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'transition:background .15s,box-shadow .15s;' +
+        'position:relative;z-index:1;' +
+      '}' +
+      '.live-wysiwyg-dag-vtree-fork:hover{background:rgba(109,76,159,.08);box-shadow:0 2px 8px rgba(0,0,0,.08);}' +
+      '.live-wysiwyg-dag-vtree-fork.active{border-style:solid;background:rgba(109,76,159,.1);}' +
+      '.live-wysiwyg-dag-vtree-svg{flex-shrink:0;color:#6d4c9f;}' +
+      '.live-wysiwyg-dag-vtree-label{' +
+        'flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;' +
+        'font-size:.7rem;font-weight:600;color:#6d4c9f;' +
+      '}' +
+
+      // V-tree option (branch picker item)
+      '.live-wysiwyg-dag-vtree-option{' +
+        'width:300px;height:36px;display:flex;align-items:center;gap:8px;' +
+        'padding:0 12px;border-radius:6px;cursor:pointer;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'transition:border-color .15s,box-shadow .15s;' +
+        'position:relative;z-index:1;' +
+      '}' +
+      '.live-wysiwyg-dag-vtree-option:hover{border-color:#6d4c9f;box-shadow:0 2px 8px rgba(0,0,0,.08);}' +
+      '.live-wysiwyg-dag-vtree-option .live-wysiwyg-dag-crumple-svg{color:#b07d2b;}' +
+      '.live-wysiwyg-dag-vtree-option-label{' +
+        'flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;' +
+        'font-size:.7rem;color:var(--md-default-fg-color,#333);' +
+      '}' +
+
+      // Block context dotted outline
+      '.live-wysiwyg-dag-block-outline{' +
+        'border:2px dashed var(--md-primary-fg-color,#4051b5);' +
+        'border-radius:8px;z-index:0;pointer-events:none;' +
+      '}' +
+      '.live-wysiwyg-dag-block-outline[data-container-type="code"]{border-color:#0d7377;}' +
+      '.live-wysiwyg-dag-block-outline[data-container-type="admonition"]{border-color:#bf6900;}' +
+      '.live-wysiwyg-dag-block-outline[data-container-type="blockquote"]{border-color:#7b1fa2;}' +
+      '.live-wysiwyg-dag-block-outline[data-container-type="list"]{border-color:#2e7d32;}' +
+      '.live-wysiwyg-dag-block-outline.inactive{opacity:.35;}' +
+      '.live-wysiwyg-dag-block-outline-title{' +
+        'position:absolute;top:-9px;left:12px;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'padding:0 6px;font-size:.62rem;font-weight:600;' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'color:inherit;white-space:nowrap;' +
+      '}' +
+
+      // Unfold / entrance animation
+      '.live-wysiwyg-history-dag-node.group-enter{' +
+        'animation:liveWysiwygGroupEnter .3s ease-out both;' +
+      '}' +
+      '@keyframes liveWysiwygGroupEnter{' +
+        '0%{transform:scaleY(0);opacity:0;}100%{transform:scaleY(1);opacity:1;}' +
+      '}' +
+
+      // Organic tree view
+      '.live-wysiwyg-organic-wrapper{transition:opacity .3s ease-out;}' +
+      '.live-wysiwyg-dag-transitioning .live-wysiwyg-organic-wrapper,' +
+      '.live-wysiwyg-dag-transitioning > div{' +
+        'animation:liveWysiwygDagFadeIn .3s ease-out both;' +
+      '}' +
+      '@keyframes liveWysiwygDagFadeIn{0%{opacity:0;}100%{opacity:1;}}' +
+      '.live-wysiwyg-organic-svg{pointer-events:none;}' +
+      '.live-wysiwyg-organic-edge{stroke:var(--md-default-fg-color--lightest,#ccc);stroke-width:1.5;fill:none;}' +
+      '.live-wysiwyg-organic-edge-active{stroke:var(--md-primary-fg-color,#4051b5);stroke-width:2;fill:none;}' +
+      '.live-wysiwyg-organic-dot{' +
+        'width:10px;height:10px;border-radius:50%;cursor:pointer;' +
+        'background:var(--md-default-fg-color--lightest,#ccc);' +
+        'transition:transform .15s,box-shadow .15s;' +
+        'z-index:1;' +
+      '}' +
+      '.live-wysiwyg-organic-dot:hover{' +
+        'transform:scale(1.6);' +
+        'box-shadow:0 0 6px rgba(0,0,0,.2);' +
+      '}' +
+      '.live-wysiwyg-organic-dot.active-path{' +
+        'background:var(--md-primary-fg-color,#4051b5);' +
+      '}' +
+      '.live-wysiwyg-organic-dot.current{' +
+        'width:14px;height:14px;margin:-2px 0 0 -2px;' +
+        'background:var(--md-accent-fg-color,#7c4dff);' +
+        'box-shadow:0 0 0 4px var(--md-accent-fg-color--transparent,rgba(124,77,255,.35)),' +
+                  '0 0 12px var(--md-accent-fg-color--transparent,rgba(124,77,255,.25));' +
+        'animation:liveWysiwygOrganicGlow 2s ease-in-out infinite;' +
+      '}' +
+      '@keyframes liveWysiwygOrganicGlow{' +
+        '0%,100%{box-shadow:0 0 0 4px var(--md-accent-fg-color--transparent,rgba(124,77,255,.35)),0 0 12px var(--md-accent-fg-color--transparent,rgba(124,77,255,.25));}' +
+        '50%{box-shadow:0 0 0 6px var(--md-accent-fg-color--transparent,rgba(124,77,255,.2)),0 0 18px var(--md-accent-fg-color--transparent,rgba(124,77,255,.15));}' +
+      '}' +
+
+      // Toggle view button
+      '.live-wysiwyg-history-toggle-view-btn{' +
+        'background:var(--md-primary-fg-color--transparent,rgba(64,81,181,.1));' +
+        'border:1px solid var(--md-primary-fg-color,#4051b5);' +
+        'border-radius:4px;padding:4px 12px;cursor:pointer;' +
+        'font-size:.72rem;font-weight:600;' +
+        'color:var(--md-primary-fg-color,#4051b5);' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+        'transition:background .15s;margin-right:8px;' +
+      '}' +
+      '.live-wysiwyg-history-toggle-view-btn:hover{' +
+        'background:var(--md-primary-fg-color--transparent,rgba(64,81,181,.2));' +
+      '}' +
+
+      // "Show All Redo History" popup item
+      '.live-wysiwyg-history-branch-item.show-all-history{' +
+        'border-top:1px solid var(--md-default-fg-color--lightest,#eee);' +
+        'margin-top:2px;padding-top:8px;' +
+        'flex-direction:row;align-items:center;' +
+      '}' +
+      '.live-wysiwyg-history-branch-item.show-all-history .live-wysiwyg-history-branch-summary{' +
+        'display:flex;align-items:center;' +
+        'color:var(--md-primary-fg-color,#4051b5);font-weight:600;' +
+      '}' +
+
+      // Hover preview tooltip
+      '.live-wysiwyg-history-hover-preview{' +
+        'position:fixed;z-index:99999;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'border:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'border-radius:6px;box-shadow:0 4px 20px rgba(0,0,0,.15);' +
+        'width:300px;max-height:280px;overflow:hidden;' +
+        'font-family:var(--md-text-font-family,sans-serif);' +
+      '}' +
+      '.live-wysiwyg-history-hover-snippet{' +
+        'padding:8px 10px;font-size:.7rem;font-family:var(--md-code-font-family,monospace);' +
+        'color:var(--md-default-fg-color--light,#666);' +
+        'border-bottom:1px solid var(--md-default-fg-color--lightest,#eee);' +
+        'white-space:pre;overflow:hidden;max-height:52px;' +
+      '}' +
+      '.live-wysiwyg-history-hover-rendered{' +
+        'padding:8px 10px;font-size:.78rem;overflow:hidden;max-height:160px;' +
+        'color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-hover-rendered h1,.live-wysiwyg-history-hover-rendered h2,' +
+      '.live-wysiwyg-history-hover-rendered h3{font-size:.85rem;margin:.3em 0;}' +
+      '.live-wysiwyg-history-hover-rendered p{margin:.3em 0;}' +
+      '.live-wysiwyg-history-hover-rendered pre{' +
+        'font-size:.68rem;background:var(--md-code-bg-color,#f5f5f5);padding:4px;border-radius:3px;overflow:hidden;' +
+      '}' +
+      '.live-wysiwyg-history-hover-fullscreen-btn{' +
+        'display:block;width:100%;padding:5px;text-align:center;' +
+        'border:none;border-top:1px solid var(--md-default-fg-color--lightest,#eee);' +
+        'background:var(--md-default-bg-color,#fff);cursor:pointer;font-size:.7rem;' +
+        'color:var(--md-primary-fg-color,#4051b5);' +
+      '}' +
+      '.live-wysiwyg-history-hover-fullscreen-btn:hover{' +
+        'background:var(--md-accent-fg-color--transparent,rgba(82,108,254,.06));' +
+      '}' +
+
+      // Preview panel (right side of DAG overlay — hidden until a node is selected)
+      '.live-wysiwyg-history-preview-panel{' +
+        'width:0;min-width:0;overflow:hidden;display:flex;flex-direction:column;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'transition:width .3s ease,min-width .3s ease,border-width .3s ease;' +
+        'border-left:0 solid var(--md-default-fg-color--lightest,#ddd);' +
+      '}' +
+      '.live-wysiwyg-history-preview-panel.open{' +
+        'width:40%;min-width:280px;overflow-y:auto;' +
+        'border-left-width:1px;' +
+      '}' +
+      '.live-wysiwyg-history-preview-header{' +
+        'display:flex;align-items:center;gap:8px;padding:10px 14px;flex-shrink:0;' +
+        'border-bottom:1px solid var(--md-default-fg-color--lightest,#eee);' +
+        'font-size:.78rem;color:var(--md-default-fg-color,#333);flex-wrap:wrap;' +
+      '}' +
+      '.live-wysiwyg-history-preview-fullscreen-btn,' +
+      '.live-wysiwyg-history-preview-restore-btn{' +
+        'border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:.72rem;' +
+      '}' +
+      '.live-wysiwyg-history-preview-fullscreen-btn{' +
+        'background:var(--md-default-fg-color--lightest,#eee);color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-preview-restore-btn{' +
+        'background:var(--md-primary-fg-color,#4051b5);color:#fff;' +
+      '}' +
+      '.live-wysiwyg-history-preview-content{' +
+        'padding:14px;font-size:.85rem;overflow-y:auto;flex:1;' +
+        'color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-preview-content h1,.live-wysiwyg-history-preview-content h2,' +
+      '.live-wysiwyg-history-preview-content h3{margin:.5em 0;}' +
+      '.live-wysiwyg-history-preview-content pre{' +
+        'font-size:.78rem;background:var(--md-code-bg-color,#f5f5f5);padding:8px;border-radius:4px;overflow:auto;' +
+      '}' +
+
+      // Diff highlight overlay for changed/added blocks
+      '.live-wysiwyg-diff-highlight{' +
+        'position:relative;' +
+      '}' +
+      '.live-wysiwyg-diff-highlight::before{' +
+        'content:"";position:absolute;inset:-2px -4px;' +
+        'background:rgba(46,160,67,.13);' +
+        'border-left:3px solid rgba(46,160,67,.6);' +
+        'border-radius:3px;pointer-events:none;z-index:0;' +
+      '}' +
+
+      // Full-size readonly preview
+      '.live-wysiwyg-history-fullsize-preview{' +
+        'position:fixed;inset:0;z-index:99995;' +
+        'background:var(--md-default-bg-color,#fff);' +
+        'display:flex;flex-direction:column;outline:none;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-header{' +
+        'display:flex;align-items:center;gap:10px;padding:10px 20px;flex-shrink:0;' +
+        'border-bottom:1px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'font-family:var(--md-text-font-family,sans-serif);font-size:.85rem;' +
+        'color:var(--md-default-fg-color,#333);' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-header span{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}' +
+      '.live-wysiwyg-history-fullsize-restore-btn{' +
+        'background:var(--md-primary-fg-color,#4051b5);color:#fff;' +
+        'border:none;border-radius:4px;padding:5px 14px;cursor:pointer;font-size:.8rem;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-close-btn{' +
+        'background:var(--md-default-fg-color--lightest,#eee);color:var(--md-default-fg-color,#333);' +
+        'border:none;border-radius:4px;padding:5px 14px;cursor:pointer;font-size:.8rem;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-body{' +
+        'flex:1;overflow-y:auto;padding:20px;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content{' +
+        'max-width:48rem;margin:0 auto;' +
+        'font-family:var(--md-text-font-family,sans-serif);font-size:.95rem;' +
+        'color:var(--md-default-fg-color,#333);line-height:1.6;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content h1{font-size:1.6rem;margin:.8em 0 .4em;}' +
+      '.live-wysiwyg-history-fullsize-content h2{font-size:1.3rem;margin:.7em 0 .3em;}' +
+      '.live-wysiwyg-history-fullsize-content h3{font-size:1.1rem;margin:.6em 0 .3em;}' +
+      '.live-wysiwyg-history-fullsize-content pre{' +
+        'background:var(--md-code-bg-color,#f5f5f5);padding:12px;border-radius:4px;overflow:auto;' +
+        'font-family:var(--md-code-font-family,monospace);font-size:.85rem;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content code{' +
+        'background:var(--md-code-bg-color,#f5f5f5);padding:.1em .3em;border-radius:3px;' +
+        'font-family:var(--md-code-font-family,monospace);font-size:.85em;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content pre code{background:none;padding:0;}' +
+      '.live-wysiwyg-history-fullsize-content blockquote{' +
+        'border-left:3px solid var(--md-default-fg-color--lightest,#ddd);' +
+        'margin:0;padding:.5em 1em;color:var(--md-default-fg-color--light,#666);' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content img{max-width:100%;height:auto;}' +
+      '.live-wysiwyg-history-fullsize-content table{' +
+        'border-collapse:collapse;width:100%;margin:1em 0;' +
+      '}' +
+      '.live-wysiwyg-history-fullsize-content th,.live-wysiwyg-history-fullsize-content td{' +
+        'border:1px solid var(--md-default-fg-color--lightest,#ddd);padding:6px 10px;text-align:left;' +
+      '}' +
+      '';
+
     return css;
   }
 
@@ -22054,6 +24954,7 @@
 
   function exitFocusMode() {
     if (!isFocusModeActive) return;
+    if (_historyModeActive) _exitHistoryMode();
     if (_mermaidModeActive) exitMermaidMode();
 
     _flushHistoryCapture();
@@ -22173,6 +25074,7 @@
 
   function enterMermaidMode(mermaidBlock) {
     if (_mermaidModeActive) return;
+    if (_historyModeActive) return;
     if (!isFocusModeActive || !wysiwygEditor) return;
 
     var pre = mermaidBlock.querySelector('pre[data-lang="mermaid"]') || mermaidBlock.querySelector('pre');
@@ -23548,7 +26450,7 @@
       _historyReset(markdown);
     };
 
-    wysiwygEditor._historyApplyContent = function (markdown) {
+    wysiwygEditor._historyApplyContent = function (markdown, htmlSnapshot) {
       textarea.value = markdown;
       var parsed = parseFrontmatter(markdown);
       wysiwygEditor._liveWysiwygFrontmatter = parsed.frontmatter;
@@ -23560,8 +26462,12 @@
       wysiwygEditor._liveWysiwygHrData = preprocessHorizontalRules(bodyForPreprocess);
       wysiwygEditor._liveWysiwygInlineCodeData = preprocessInlineCode(bodyForPreprocess);
       if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor.editableArea) {
-        var html = wysiwygEditor._markdownToHtml(parsed.body);
-        wysiwygEditor.editableArea.innerHTML = html;
+        if (htmlSnapshot) {
+          wysiwygEditor.editableArea.innerHTML = htmlSnapshot;
+        } else {
+          var html = wysiwygEditor._markdownToHtml(parsed.body);
+          wysiwygEditor.editableArea.innerHTML = html;
+        }
         populateRawHtmlBlocks(wysiwygEditor.editableArea);
         enhanceCodeBlocks(wysiwygEditor.editableArea);
         enhanceMermaidBlocks(wysiwygEditor.editableArea);
@@ -24162,6 +27068,7 @@
       if (wysiwygEditor._finalizeUpdate) {
         wysiwygEditor._finalizeUpdate(ea.innerHTML);
       }
+      _scheduleHistoryCapture(true);
       return true;
     }
 
@@ -24323,6 +27230,7 @@
             }
             anc = anc.parentNode;
           }
+          _flushHistoryCapture();
           var pre = document.createElement('pre');
           pre.setAttribute('data-md-literal', '```');
           var code = document.createElement('code');
@@ -24357,8 +27265,301 @@
           if (wysiwygEditor._finalizeUpdate) {
             wysiwygEditor._finalizeUpdate(ea.innerHTML);
           }
+          _scheduleHistoryCapture(true);
         }, true);
       }
+
+    // ── Inline element arrow-key escape and Enter splitting ──
+    (function inlineElementEscapeSetup() {
+      var ea = wysiwygEditor.editableArea;
+      if (!ea) return;
+
+      var INLINE_ESCAPE_TAGS = { CODE: 1, STRONG: 1, EM: 1, DEL: 1, A: 1, B: 1 };
+
+      function findInlineAncestor(node) {
+        var n = node;
+        var anc = n.nodeType === 3 ? n.parentNode : n;
+        while (anc && anc !== ea) {
+          if (INLINE_ESCAPE_TAGS[anc.nodeName]) {
+            if (anc.nodeName === 'CODE' && anc.parentNode && anc.parentNode.nodeName === 'PRE') return null;
+            return anc;
+          }
+          if (anc.nodeName === 'PRE') return null;
+          anc = anc.parentNode;
+        }
+        return null;
+      }
+
+      function isAtEnd(inlineEl, anchorNode, anchorOffset) {
+        if (anchorNode === inlineEl) return anchorOffset >= inlineEl.childNodes.length;
+        if (anchorNode.nodeType === 3 && anchorNode.parentNode === inlineEl) {
+          if (anchorOffset < anchorNode.textContent.length) return false;
+          var sib = anchorNode.nextSibling;
+          while (sib) {
+            if (sib.nodeType === 3 && sib.textContent.replace(/[\u200B\u200C\u200D\uFEFF]/g, '').length > 0) return false;
+            if (sib.nodeType === 1) return false;
+            sib = sib.nextSibling;
+          }
+          return true;
+        }
+        return false;
+      }
+
+      function isAtStart(inlineEl, anchorNode, anchorOffset) {
+        if (anchorNode === inlineEl) return anchorOffset === 0;
+        if (anchorNode.nodeType === 3 && anchorNode.parentNode === inlineEl) {
+          var effectiveOffset = anchorOffset;
+          var txt = anchorNode.textContent || '';
+          while (effectiveOffset > 0 && /[\u200B\u200C\u200D\uFEFF]/.test(txt.charAt(effectiveOffset - 1))) effectiveOffset--;
+          if (effectiveOffset > 0) return false;
+          var sib = anchorNode.previousSibling;
+          while (sib) {
+            if (sib.nodeType === 3 && sib.textContent.replace(/[\u200B\u200C\u200D\uFEFF]/g, '').length > 0) return false;
+            if (sib.nodeType === 1) return false;
+            sib = sib.previousSibling;
+          }
+          return true;
+        }
+        return false;
+      }
+
+      function ensureTextNodeAfter(inlineEl) {
+        var next = inlineEl.nextSibling;
+        if (next && next.nodeType === 3) return next;
+        var tn = document.createTextNode('\u200B');
+        if (inlineEl.nextSibling) {
+          inlineEl.parentNode.insertBefore(tn, inlineEl.nextSibling);
+        } else {
+          inlineEl.parentNode.appendChild(tn);
+        }
+        return tn;
+      }
+
+      function ensureTextNodeBefore(inlineEl) {
+        var prev = inlineEl.previousSibling;
+        if (prev && prev.nodeType === 3) return prev;
+        var tn = document.createTextNode('\u200B');
+        inlineEl.parentNode.insertBefore(tn, inlineEl);
+        return tn;
+      }
+
+      _ekh.inlineArrowEscape = function (e) {
+        if (e.shiftKey) return;
+        if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+        var sel = window.getSelection();
+        if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+        var anchorNode = sel.anchorNode;
+        var anchorOffset = sel.anchorOffset;
+        if (!anchorNode) return;
+        var inlineEl = findInlineAncestor(anchorNode);
+        if (!inlineEl) return;
+
+        var isRight = e.key === 'ArrowRight';
+        if (isRight && isAtEnd(inlineEl, anchorNode, anchorOffset)) {
+          e.preventDefault();
+          var afterNode = ensureTextNodeAfter(inlineEl);
+          var startOff = (afterNode.textContent.length > 0 && /[\u200B\u200C\u200D\uFEFF]/.test(afterNode.textContent.charAt(0))) ? 1 : 0;
+          var range = document.createRange();
+          range.setStart(afterNode, startOff);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        } else if (!isRight && isAtStart(inlineEl, anchorNode, anchorOffset)) {
+          e.preventDefault();
+          var beforeNode = ensureTextNodeBefore(inlineEl);
+          var endOff = beforeNode.textContent.length;
+          if (endOff > 0 && /[\u200B\u200C\u200D\uFEFF]/.test(beforeNode.textContent.charAt(endOff - 1))) endOff--;
+          var range = document.createRange();
+          range.setStart(beforeNode, endOff);
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      };
+
+      function findContainingBlock(node) {
+        var anc = node;
+        while (anc && anc !== ea) {
+          if (anc.nodeName === 'P' || anc.nodeName === 'LI' || anc.nodeName === 'DIV' ||
+              (anc.nodeName.match && anc.nodeName.match(/^H[1-6]$/))) {
+            if (anc.nodeName === 'DIV' && anc === ea) break;
+            return anc;
+          }
+          anc = anc.parentNode;
+        }
+        return null;
+      }
+
+      function collectNodesAfter(refNode, container) {
+        var nodes = [];
+        var sib = refNode.nextSibling;
+        while (sib) {
+          nodes.push(sib);
+          sib = sib.nextSibling;
+        }
+        if (refNode.parentNode !== container) {
+          var parent = refNode.parentNode;
+          sib = parent.nextSibling;
+          while (sib) {
+            nodes.push(sib);
+            sib = sib.nextSibling;
+          }
+        }
+        return nodes;
+      }
+
+      _ekh.inlineEnterEscape = function (e) {
+        if (e.shiftKey) return;
+        if (wysiwygEditor.currentMode !== 'wysiwyg') return;
+        var sel = window.getSelection();
+        if (!sel || !sel.isCollapsed || !sel.rangeCount) return;
+        var anchorNode = sel.anchorNode;
+        var anchorOffset = sel.anchorOffset;
+        if (!anchorNode) return;
+        var inlineEl = findInlineAncestor(anchorNode);
+        if (!inlineEl) return;
+
+        var block = findContainingBlock(inlineEl);
+        if (!block) return;
+
+        e.preventDefault();
+        _flushHistoryCapture();
+
+        var atEnd = isAtEnd(inlineEl, anchorNode, anchorOffset);
+        var atStart = isAtStart(inlineEl, anchorNode, anchorOffset);
+
+        var newBlock;
+        if (block.nodeName === 'LI') {
+          newBlock = document.createElement('li');
+        } else {
+          newBlock = document.createElement('p');
+        }
+
+        if (atStart) {
+          var nodesFromInline = [];
+          var sib = inlineEl;
+          while (sib) {
+            nodesFromInline.push(sib);
+            sib = sib.nextSibling;
+          }
+          for (var i = 0; i < nodesFromInline.length; i++) {
+            newBlock.appendChild(nodesFromInline[i]);
+          }
+          if (!block.hasChildNodes() || (block.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '').length === 0) {
+            block.innerHTML = '<br>';
+          }
+          if (block.nodeName === 'LI' && block.parentNode) {
+            block.parentNode.insertBefore(newBlock, block.nextSibling);
+          } else {
+            block.parentNode.insertBefore(newBlock, block.nextSibling);
+          }
+          var cursorTarget = newBlock.firstChild;
+          if (!cursorTarget) { cursorTarget = document.createTextNode('\u200B'); newBlock.appendChild(cursorTarget); }
+          var range = document.createRange();
+          if (cursorTarget.nodeType === 3) {
+            range.setStart(cursorTarget, 0);
+          } else {
+            range.setStart(newBlock, 0);
+          }
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        } else if (atEnd) {
+          var nodesAfter = collectNodesAfter(inlineEl, block);
+          var hasContentAfter = false;
+          for (var i = 0; i < nodesAfter.length; i++) {
+            var nodeText = (nodesAfter[i].textContent || '').replace(/[\u200B\u200C\u200D\uFEFF]/g, '').trim();
+            if (nodeText.length > 0 || (nodesAfter[i].nodeType === 1 && nodesAfter[i].nodeName !== 'BR')) {
+              hasContentAfter = true;
+              break;
+            }
+          }
+          if (hasContentAfter) {
+            for (var i = 0; i < nodesAfter.length; i++) {
+              newBlock.appendChild(nodesAfter[i]);
+            }
+          } else {
+            for (var i = 0; i < nodesAfter.length; i++) {
+              if (nodesAfter[i].parentNode) nodesAfter[i].parentNode.removeChild(nodesAfter[i]);
+            }
+            newBlock.innerHTML = '<br>';
+          }
+          block.parentNode.insertBefore(newBlock, block.nextSibling);
+          var cursorTarget = newBlock.firstChild;
+          if (!cursorTarget) { cursorTarget = document.createTextNode('\u200B'); newBlock.appendChild(cursorTarget); }
+          var range = document.createRange();
+          if (cursorTarget.nodeType === 3) {
+            range.setStart(cursorTarget, 0);
+          } else {
+            range.setStart(newBlock, 0);
+          }
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        } else {
+          var text = anchorNode.textContent || '';
+          var leftText = text.substring(0, anchorOffset);
+          var rightText = text.substring(anchorOffset);
+
+          anchorNode.textContent = leftText;
+
+          var cloned = document.createElement(inlineEl.nodeName);
+          for (var ai = 0; ai < inlineEl.attributes.length; ai++) {
+            var attr = inlineEl.attributes[ai];
+            if (attr.name === 'data-md-literal') continue;
+            cloned.setAttribute(attr.name, attr.value);
+          }
+          cloned.textContent = rightText;
+
+          var nodesAfterInline = collectNodesAfter(inlineEl, block);
+          if (rightText.replace(/[\u200B\u200C\u200D\uFEFF]/g, '').length > 0) {
+            newBlock.appendChild(cloned);
+          } else {
+            if (rightText) {
+              newBlock.appendChild(document.createTextNode(rightText));
+            }
+          }
+          for (var i = 0; i < nodesAfterInline.length; i++) {
+            newBlock.appendChild(nodesAfterInline[i]);
+          }
+          if (!newBlock.hasChildNodes()) newBlock.innerHTML = '<br>';
+
+          var trailingInOriginal = inlineEl.nextSibling;
+          while (trailingInOriginal) {
+            var next = trailingInOriginal.nextSibling;
+            if (trailingInOriginal.nodeType === 3) {
+              var trimmed = trailingInOriginal.textContent.replace(/[\u200B\u200C\u200D\uFEFF]/g, '');
+              if (trimmed.length === 0) { trailingInOriginal.parentNode.removeChild(trailingInOriginal); }
+            }
+            trailingInOriginal = next;
+          }
+
+          if (leftText.replace(/[\u200B\u200C\u200D\uFEFF]/g, '').length === 0) {
+            if (inlineEl.parentNode) inlineEl.parentNode.removeChild(inlineEl);
+            if (!block.hasChildNodes() || (block.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF\s]/g, '').length === 0) {
+              block.innerHTML = '<br>';
+            }
+          }
+
+          block.parentNode.insertBefore(newBlock, block.nextSibling);
+          var cursorTarget = newBlock.firstChild;
+          if (!cursorTarget) { cursorTarget = document.createTextNode('\u200B'); newBlock.appendChild(cursorTarget); }
+          var range = document.createRange();
+          if (cursorTarget.nodeType === 3) {
+            range.setStart(cursorTarget, 0);
+          } else {
+            range.setStart(newBlock, 0);
+          }
+          range.collapse(true);
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+
+        if (wysiwygEditor._finalizeUpdate) {
+          wysiwygEditor._finalizeUpdate(ea.innerHTML);
+        }
+      };
+    })();
 
     (function emojiShortcodeSupport() {
       var EMOJI_MAP = (typeof liveWysiwygEmojiMap !== "undefined" ? liveWysiwygEmojiMap : {});
@@ -25008,14 +28209,12 @@
             } else {
               wrapper.parentNode.appendChild(pAfter);
             }
-            requestAnimationFrame(function () {
-              var range = document.createRange();
-              range.setStart(pAfter, 0);
-              range.collapse(true);
-              sel.removeAllRanges();
-              sel.addRange(range);
-              ea.focus();
-            });
+            var range = document.createRange();
+            range.setStart(pAfter, 0);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            ea.focus();
           }
         } else {
           requestAnimationFrame(function () {
@@ -25320,7 +28519,7 @@
         if (node.nodeType === 3) node = node.parentNode;
         if (!ea.contains(node)) return false;
 
-        // Inline element revert: cursor at start, at end, or immediately after (CODE, STRONG, EM, DEL, A)
+        // Inline element revert: cursor at start/end (non-CODE) or immediately after (all inline elements)
         var anchorNode = sel.anchorNode;
         var anchorOffset = sel.anchorOffset;
         var inlineEl = null;
@@ -25332,11 +28531,13 @@
         while (anc && anc !== ea) {
           if (INLINE_REVERT_TAGS[anc.nodeName]) {
             if (anc.nodeName === 'CODE' && anc.parentNode && anc.parentNode.nodeName === 'PRE') break;
-            inlineEl = anc;
-            var atStart = (n === anc && anchorOffset === 0) || (n.parentNode === anc && anchorOffset === 0);
-            var atEnd = (n === anc && anchorOffset === anc.childNodes.length) ||
-              (n.parentNode === anc && anchorOffset === (n.textContent || '').length);
-            if (atStart || atEnd) atRevertPosition = true;
+            if (anc.nodeName !== 'CODE') {
+              inlineEl = anc;
+              var atStart = (n === anc && anchorOffset === 0) || (n.parentNode === anc && anchorOffset === 0);
+              var atEnd = (n === anc && anchorOffset === anc.childNodes.length) ||
+                (n.parentNode === anc && anchorOffset === (n.textContent || '').length);
+              if (atStart || atEnd) atRevertPosition = true;
+            }
             break;
           }
           if (anc.nodeName === 'PRE') break;
@@ -25695,10 +28896,12 @@
         }
 
         if (e.key === 'Backspace' && !e.defaultPrevented) {
+          _flushHistoryCapture();
           if (handleRevertOnBackspace(sel)) {
             e.preventDefault();
             e.stopImmediatePropagation();
             if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+            _scheduleHistoryCapture(true);
             return;
           }
         }
@@ -25709,10 +28912,12 @@
         var anchorOffset = sel.anchorOffset;
         if (!anchorNode || anchorNode.nodeType !== 3) return;
         if (isInsidePreOrCode(anchorNode)) return;
+        _flushHistoryCapture();
         var converted = handleBlockConversions(anchorNode, anchorOffset, sel, false);
         if (converted) {
           e.preventDefault();
           if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          _scheduleHistoryCapture(true);
         }
       };
 
@@ -25734,7 +28939,10 @@
 
         if (ch === ' ') {
           converted = handleListToChecklist(anchorNode, anchorOffset, sel);
-          if (!converted) converted = handleBlockConversions(anchorNode, anchorOffset, sel, true);
+          if (!converted) {
+            _flushHistoryCapture();
+            converted = handleBlockConversions(anchorNode, anchorOffset, sel, true);
+          }
         }
 
         if (!converted && (ch === '-' || ch === '*' || ch === '_')) {
@@ -25753,8 +28961,9 @@
           converted = handleCloseParen(anchorNode, anchorOffset, sel);
         }
 
-        if (converted && wysiwygEditor._finalizeUpdate) {
-          wysiwygEditor._finalizeUpdate(ea.innerHTML);
+        if (converted) {
+          if (wysiwygEditor._finalizeUpdate) wysiwygEditor._finalizeUpdate(ea.innerHTML);
+          _scheduleHistoryCapture(true);
         }
       });
     })();
@@ -25883,7 +29092,16 @@
         if (node.nodeName === "CODE" && !this._findParentElement(node, 'PRE')) {
           var codeContent = (node.textContent || '').replace(/[\u200B\u200C\u200D\uFEFF]/g, '').trim();
           if (options && options.inTableCell) codeContent = codeContent.replace(/\|/g, '\\|');
-          if (codeContent.indexOf('`') >= 0) return '`` ' + codeContent + ' ``';
+          if (codeContent.indexOf('`') >= 0) {
+            var needed = 1, brun = 0;
+            for (var ci = 0; ci < codeContent.length; ci++) {
+              if (codeContent.charAt(ci) === '`') { brun++; if (brun >= needed) needed = brun + 1; }
+              else { brun = 0; }
+            }
+            var ticks = '';
+            for (var ti = 0; ti < needed; ti++) ticks += '`';
+            return ticks + ' ' + codeContent + ' ' + ticks;
+          }
           return '`' + codeContent + '`';
         }
         if (node.nodeName === "IMG" && node.getAttribute) {
@@ -25968,6 +29186,7 @@
             }
             if (toRemove.length === 0) return;
             e.preventDefault();
+            _flushHistoryCapture();
             var insertionParent = toRemove[0].parentNode;
             var insertionRef = toRemove[0].nextSibling;
             for (var ri = 0; ri < toRemove.length; ri++) {
@@ -26007,6 +29226,7 @@
             if (wysiwygEditor._finalizeUpdate) {
               wysiwygEditor._finalizeUpdate(ea.innerHTML);
             }
+            _scheduleHistoryCapture(true);
             return;
           }
           var node = sel.anchorNode;
@@ -26027,6 +29247,7 @@
             e.preventDefault();
             var preEl = blockContainer.nodeName === 'PRE' ? blockContainer : blockContainer.querySelector('pre');
             var literal = preEl && preEl.getAttribute('data-md-literal');
+            _flushHistoryCapture();
             var parentNode = blockContainer.parentNode;
             var nextSib = blockContainer.nextSibling;
             parentNode.removeChild(blockContainer);
@@ -26056,6 +29277,7 @@
             if (wysiwygEditor._finalizeUpdate) {
               wysiwygEditor._finalizeUpdate(ea.innerHTML);
             }
+            _scheduleHistoryCapture(true);
             return;
           }
 
@@ -27972,6 +31194,8 @@
           e.preventDefault();
           _undoViaBeforeinput = true;
           _contentRedo();
+        } else if (_historyBranchPopup) {
+          _dismissHistoryBranchPopup();
         }
       });
 
@@ -27988,6 +31212,7 @@
         var key = e.key;
 
         if (key === 'Enter') {
+          if (_ekh.inlineEnterEscape) { _ekh.inlineEnterEscape(e); if (e.defaultPrevented) return; }
           if (_ekh.reverseBubble) { _ekh.reverseBubble(e); if (e.defaultPrevented) return; }
           if (_ekh.listEnterExit) { _ekh.listEnterExit(e); if (e.defaultPrevented) return; }
           if (_ekh.admonitionEnterExit) { _ekh.admonitionEnterExit(e); if (e.defaultPrevented) return; }
@@ -28005,6 +31230,7 @@
         } else if (key === ' ') {
           if (_ekh.mdAuto) _ekh.mdAuto(e);
         } else if (key === 'ArrowLeft' || key === 'ArrowRight') {
+          if (_ekh.inlineArrowEscape) { _ekh.inlineArrowEscape(e); if (e.defaultPrevented) return; }
           if (_ekh.checklistArrow) _ekh.checklistArrow(e);
         } else if (key === 'a' && (e.metaKey || e.ctrlKey)) {
           if (_ekh.progressiveSelectAll) _ekh.progressiveSelectAll(e);


### PR DESCRIPTION
Enhancement
-----------

- Universal History UI for redoing DAG branches

Fixes
-----

- Bugfix moving subfolders not getting proper weight
- Bugfix triple backticks inline code blocks
- Bugfix inline element escape keys.  For elements like: bold, italics, strikethroughs, inline codeblocks, etc.  The user can now properly escape the inline element with left and right arrow key shortcuts.  Pressing enter while the cursor is midway through an inline element properly handles its splitting rather than unexpected editing behavior.
- Bugfix pressing backspace on inline code blocks.  Revert only if cursor is at the end outside of the inline code blocks.  Pressing backspace from within the inline code block should not revert it and allow the user to remove content from within the inline code block.
- Fixing history
  - Undo history now respects markdown reversions
  - Bugfix: Universal undo handles undoing mermaid diagrams with default content
  - More reliable undo DAG capturing which had issues when rendering checks failed
  - History is now code-block aware and cursor placement is block level