### PR TITLE
Tables needed some love

### DIFF
--- a/.cursor/rules/help-reference-updates.mdc
+++ b/.cursor/rules/help-reference-updates.mdc
@@ -1,0 +1,30 @@
+---
+description: When to update the WYSIWYG editor help reference documentation
+globs: mkdocs-live-wysiwyg-plugin/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+alwaysApply: false
+---
+
+# Help Reference Updates
+
+The file `mkdocs-live-wysiwyg-plugin/mkdocs_live_wysiwyg_plugin/help-reference.md` is the user-facing help documentation for the WYSIWYG editor. It is displayed in-app via Ctrl+? / Cmd+?.
+
+## When to Update
+
+Update `help-reference.md` whenever:
+
+- A new keyboard shortcut or typing shortcut is added
+- An existing shortcut's behavior changes
+- A new auto-conversion pattern is added (inline or block)
+- A new UI element (button, dropdown, mode) is added to the editor
+- An existing UI element's behavior or location changes
+
+## Structure
+
+The file has context-tagged sections (`<!-- context: all -->`, `<!-- context: content -->`, `<!-- context: nav -->`). Place new entries in the appropriate section:
+
+- **General**: modes, saving, global shortcuts
+- **Content Shortcuts**: WYSIWYG/Markdown mode shortcuts
+- **Auto-Conversions**: inline typing patterns (bold, italic, code, links)
+- **Block Elements**: code blocks, admonitions, block quotes, lists, horizontal rules
+- **Inline & Emoji**: inline code, emoji shortcodes
+- **Nav Shortcuts**: focus mode nav menu shortcuts

--- a/.cursor/rules/markdown-awareness.mdc
+++ b/.cursor/rules/markdown-awareness.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 The Markdown Awareness subsystem preserves markdown fidelity through the lossy HTML round-trip and ensures all content-loading paths produce a fully enhanced, structurally correct DOM. It has two pillars: the 7 preprocess/postprocess pairs that capture and restore markdown-specific formatting, and the 6 DOM enhancer functions that add interactive UI to raw elements.
 
+The table pair (`preprocessTables` / `postprocessTables`) is the most sophisticated pair. It snapshots entire table blocks and uses normalized content comparison to detect modifications. Unchanged tables with consistent formatting are restored verbatim; unchanged tables with inconsistent formatting and all modified/new tables are balanced via `_formatBalancedTable` (alignment-aware, width-limited). Column alignment (`text-align` on `<th>`/`<td>`) round-trips through GFM markers (`:---`, `:---:`, `---:`).
+
 ## Rules
 
 1. **Every content-loading code path must refresh preprocess data and run DOM enhancers.** If a function sets `editableArea.innerHTML` from markdown, it must update all 7 `_liveWysiwyg*Data` stores and call all 6 enhance functions. Partial loading (setting innerHTML without preprocessing or enhancing) is a bug. Current content-loading paths: `setValue`, `switchToMode`, `_historyApplyContent`.
@@ -27,6 +29,14 @@ The Markdown Awareness subsystem preserves markdown fidelity through the lossy H
 
 9. **Undo history is aware of markdown construct boundaries.** The Content History pre-flush captures intermediate typing states (literal `` ```mermaid `` text, `## ` prefixes, `> ` prefixes) as HTML snapshot nodes before block conversions. This preserves the exact DOM of partially-typed markdown constructs that the parser would reinterpret on round-trip. The always-on HTML snapshot ensures faithful restoration during undo, allowing walkback through every conversion step.
 
+10. **Table column alignment must survive WYSIWYG round-trips.** `_htmlToMarkdown` reads `style.textAlign` from `<th>`/`<td>` and emits GFM alignment markers. `_markdownToHtml` and DOM enhancement parse these markers back into `text-align` styles. The contextual table toolbar provides alignment buttons that set `text-align` on all cells in the selected column.
+
+11. **Unchanged tables with consistent formatting are restored verbatim.** `postprocessTables` compares normalized content against preprocess snapshots. Matching tables with uniform row lengths are restored byte-for-byte. This prevents formatting diffs on content the user did not touch.
+
+12. **Modified or inconsistently formatted tables are balanced.** `_formatBalancedTable` produces evenly padded columns with aligned pipe separators, respecting per-table (`data-table-width`) or global (`localStorage` key `liveWysiwygTableWidthLimit`, default 120) width limits.
+
+13. **Tables must be block-level siblings, never nested inside headings or inline containers.** `_insertTableWysiwyg` inserts tables as siblings after block elements. The heading case in `_nodeToMarkdownRecursive` defensively splits inadvertently nested block children into separate markdown blocks.
+
 ## Preprocess/Postprocess Pairs
 
 | Store | Preprocessor | Postprocessor |
@@ -34,7 +44,7 @@ The Markdown Awareness subsystem preserves markdown fidelity through the lossy H
 | `_liveWysiwygCodeBlockData` | `preprocessCodeBlocks` | `postprocessCodeBlocks` |
 | `_liveWysiwygLinkData` | `preprocessMarkdownLinks` | `postprocessMarkdownLinks` |
 | `_liveWysiwygListMarkerData` | `preprocessListMarkers` | `postprocessListMarkers` |
-| `_liveWysiwygTableSepData` | `preprocessTableSeparators` | `postprocessTableSeparators` |
+| `_liveWysiwygTableData` | `preprocessTables` | `postprocessTables` |
 | `_liveWysiwygHrData` | `preprocessHorizontalRules` | `postprocessHorizontalRules` |
 | `_liveWysiwygInlineCodeData` | `preprocessInlineCode` | `postprocessInlineCode` |
 | `_liveWysiwygRawHtmlData` | `preprocessRawHtml` | `postprocessRawHtml` |

--- a/docs/design/DESIGN-architecture-overview.md
+++ b/docs/design/DESIGN-architecture-overview.md
@@ -134,6 +134,7 @@ UI Subsystem
   |     |-- Keyboard
   |     |-- Progressive Select All
   |     |-- Markdown Awareness
+  |     |-- Tables
   |     |-- Dialog UX
   |     |-- Table of Contents
   |     |-- Help System (Layer 5 modal, context-sensitive shortcut reference)
@@ -198,6 +199,7 @@ Mermaid-related design documents are organized under `docs/design/mermaid/` whil
 - [DESIGN-centralized-keyboard.md](ui/DESIGN-centralized-keyboard.md) -- Three-tier keyboard handling.
 - [DESIGN-progressive-select-all.md](ui/DESIGN-progressive-select-all.md) -- Progressive Ctrl+A selection and cut/copy auto-expansion.
 - [DESIGN-markdown-awareness.md](ui/DESIGN-markdown-awareness.md) -- Preprocess/postprocess round-trip and DOM enhancement contract.
+- [DESIGN-tables.md](ui/DESIGN-tables.md) -- Table editing, formatting pipeline, alignment, width management, and settings popover.
 - [DESIGN-popup-dialog-ux.md](ui/DESIGN-popup-dialog-ux.md) -- Unified dialog interaction model.
 - [DESIGN-table-of-contents.md](ui/DESIGN-table-of-contents.md) -- Right sidebar TOC panel.
 - [DESIGN-help-system.md](ui/DESIGN-help-system.md) -- Layer 5 help modal, context-sensitive shortcut reference.

--- a/docs/design/backend/DESIGN-application-storage.md
+++ b/docs/design/backend/DESIGN-application-storage.md
@@ -48,7 +48,9 @@ Nav-operational data is generated during editing sessions and may become incompa
   "live_wysiwyg_focus_nav_target": "Page Title",
   "live_wysiwyg_migration_result": "success",
   "live_wysiwyg_migration_normalize": "1",
-  "live_wysiwyg_migration_adjust_weight": "1"
+  "live_wysiwyg_migration_adjust_weight": "1",
+  "live_wysiwyg_table_width": "120",
+  "live_wysiwyg_minimal_tables": "0"
 }
 ```
 

--- a/docs/design/ui/DESIGN-markdown-awareness.md
+++ b/docs/design/ui/DESIGN-markdown-awareness.md
@@ -14,7 +14,7 @@ All code lives in `live-wysiwyg-integration.js`.
 - **Info-string attributes**: `title="foo"`, `linenums="1"`, `hl_lines="2 3"` are stored as `data-*` attributes on `<pre>` but `_htmlToMarkdown` must explicitly read them back
 - **List markers**: `*`, `+` become `-`
 - **Ordered list numbering**: `1.`, `2.`, `3.` become `1.`, `1.`, `1.`
-- **Table separators**: column alignment markers are normalized
+- **Table formatting**: column widths, alignment markers, and cell padding are normalized
 - **Horizontal rule style**: `***`, `___` become `---`
 - **Inline code backtick count**: preserved via run-length fence calculation (longest backtick run + 1)
 - **Reference links**: `[text][ref]` with `[ref]: url` become inline `[text](url)`
@@ -33,12 +33,24 @@ Seven pairs of functions capture markdown-specific formatting before HTML conver
 | `_liveWysiwygCodeBlockData` | `preprocessCodeBlocks` | `postprocessCodeBlocks` | Fence style, language, title, linenums, hl_lines, indented blocks |
 | `_liveWysiwygLinkData` | `preprocessMarkdownLinks` | `postprocessMarkdownLinks` | Inline vs reference links, ref definitions |
 | `_liveWysiwygListMarkerData` | `preprocessListMarkers` | `postprocessListMarkers` | Marker style (`*`, `-`, `+`, `1.`) and checklist syntax |
-| `_liveWysiwygTableSepData` | `preprocessTableSeparators` | `postprocessTableSeparators` | Table separator line formatting |
+| `_liveWysiwygTableData` | `preprocessTables` | `postprocessTables` | Full table formatting: cell padding, column alignment, line width |
 | `_liveWysiwygHrData` | `preprocessHorizontalRules` | `postprocessHorizontalRules` | HR style (`---`, `***`, `___`) |
 | `_liveWysiwygInlineCodeData` | `preprocessInlineCode` | `postprocessInlineCode` | Multi-line inline code spans |
 | `_liveWysiwygRawHtmlData` | `preprocessRawHtml` | `postprocessRawHtml` | Raw HTML blocks and comments |
 
 **Lifecycle**: Preprocessors run when markdown enters the editor (`setValue`, `switchToMode`). Postprocessors run when markdown leaves the editor (`getValue`, `switchToMode` to markdown). The stores must always reflect the current document content — stale stores cause content-matching failures that silently lose formatting.
+
+**Table subsystem details**: The table pair (`preprocessTables` / `postprocessTables`) is more sophisticated than the other pairs. It snapshots entire table blocks (not just separator lines) and uses normalized content comparison (all whitespace stripped) to detect whether the user modified a table. Behavior:
+
+- **Unchanged tables with consistent formatting** (all rows same length): restored verbatim from the original, preserving the author's exact spacing and alignment style.
+- **Unchanged tables with inconsistent formatting** (rows of different lengths): reformatted via `_formatBalancedTable` to produce aligned pipe columns with consistent cell padding.
+- **Modified or new tables**: always reformatted via `_formatBalancedTable` with column-aligned padding.
+
+`_formatBalancedTable` is alignment-aware — it reads GFM alignment markers (`:---`, `:---:`, `---:`) from the separator row and applies directional padding (left-pad for right-aligned columns, split-pad for centered columns). It caps total line width to the global table width (default 120, configurable via localStorage key `liveWysiwygTableWidthLimit` through `_getGlobalTableWidth()` / `_setGlobalTableWidth()`).
+
+The TABLE case in `_htmlToMarkdown` (`editor.js`) reads `style.textAlign` from header `<th>` elements and emits the corresponding alignment markers in the separator line, ensuring alignment survives WYSIWYG round-trips. The contextual table toolbar includes alignment buttons (left/center/right) that set `text-align` on all cells in the selected column.
+
+Per-table width overrides can be stored on DOM table elements via `dataset.tableWidth`, which is read at serialize time and passed through to `_formatBalancedTable` as the width limit for that specific table.
 
 **Special case**: `_liveWysiwygRawHtmlData` is populated automatically inside the `patchMarkdownToHtmlForRawHtml` wrapper on `_markdownToHtml`. Any code path that calls `_markdownToHtml` gets raw HTML data for free. The other 6 stores must be refreshed explicitly.
 
@@ -90,6 +102,7 @@ Any function that loads markdown content into the WYSIWYG editable area must:
 | `data-linenums` | `_markdownToHtml` code renderer | `_htmlToMarkdown` PRE handler | Line number start |
 | `data-hl-lines` | `_markdownToHtml` code renderer | `_htmlToMarkdown` PRE handler | Highlighted lines |
 | `data-md-literal` | Inline typing handlers | Backspace revert handlers | Original markdown syntax for revert |
+| `data-table-width` | `preprocessTables` / settings popover | `postprocessTables` via DOM read | Per-table line width limit override |
 
 `data-md-literal` is documented in [targeted-markdown-revert.mdc](../../../.cursor/rules/targeted-markdown-revert.mdc). It is distinct from the preprocess/postprocess system — it stores the original typed markdown syntax on individual DOM elements so Backspace can revert to the literal markdown text.
 
@@ -134,3 +147,11 @@ Used for diagnostic logging in the Content History subsystem but does **not** ga
 8. **Ordered list numbering style must be preserved across WYSIWYG ↔ Markdown transitions.** If the document uses repeating `1.` markers (the `all-ones` style detected by `preprocessListMarkers`), then switching to markdown via `_htmlToMarkdown` and back must reproduce repeating `1.` markers — never incrementing `1.`, `2.`, `3.`. The `olStyle` field in `_liveWysiwygListMarkerData` records the document's style; `postprocessListMarkers` must honor it.
 
 9. **New ordered lists must follow the document's existing numbering style.** When a document contains any repeating `1.` ordered lists (`olStyle === 'all-ones'`), newly inserted ordered lists (via toolbar, inline typing, or any other mechanism) must use repeating `1.` markers to match. Do not mix incrementing and repeating styles within a single document.
+
+10. **Table column alignment must survive WYSIWYG round-trips.** `_htmlToMarkdown` reads `style.textAlign` from `<th>` and `<td>` elements and emits GFM alignment markers (`:---`, `:---:`, `---:`) in the separator line. `_markdownToHtml` (via the marked renderer) and WYSIWYG DOM enhancement must parse these markers and apply corresponding `text-align` styles so the alignment is visible in the editor and persists when switching modes.
+
+11. **Unchanged tables must be restored verbatim when consistently formatted.** `postprocessTables` compares the normalized content of the serialized table against preprocess snapshots. If the content matches and the original table had consistent row lengths (all lines the same length), the original raw text is restored byte-for-byte. This prevents the editor from introducing formatting diffs on content that the user did not touch.
+
+12. **Modified or inconsistently formatted tables are balanced.** When a table's content has changed or the original had inconsistent row lengths, `postprocessTables` calls `_formatBalancedTable` to produce evenly padded columns with aligned pipe separators, respecting the per-table or global width limit.
+
+13. **Tables must be block-level siblings in the DOM, never nested inside headings or other inline containers.** `_insertTableWysiwyg` must insert `<table>` elements as siblings after block elements (headings, paragraphs), not as children. If the cursor is in an empty paragraph, the paragraph is replaced. The heading case in `_nodeToMarkdownRecursive` includes defensive splitting to emit block children (like inadvertently nested tables) as separate markdown blocks with blank-line separation.

--- a/docs/design/ui/DESIGN-tables.md
+++ b/docs/design/ui/DESIGN-tables.md
@@ -1,0 +1,237 @@
+# Tables — Design Document
+
+## Overview
+
+Tables span two code locations: `editor.js` owns the WYSIWYG DOM interactions (toolbar, insertion, alignment, settings popover) and `live-wysiwyg-integration.js` owns the markdown round-trip pipeline (preprocess/postprocess, balanced formatting, width management). This document describes both halves and how they coordinate.
+
+For the round-trip contracts that tables share with other markdown constructs, see [DESIGN-markdown-awareness.md](DESIGN-markdown-awareness.md).
+
+## Contextual Table Toolbar
+
+Clicking a `<th>` or `<td>` inside the editable area activates the contextual table toolbar (`.md-contextual-table-toolbar`). The toolbar floats above the clicked cell and provides:
+
+| Section | Buttons | Action |
+|---------|---------|--------|
+| Insert | Insert Row Above/Below, Insert Column Left/Right | DOM manipulation + `_finalizeUpdate` |
+| Delete | Delete Row, Delete Column | Removes row/column or entire table if last one |
+| Alignment | Left, Center, Right | Sets `style.textAlign` on all cells in the column |
+| Settings | Gear icon | Opens the table settings popover |
+
+Separators (`.md-ctt-separator`) visually divide the four sections.
+
+### Delete behavior
+
+- **Delete Row** (`_deleteRowWysiwyg`): Removes the current row. If the table has only 2 rows (header + one data row), the entire table is replaced with an empty paragraph. After deletion, focus moves to the same column in the nearest remaining row.
+- **Delete Column** (`_deleteColumnWysiwyg`): Removes the column at `cellIndex` from every row. If the table has only one column, the entire table is replaced with an empty paragraph. After deletion, focus moves to the nearest remaining column in the same row.
+
+### Activation and Dismissal
+
+`_handleEditableAreaClickForTable` fires on every editable area click. It walks up from the click target to find a `<td>` or `<th>`, then records `currentTableSelectionInfo` (cell, row, table, indices) and shows the toolbar. Clicking outside any table cell or toolbar button dismisses the toolbar.
+
+The toolbar ESC handler (`_handlePopupEscKey`) is registered on `document` at capture phase when the toolbar is shown, and removed when hidden. When the settings popover is open, ESC closes only the popover (not the toolbar) — a second ESC then closes the toolbar.
+
+## Column Alignment
+
+### Round-trip
+
+Alignment flows through three stages:
+
+1. **Markdown to HTML**: The `marked` renderer reads GFM alignment markers (`:---`, `:---:`, `---:`) from the separator row and emits `align` attributes on `<th>` and `<td>` elements.
+2. **Normalization**: `_normalizeTableAlignAttrs(container)` converts `align` attributes to `style.textAlign` and removes the `align` attributes. This runs on every content-load path (`setValue`, `switchToMode`, `_historyApplyContent`, emoji reload).
+3. **HTML to markdown**: The TABLE case in `_nodeToMarkdownRecursive` reads `_getCellAlign(cell)` (which checks `style.textAlign` first, then `align` attribute) from header cells and emits the corresponding separator markers.
+
+### WYSIWYG editing
+
+The alignment buttons call `_setColumnAlignment(alignment)`, which iterates all rows in the table and sets `style.textAlign` on the cell at the selected column index. Left alignment clears the style (default). The `align` attribute is always removed to prevent dual-source conflicts. `_updateAlignmentButtonStates` highlights the active alignment button by reading the header cell's alignment.
+
+### Helper functions
+
+| Function | Location | Purpose |
+|----------|----------|---------|
+| `_getCellAlign(cell)` | `editor.js` | Returns alignment from `style.textAlign` or `align` attribute |
+| `_normalizeTableAlignAttrs(container)` | `editor.js` (exposed on `window`) | Converts `align` attrs to inline styles on load |
+
+## Table Insertion
+
+`_insertTableWysiwyg(rows, cols)` inserts a new table into the WYSIWYG DOM with the following placement logic:
+
+1. If the cursor is in an **empty paragraph**, the paragraph is replaced by the table.
+2. If the cursor is in a **non-empty block** (heading, paragraph, blockquote, list item), the table is inserted as a sibling after the block.
+3. Otherwise, the table is inserted at the range position.
+
+A trailing `<p>` with a zero-width space is always appended after the table to ensure the cursor has a landing point. This prevents tables from being absorbed into headings or other block elements.
+
+The heading case in `_nodeToMarkdownRecursive` includes defensive splitting: if a `<table>` is found inside an `<h1>`–`<h6>` (which should never happen, but can if insertion logic fails), the table is emitted as a separate block with blank-line separation.
+
+## Width Management
+
+### Global width
+
+A global table width limit (default 120 characters) is stored in `liveWysiwygSettings` under key `live_wysiwyg_table_width`. Two functions manage it:
+
+| Function | Purpose |
+|----------|---------|
+| `_getGlobalTableWidth()` | Reads from settings, falls back to 120 |
+| `_setGlobalTableWidth(w)` | Writes to settings |
+
+Both are exposed on `window` for cross-file access.
+
+### Minimal tables mode
+
+A global boolean preference stored in `liveWysiwygSettings` under key `live_wysiwyg_minimal_tables` (default `"0"` = off). When enabled, `_formatBalancedTable` skips column expansion, producing the tightest possible ASCII table output. Capping at the max width still applies.
+
+| Function | Purpose |
+|----------|---------|
+| `_getMinimalTables()` | Returns true if minimal tables mode is enabled |
+| `_setMinimalTables(v)` | Writes the boolean preference |
+
+Both are exposed on `window` for cross-file access.
+
+### Per-table width
+
+Individual tables can override the global width via the `data-table-width` DOM attribute. This value is:
+
+- **Detected** by `preprocessTables` from consistently formatted tables (all rows the same length).
+- **Set manually** by the user through the settings popover.
+- **Auto-increased** by `_collectTableWidthsFromDOM` when content grows beyond the stored width (capped at the global limit).
+- **Read** at serialize time and passed to `postprocessTables` as the effective width for formatting.
+
+### Natural width auto-growth
+
+`_computeNaturalTableWidth(tableEl)` computes the minimum ASCII table width from a DOM table's cell contents. It is exposed on `window` and used in two places:
+
+1. **`_collectTableWidthsFromDOM`**: At serialize time, if a table's natural width exceeds its stored `data-table-width`, the attribute is auto-increased to `min(naturalWidth, globalWidth)`. This ensures tables expand to accommodate growing content without exceeding the global limit.
+2. **`_showTableSettingsPopover`**: When the popover opens, it computes the natural width and displays `max(storedWidth, min(naturalWidth, globalWidth))`, updating the DOM attribute if the content has grown.
+
+## Settings Popover
+
+The settings popover (`.md-ctt-settings-popover`) is a settings dialog attached to the gear button in the contextual toolbar. It follows the [Dialog UX](DESIGN-popup-dialog-ux.md) settings dialog pattern — changes apply immediately with no explicit Apply button.
+
+### Fields
+
+| Field | Tab Index | Description |
+|-------|-----------|-------------|
+| Max width | 1 | Global max table width (number input, min 20). Saved on `change`. |
+| Minimal tables | 2 | Checkbox: when enabled, tables use tightest possible widths (no expansion). Saved on `change`. |
+
+### Keyboard behavior
+
+Uses `_attachDialogKeyboard` with `category: 'settings'`:
+
+- **ESC**: Dismisses the popover.
+- **Enter**: Dismisses the popover.
+- **Tab/Shift+Tab**: Navigates between fields in tab-index order.
+
+### Dismissal
+
+- **Click outside**: `mousedown` handler on `document` (capture phase) closes the popover when clicking outside the popover and gear button.
+- **ESC layering**: When the popover is open, the toolbar's ESC handler defers to the popover. First ESC closes the popover; second ESC closes the toolbar.
+- **Cleanup**: `_hideTableSettingsPopover` removes the `mousedown` listener from `document` and removes the popover DOM element.
+
+## Balanced Formatting Pipeline
+
+The formatting pipeline ensures consistent ASCII table layout on every markdown serialize. It lives in `live-wysiwyg-integration.js`.
+
+### Preprocess (`preprocessTables`)
+
+Runs when markdown enters the editor. Scans for GFM table blocks (header row + separator row + data rows) and stores each as:
+
+| Field | Description |
+|-------|-------------|
+| `raw` | Original table text (verbatim) |
+| `norm` | Whitespace-stripped content for matching |
+| `detectedWidth` | Row length if all rows are the same length, else 0 |
+
+### Postprocess (`postprocessTables`)
+
+Runs when markdown leaves the editor. For each table in the output:
+
+1. **Match**: Compare normalized content against preprocessed originals.
+2. **Decide**:
+   - Matched + all rows same length + no cursor markers + width unchanged: restore verbatim.
+   - Matched + cursor markers present: reformat using current table lines (preserves markers).
+   - Matched + inconsistent formatting or width changed: reformat using original lines.
+   - Not matched (new or edited table): reformat using current lines.
+3. **Format**: `_formatBalancedTable` produces aligned pipe columns with consistent cell padding.
+
+### `_formatBalancedTable`
+
+Accepts table lines and an optional width limit. Uses a dual-parse strategy:
+
+| Parser | Function | Purpose |
+|--------|----------|---------|
+| Clean | `_parseTableCells` | Strips zero-width characters (`\u200B`, `\u200C`, `\u200D`); used for width math |
+| Raw | `_parseTableCellsRaw` | Preserves all characters including cursor markers; used for output content |
+
+Column widths are computed from clean cell lengths (minimum 3 per column). The formatter then adjusts widths to match the target width:
+
+- **Capping** (total > limit): columns exceeding a fair share of available space are reduced.
+- **Expansion** (total < limit): remaining space is distributed proportionally across columns based on their natural content widths. This ensures tables maintain their width after edits that reduce content.
+- **Minimal mode**: when `_getMinimalTables()` returns true, expansion is skipped — columns stay at their natural widths. Capping still applies.
+
+Padding respects alignment:
+
+| Alignment | Padding |
+|-----------|---------|
+| Left (default) | Content + trailing spaces |
+| Right | Leading spaces + content |
+| Center | Split spaces around content |
+
+The separator row uses alignment markers (`:---`, `:---:`, `---:`) sized to the column width.
+
+### Cursor marker preservation
+
+The WYSIWYG-to-Markdown mode switch (Boundary 2 in the [cursor-selection-preservation](../../../.cursor/rules/cursor-selection-preservation.mdc) cardinal rule) injects zero-width Unicode markers into the DOM before conversion: `CURSOR_MARKER` (`\u200C` x6) for selection start and `CURSOR_MARKER_END` (`\u200D` x6) for selection end. These markers flow through `_htmlToMarkdown` into the markdown text, including into table cells. Without special handling, the markers would inflate column width calculations and produce misaligned tables — or be stripped, losing the cursor position.
+
+The dual-parse strategy ensures markers survive table formatting:
+
+- `_parseTableCells` strips markers so they do not inflate column width calculations.
+- `_parseTableCellsRaw` preserves markers so they appear in the formatted output.
+- Padding is computed from clean lengths, so the formatted table has correct visual alignment despite containing invisible marker characters.
+- `postprocessTables` detects cursor markers and forces reformatting (using current lines, not verbatim originals) so the markers are included in the output.
+
+See [text-selection-architecture](../../../.cursor/rules/text-selection-architecture.mdc) for the full selection system architecture, including the independence of the three selection codepaths (read-only to edit, WYSIWYG to Markdown, focus mode transitions).
+
+## CSS Classes
+
+| Class | Element | Purpose |
+|-------|---------|---------|
+| `.md-contextual-table-toolbar` | `<div>` | Floating toolbar container |
+| `.md-contextual-table-toolbar-button` | `<button>` | Individual toolbar button |
+| `.md-ctt-button-active` | `<button>` | Active alignment button highlight |
+| `.md-ctt-separator` | `<span>` | Visual separator between button groups |
+| `.md-ctt-settings-popover` | `<div>` | Settings popover container |
+| `.md-ctt-settings-label` | `<label>` | Field label in popover |
+| `.md-ctt-settings-row` | `<div>` | Horizontal layout for inline label + input |
+| `.md-ctt-settings-inline-label` | `<span>` | Inline text label within a settings row |
+| `.md-ctt-settings-input` | `<input>` | Number input field |
+
+## Relationship to Other Subsystems
+
+- **Markdown Awareness** ([DESIGN-markdown-awareness.md](DESIGN-markdown-awareness.md)): Tables are one of 7 preprocess/postprocess pairs. The table pair (`preprocessTables` / `postprocessTables`) is documented in the markdown awareness design as part of the round-trip contract. The `data-table-width` attribute is listed in the `data-*` attribute bridge.
+
+- **Dialog UX** ([DESIGN-popup-dialog-ux.md](DESIGN-popup-dialog-ux.md)): The settings popover follows the settings dialog pattern — no Apply button, changes apply immediately, Enter/ESC both dismiss, auto-focus, explicit tab order, and click-outside dismissal via `_attachDialogKeyboard`.
+
+- **Cursor & Selection Preservation** ([cursor-selection-preservation.mdc](../../../.cursor/rules/cursor-selection-preservation.mdc)): The dual-parse strategy in `_formatBalancedTable` preserves cursor markers through table formatting, ensuring cursor position survives WYSIWYG-to-Markdown mode switches (Boundary 2) even when tables are reformatted. The table formatting pipeline is one of the few subsystems that must be explicitly aware of cursor markers because it rewrites content that may contain them.
+
+- **Text Selection Architecture** ([text-selection-architecture.mdc](../../../.cursor/rules/text-selection-architecture.mdc)): Tables interact with the edit-mode selection codepath. The `injectMarkerAtCaretInEditable` function places markers into table cell text nodes; `_htmlToMarkdown` serializes them into the markdown table lines; `postprocessTables` and `_formatBalancedTable` must preserve them through reformatting; and `findAndStripCursorMarkerPositions` resolves them back to DOM positions after Markdown-to-WYSIWYG conversion.
+
+- **Read-Only Selection Heuristics** ([DESIGN-readonly-selection-heuristics.md](DESIGN-readonly-selection-heuristics.md)): When the user selects text spanning table cells in the read-only rendered page and switches to edit mode, the pseudo-markdown builder (`buildPseudoMarkdown`) must produce table-like output so the selection search can locate the corresponding position in the markdown source. This is a separate codepath from the edit-mode cursor markers used in the dual-parse strategy.
+
+- **Content History** ([DESIGN-unified-content-undo.md](DESIGN-unified-content-undo.md)): `_normalizeTableAlignAttrs` runs in `_historyApplyContent` to ensure alignment attributes are normalized after undo/redo restore.
+
+## Rules
+
+1. **Tables must be block-level siblings, never nested inside inline containers.** `_insertTableWysiwyg` inserts tables as siblings after block elements. The heading case in `_nodeToMarkdownRecursive` defensively splits nested tables into separate blocks.
+
+2. **Alignment flows through `style.textAlign`, not the `align` attribute.** All content-load paths call `_normalizeTableAlignAttrs` to convert `align` to `style.textAlign`. WYSIWYG editing and markdown serialization both read and write `style.textAlign`.
+
+3. **Unchanged, consistently formatted tables are restored verbatim.** `postprocessTables` matches table content against preprocess snapshots. Byte-for-byte restoration prevents the editor from introducing formatting diffs on content the user did not touch.
+
+4. **Modified or inconsistently formatted tables are balanced.** `_formatBalancedTable` produces aligned pipe columns up to the effective width limit (per-table > detected > global).
+
+5. **Per-table width auto-grows with content.** `_collectTableWidthsFromDOM` increases `data-table-width` when the table's natural minimum width exceeds the stored value, capped at the global limit. The user never sees truncated columns from a stale width setting.
+
+6. **Cursor markers must not affect column width calculations.** `_parseTableCells` (used for width math) strips zero-width characters. `_parseTableCellsRaw` (used for output content) preserves them. This dual-parse strategy is the only mechanism that allows both cursor tracking and table formatting to coexist.
+
+7. **The settings popover follows the Dialog UX settings pattern.** Changes apply immediately on interaction. ESC and Enter both dismiss. Click-outside dismisses. Tab navigates fields. The first input is auto-focused.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,18 @@ title: Example WYSIWYG site
 ---
 # Welcome
 
+| Header 1              | Header 2                |
+| --------------------- | ----------------------- |
+| Everything is awesome | Cool when you're part of a yay |
+| living the dream      | team                    |
+
 - foo
 - bar
 
   > abc
 
   bar
+
 - baz
 
 1. Car
@@ -39,6 +45,7 @@ Another item
       ```
 
       test
+
    2. Another
 2. Launch a server on `http://127.0.0.1:8000/`.
 

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -5098,37 +5098,250 @@
     return result.join('\n');
   }
 
-  function preprocessTableSeparators(markdown) {
-    if (!markdown || typeof markdown !== 'string') return { separators: [] };
-    var separators = [];
-    var lines = markdown.split('\n');
-    for (var i = 1; i < lines.length; i++) {
-      if (/^\|[\s:=-]+(\|[\s:=-]+)+\|?\s*$/.test(lines[i]) && /\|/.test(lines[i - 1])) {
-        separators.push({ header: lines[i - 1].replace(/\s+/g, ''), separator: lines[i] });
+  var TABLE_WIDTH_DEFAULT = 120;
+  function _getGlobalTableWidth() {
+    var v = parseInt(_getSetting('live_wysiwyg_table_width'), 10);
+    return v > 0 ? v : TABLE_WIDTH_DEFAULT;
+  }
+  function _setGlobalTableWidth(w) {
+    _setSetting('live_wysiwyg_table_width', String(w));
+  }
+  window._getGlobalTableWidth = _getGlobalTableWidth;
+  window._setGlobalTableWidth = _setGlobalTableWidth;
+
+  function _getMinimalTables() { return _getSetting('live_wysiwyg_minimal_tables') === '1'; }
+  function _setMinimalTables(v) { _setSetting('live_wysiwyg_minimal_tables', v ? '1' : '0'); }
+  window._getMinimalTables = _getMinimalTables;
+  window._setMinimalTables = _setMinimalTables;
+
+  function _computeNaturalTableWidth(tableEl) {
+    var rows = tableEl.querySelectorAll('tr');
+    if (!rows.length) return 0;
+    var colCount = rows[0].cells.length;
+    var maxWidths = [];
+    for (var c = 0; c < colCount; c++) maxWidths.push(3);
+    for (var r = 0; r < rows.length; r++) {
+      for (c = 0; c < rows[r].cells.length && c < colCount; c++) {
+        var text = (rows[r].cells[c].textContent || '').replace(/[\u200B\u200C\u200D]/g, '').trim();
+        if (text.length > maxWidths[c]) maxWidths[c] = text.length;
       }
     }
-    return { separators: separators };
+    var total = 1;
+    for (c = 0; c < colCount; c++) total += maxWidths[c] + 3;
+    return total;
+  }
+  window._computeNaturalTableWidth = _computeNaturalTableWidth;
+
+  function _collectTableWidthsFromDOM(editableArea) {
+    if (!editableArea) return [];
+    var domTables = editableArea.querySelectorAll('table');
+    var globalW = _getGlobalTableWidth();
+    var widths = [];
+    for (var t = 0; t < domTables.length; t++) {
+      var stored = parseInt(domTables[t].dataset.tableWidth, 10) || 0;
+      var natural = _computeNaturalTableWidth(domTables[t]);
+      if (natural > stored && natural <= globalW) {
+        stored = natural;
+        domTables[t].dataset.tableWidth = stored;
+      } else if (natural > stored && natural > globalW) {
+        stored = globalW;
+        domTables[t].dataset.tableWidth = stored;
+      }
+      widths.push(stored);
+    }
+    return widths;
   }
 
-  function postprocessTableSeparators(markdown, tableData) {
-    if (!markdown || typeof markdown !== 'string') return markdown;
-    if (!tableData || !tableData.separators || !tableData.separators.length) return markdown;
-    var originals = tableData.separators;
-    var used = 0;
+  function _parseTableCells(line) {
+    var trimmed = line.replace(/[\u200B\u200C\u200D]/g, '').trim();
+    if (trimmed.charAt(0) === '|') trimmed = trimmed.substring(1);
+    if (trimmed.charAt(trimmed.length - 1) === '|') trimmed = trimmed.substring(0, trimmed.length - 1);
+    return trimmed.split('|').map(function (c) { return c.trim(); });
+  }
+
+  function _parseTableCellsRaw(line) {
+    var trimmed = line.trim();
+    if (trimmed.charAt(0) === '|') trimmed = trimmed.substring(1);
+    if (trimmed.charAt(trimmed.length - 1) === '|') trimmed = trimmed.substring(0, trimmed.length - 1);
+    return trimmed.split('|').map(function (c) { return c.trim(); });
+  }
+
+  function _formatBalancedTable(tableLines, widthLimit) {
+    var rows = tableLines.map(_parseTableCells);
+    var rawRows = tableLines.map(_parseTableCellsRaw);
+    var sepIdx = 1;
+    var colCount = rows[0].length;
+    var limit = widthLimit || _getGlobalTableWidth();
+
+    var aligns = [];
+    for (var c = 0; c < colCount; c++) {
+      var sep = (rows[sepIdx] && rows[sepIdx][c]) || '---';
+      var left = sep.charAt(0) === ':';
+      var right = sep.charAt(sep.length - 1) === ':';
+      if (left && right) aligns.push('center');
+      else if (right) aligns.push('right');
+      else aligns.push('left');
+    }
+
+    var widths = [];
+    for (c = 0; c < colCount; c++) {
+      var maxW = 3;
+      for (var r = 0; r < rows.length; r++) {
+        if (r === sepIdx) continue;
+        var cell = (rows[r][c] || '');
+        if (cell.length > maxW) maxW = cell.length;
+      }
+      widths.push(maxW);
+    }
+
+    var overhead = 1 + colCount * 3;
+    var total = overhead;
+    for (c = 0; c < colCount; c++) total += widths[c];
+    if (total > limit) {
+      var available = limit - overhead;
+      var fair = Math.max(3, Math.floor(available / colCount));
+      for (c = 0; c < colCount; c++) {
+        if (widths[c] > fair) widths[c] = fair;
+      }
+    } else if (total < limit && !_getMinimalTables()) {
+      var extra = limit - total;
+      var contentTotal = 0;
+      for (c = 0; c < colCount; c++) contentTotal += widths[c];
+      if (contentTotal > 0) {
+        var distributed = 0;
+        for (c = 0; c < colCount - 1; c++) {
+          var share = Math.floor(extra * widths[c] / contentTotal);
+          widths[c] += share;
+          distributed += share;
+        }
+        widths[colCount - 1] += (extra - distributed);
+      }
+    }
+
+    var out = [];
+    for (var r2 = 0; r2 < rows.length; r2++) {
+      if (r2 === sepIdx) {
+        var sepCells = [];
+        for (c = 0; c < colCount; c++) {
+          var al = aligns[c];
+          var dashCount = widths[c];
+          if (al === 'center') {
+            sepCells.push(':' + '-'.repeat(Math.max(1, dashCount - 2)) + ':');
+          } else if (al === 'right') {
+            sepCells.push('-'.repeat(Math.max(1, dashCount - 1)) + ':');
+          } else {
+            sepCells.push('-'.repeat(dashCount));
+          }
+        }
+        out.push('| ' + sepCells.join(' | ') + ' |');
+      } else {
+        var cells = [];
+        for (c = 0; c < colCount; c++) {
+          var cell2 = rawRows[r2][c] || '';
+          var cleanLen = (rows[r2][c] || '').length;
+          var pad = widths[c] - cleanLen;
+          if (pad <= 0) {
+            cells.push(cell2);
+          } else if (aligns[c] === 'right') {
+            cells.push(' '.repeat(pad) + cell2);
+          } else if (aligns[c] === 'center') {
+            var lpad = Math.floor(pad / 2);
+            cells.push(' '.repeat(lpad) + cell2 + ' '.repeat(pad - lpad));
+          } else {
+            cells.push(cell2 + ' '.repeat(pad));
+          }
+        }
+        out.push('| ' + cells.join(' | ') + ' |');
+      }
+    }
+    return out.join('\n');
+  }
+
+  function preprocessTables(markdown) {
+    if (!markdown || typeof markdown !== 'string') return { tables: [] };
+    var tables = [];
     var lines = markdown.split('\n');
-    for (var i = 1; i < lines.length; i++) {
-      if (/^\|(\s*---\s*\|)+\s*$/.test(lines[i]) && /\|/.test(lines[i - 1])) {
-        var normHeader = lines[i - 1].replace(/\s+/g, '');
+    var i = 0;
+    while (i < lines.length) {
+      if (i + 1 < lines.length &&
+          /\|/.test(lines[i]) &&
+          /^\|[\s:=-]+(\|[\s:=-]+)+\|?\s*$/.test(lines[i + 1])) {
+        var start = i;
+        i += 2;
+        while (i < lines.length && /\|/.test(lines[i]) && !/^\s*$/.test(lines[i])) {
+          i++;
+        }
+        var rawLines = lines.slice(start, i);
+        var raw = rawLines.join('\n');
+        var norm = raw.replace(/\s+/g, '');
+        var allSame = true;
+        for (var k = 1; k < rawLines.length; k++) {
+          if (rawLines[k].length !== rawLines[0].length) { allSame = false; break; }
+        }
+        var dw = allSame ? rawLines[0].length : 0;
+        tables.push({ raw: raw, norm: norm, detectedWidth: dw });
+      } else {
+        i++;
+      }
+    }
+    return { tables: tables };
+  }
+
+  function postprocessTables(markdown, tableData, tableWidths) {
+    if (!markdown || typeof markdown !== 'string') return markdown;
+    if (!tableData || !tableData.tables) return markdown;
+    var originals = tableData.tables;
+    var lines = markdown.split('\n');
+    var result = [];
+    var used = 0;
+    var tableIdx = 0;
+    var i = 0;
+    while (i < lines.length) {
+      if (i + 1 < lines.length &&
+          /\|/.test(lines[i]) &&
+          /^\|(\s*:?---+:?\s*\|)+\s*$/.test(lines[i + 1])) {
+        var start = i;
+        i += 2;
+        while (i < lines.length && /\|/.test(lines[i]) && !/^\s*$/.test(lines[i])) {
+          i++;
+        }
+        var tableLines = lines.slice(start, i);
+        var tableText = tableLines.join('\n');
+        var hasCursorMarkers = tableText.indexOf('\u200C\u200C\u200C\u200C\u200C\u200C') >= 0 || tableText.indexOf('\u200D\u200D\u200D\u200D\u200D\u200D') >= 0;
+        var norm = tableText.replace(/[\u200B\u200C\u200D]/g, '').replace(/\s+/g, '');
+        var perTableWidth = (tableWidths && tableWidths[tableIdx]) || 0;
+        var matched = false;
         for (var j = used; j < originals.length; j++) {
-          if (originals[j].header === normHeader) {
-            lines[i] = originals[j].separator;
+          if (originals[j].norm === norm) {
+            var origLines = originals[j].raw.split('\n');
+            var allSameLen = true;
+            for (var k = 1; k < origLines.length; k++) {
+              if (origLines[k].length !== origLines[0].length) { allSameLen = false; break; }
+            }
+            var effectiveWidth = perTableWidth || originals[j].detectedWidth || _getGlobalTableWidth();
+            if (allSameLen && !hasCursorMarkers && (!perTableWidth || perTableWidth === originals[j].detectedWidth)) {
+              result.push(originals[j].raw);
+            } else if (hasCursorMarkers) {
+              result.push(_formatBalancedTable(tableLines, effectiveWidth));
+            } else {
+              result.push(_formatBalancedTable(origLines, effectiveWidth));
+            }
             used = j + 1;
+            matched = true;
             break;
           }
         }
+        if (!matched) {
+          var newWidth = perTableWidth || _getGlobalTableWidth();
+          result.push(_formatBalancedTable(tableLines, newWidth));
+        }
+        tableIdx++;
+      } else {
+        result.push(lines[i]);
+        i++;
       }
     }
-    return lines.join('\n');
+    return result.join('\n');
   }
 
   function preprocessHorizontalRules(markdown) {
@@ -6449,13 +6662,23 @@
         var mdWithRefsExtracted = extractRefDefsFromCommentBlocks(markdown);
         this._liveWysiwygLinkData = preprocessMarkdownLinks(mdWithRefsExtracted);
         this._liveWysiwygListMarkerData = preprocessListMarkers(mdWithRefsExtracted);
-        this._liveWysiwygTableSepData = preprocessTableSeparators(mdWithRefsExtracted);
+        this._liveWysiwygTableData = preprocessTables(mdWithRefsExtracted);
         this._liveWysiwygCodeBlockData = preprocessCodeBlocks(mdWithRefsExtracted);
         this._liveWysiwygHrData = preprocessHorizontalRules(mdWithRefsExtracted);
         this._liveWysiwygInlineCodeData = preprocessInlineCode(mdWithRefsExtracted);
         mdToUse = mdWithRefsExtracted;
       }
-      return origSetValue.apply(this, [mdToUse, isInitialSetup]);
+      var setResult = origSetValue.apply(this, [mdToUse, isInitialSetup]);
+      if (this._liveWysiwygTableData && this.editableArea) {
+        var domTbls = this.editableArea.querySelectorAll('table');
+        var tblArr = this._liveWysiwygTableData.tables;
+        for (var ti = 0; ti < domTbls.length && ti < tblArr.length; ti++) {
+          if (tblArr[ti].detectedWidth > 0) {
+            domTbls[ti].dataset.tableWidth = tblArr[ti].detectedWidth;
+          }
+        }
+      }
+      return setResult;
     };
     proto.switchToMode = function (mode, isInitialSetup) {
       if (mode === 'wysiwyg' && !isInitialSetup && this.markdownArea && this.markdownArea.value) {
@@ -6464,7 +6687,7 @@
         var bodyWithRefsExtracted = extractRefDefsFromCommentBlocks(cleanBody);
         var newLinkData = preprocessMarkdownLinks(bodyWithRefsExtracted);
         var newListData = preprocessListMarkers(cleanBody);
-        this._liveWysiwygTableSepData = preprocessTableSeparators(cleanBody);
+        this._liveWysiwygTableData = preprocessTables(cleanBody);
         this._liveWysiwygCodeBlockData = preprocessCodeBlocks(cleanBody);
         this._liveWysiwygHrData = preprocessHorizontalRules(cleanBody);
         this._liveWysiwygInlineCodeData = preprocessInlineCode(cleanBody);
@@ -6475,7 +6698,17 @@
           this._liveWysiwygListMarkerData = newListData;
         }
       }
+      var tableWidthsForSwitch = _collectTableWidthsFromDOM(this.editableArea);
       var result = origSwitchToMode.apply(this, arguments);
+      if (mode === 'wysiwyg' && this._liveWysiwygTableData && this.editableArea) {
+        var domTbls2 = this.editableArea.querySelectorAll('table');
+        var tblArr2 = this._liveWysiwygTableData.tables;
+        for (var ti2 = 0; ti2 < domTbls2.length && ti2 < tblArr2.length; ti2++) {
+          if (tblArr2[ti2].detectedWidth > 0) {
+            domTbls2[ti2].dataset.tableWidth = tblArr2[ti2].detectedWidth;
+          }
+        }
+      }
       if (mode === 'markdown') {
         var md = this.markdownArea.value;
         if (this._liveWysiwygRawHtmlData) {
@@ -6487,8 +6720,8 @@
         if (this._liveWysiwygListMarkerData) {
           md = postprocessListMarkers(md, this._liveWysiwygListMarkerData);
         }
-        if (this._liveWysiwygTableSepData) {
-          md = postprocessTableSeparators(md, this._liveWysiwygTableSepData);
+        if (this._liveWysiwygTableData) {
+          md = postprocessTables(md, this._liveWysiwygTableData, tableWidthsForSwitch);
         }
         if (this._liveWysiwygCodeBlockData) {
           md = postprocessCodeBlocks(md, this._liveWysiwygCodeBlockData);
@@ -6534,8 +6767,9 @@
       if (this._liveWysiwygListMarkerData) {
         body = postprocessListMarkers(body, this._liveWysiwygListMarkerData);
       }
-      if (this._liveWysiwygTableSepData) {
-        body = postprocessTableSeparators(body, this._liveWysiwygTableSepData);
+      if (this._liveWysiwygTableData) {
+        var tw = _collectTableWidthsFromDOM(this.editableArea);
+        body = postprocessTables(body, this._liveWysiwygTableData, tw);
       }
       if (this._liveWysiwygCodeBlockData) {
         body = postprocessCodeBlocks(body, this._liveWysiwygCodeBlockData);
@@ -8540,7 +8774,53 @@
     return '---\n' + outLines.join('\n') + '\n---\n';
   }
 
-  function _buildFrontmatterFromFm(fm, isIndex, origFm) {
+  function _fmDeepEqual(a, b) {
+    if (a === b) return true;
+    if (a == null || b == null) return a == b;
+    if (typeof a !== typeof b) return false;
+    if (typeof a !== 'object') return false;
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  function _extractRawFmBlocks(rawFmText) {
+    if (!rawFmText) return {};
+    var inner = rawFmText;
+    if (inner.startsWith('---')) {
+      var startIdx = inner.indexOf('\n');
+      if (startIdx === -1) return {};
+      inner = inner.substring(startIdx + 1);
+    }
+    var endIdx = inner.lastIndexOf('\n---');
+    if (endIdx !== -1) inner = inner.substring(0, endIdx);
+    else {
+      endIdx = inner.lastIndexOf('\n...');
+      if (endIdx !== -1) inner = inner.substring(0, endIdx);
+    }
+
+    var lines = inner.split('\n');
+    var blocks = {};
+    var currentKey = null;
+    var currentLines = [];
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var m = line.match(/^([a-zA-Z_][\w-]*)\s*:/);
+      if (m) {
+        if (currentKey !== null) {
+          blocks[currentKey] = currentLines.join('\n');
+        }
+        currentKey = m[1];
+        currentLines = [line];
+      } else if (currentKey !== null) {
+        currentLines.push(line);
+      }
+    }
+    if (currentKey !== null) {
+      blocks[currentKey] = currentLines.join('\n');
+    }
+    return blocks;
+  }
+
+  function _buildFrontmatterFromFm(fm, isIndex, origFm, rawFmText) {
     if (!fm || typeof fm !== 'object') return '';
     var nwKeys = { weight: 1, headless: 1, retitled: 1, empty: 1 };
     var defaults = (typeof liveWysiwygNavWeightConfig !== 'undefined' && liveWysiwygNavWeightConfig.enabled)
@@ -8565,11 +8845,21 @@
       }
     }
 
+    var rawBlocks = _extractRawFmBlocks(rawFmText);
+
     function makeLine(key) {
       var val = fm[key];
       if (val == null) return null;
       if (key in nwKeys && shouldStrip(key, val)) return null;
-      return key + ': ' + _fmSerialize(val);
+      if (rawBlocks[key] && origFm && origFm.hasOwnProperty(key) && _fmDeepEqual(val, origFm[key])) {
+        return rawBlocks[key];
+      }
+      var serialized = _fmSerialize(val);
+      if (serialized.indexOf('\n') !== -1) {
+        var indented = serialized.split('\n').map(function(l) { return '  ' + l; }).join('\n');
+        return key + ':\n' + indented;
+      }
+      return key + ': ' + serialized;
     }
 
     var outLines = [];
@@ -8603,6 +8893,9 @@
       if (/[:#\[\]{}&*?|>!%@`,]/.test(val) || val === '' || val.trim() !== val)
         return '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
       return val;
+    }
+    if (val !== null && typeof val === 'object' && typeof jsyaml !== 'undefined') {
+      return jsyaml.dump(val, { indent: 2, lineWidth: -1, noRefs: true }).trimEnd();
     }
     return String(val);
   }
@@ -14940,6 +15233,7 @@
 
     return { markDirty: function () { dirty = true; } };
   }
+  window._attachDialogKeyboard = _attachDialogKeyboard;
 
   function _promptNewFolder(item, extraItems) {
     var isAsset = item && item.type === 'asset';
@@ -15252,11 +15546,7 @@
             }
             copy[k] = metaCopy;
           } else if (k === '_fm' && item[k] && typeof item[k] === 'object') {
-            var fmCopy = {};
-            for (var fk in item[k]) {
-              if (item[k].hasOwnProperty(fk)) fmCopy[fk] = item[k][fk];
-            }
-            copy[k] = fmCopy;
+            copy[k] = JSON.parse(JSON.stringify(item[k]));
           } else if (k === '_warnings' && Array.isArray(item[k])) {
             copy[k] = item[k].map(function (w) {
               var entry = { reason: w.reason, renames: w.renames || 0 };
@@ -16653,8 +16943,8 @@
       var dFm = p.desiredFm || {};
       var oFm = p.origFm || {};
       var hasSetContent = p.setContent !== null;
-      var hasFmKeys = Object.keys(dFm).length > 0;
-      if (hasFmKeys || hasSetContent) {
+      var fmChanged = !_fmDeepEqual(dFm, oFm);
+      if (fmChanged || hasSetContent) {
         var fmOp = {
           type: 'set-frontmatter', src_path: p.desiredPath,
           fm: dFm, origFm: oFm,
@@ -17654,14 +17944,16 @@
         var scBody = scParsed.hasBlock ? op.setContent.substring(scParsed.bodyStart) : op.setContent;
         var mergedFm = Object.assign({}, scParsed.hasBlock ? scParsed.fields : {}, op.fm);
         var effectiveOrig = scParsed.hasBlock ? scParsed.fields : (op.origFm || {});
-        var newFm = _buildFrontmatterFromFm(mergedFm, op.isIndex, effectiveOrig);
+        var scRaw = scParsed.hasBlock ? scParsed.raw : '';
+        var newFm = _buildFrontmatterFromFm(mergedFm, op.isIndex, effectiveOrig, scRaw);
         var finalContent = newFm + scBody;
         return _wsSetContents(actualPath, finalContent);
       }
       return _wsGetContents(actualPath).then(function (content) {
         var parsed = _parseFrontmatter(content);
         var body = parsed.hasBlock ? content.substring(parsed.bodyStart) : content;
-        var newFm = _buildFrontmatterFromFm(op.fm, op.isIndex, op.origFm);
+        var rawFmText = parsed.hasBlock ? parsed.raw : '';
+        var newFm = _buildFrontmatterFromFm(op.fm, op.isIndex, op.origFm, rawFmText);
         var finalContent = newFm + body;
         return _wsSetContents(actualPath, finalContent);
       });
@@ -26361,8 +26653,9 @@
           if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygListMarkerData) {
             markdownContent = postprocessListMarkers(markdownContent, wysiwygEditor._liveWysiwygListMarkerData);
           }
-          if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygTableSepData) {
-            markdownContent = postprocessTableSeparators(markdownContent, wysiwygEditor._liveWysiwygTableSepData);
+          if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygTableData) {
+            var twOnUpdate = _collectTableWidthsFromDOM(wysiwygEditor.editableArea);
+            markdownContent = postprocessTables(markdownContent, wysiwygEditor._liveWysiwygTableData, twOnUpdate);
           }
           if (wysiwygEditor.currentMode === 'wysiwyg' && wysiwygEditor._liveWysiwygCodeBlockData) {
             markdownContent = postprocessCodeBlocks(markdownContent, wysiwygEditor._liveWysiwygCodeBlockData);
@@ -26457,7 +26750,7 @@
       var bodyForPreprocess = extractRefDefsFromCommentBlocks(parsed.body);
       wysiwygEditor._liveWysiwygLinkData = preprocessMarkdownLinks(bodyForPreprocess);
       wysiwygEditor._liveWysiwygListMarkerData = preprocessListMarkers(bodyForPreprocess);
-      wysiwygEditor._liveWysiwygTableSepData = preprocessTableSeparators(bodyForPreprocess);
+      wysiwygEditor._liveWysiwygTableData = preprocessTables(bodyForPreprocess);
       wysiwygEditor._liveWysiwygCodeBlockData = preprocessCodeBlocks(bodyForPreprocess);
       wysiwygEditor._liveWysiwygHrData = preprocessHorizontalRules(bodyForPreprocess);
       wysiwygEditor._liveWysiwygInlineCodeData = preprocessInlineCode(bodyForPreprocess);
@@ -26468,6 +26761,7 @@
           var html = wysiwygEditor._markdownToHtml(parsed.body);
           wysiwygEditor.editableArea.innerHTML = html;
         }
+        if (window._normalizeTableAlignAttrs) window._normalizeTableAlignAttrs(wysiwygEditor.editableArea);
         populateRawHtmlBlocks(wysiwygEditor.editableArea);
         enhanceCodeBlocks(wysiwygEditor.editableArea);
         enhanceMermaidBlocks(wysiwygEditor.editableArea);
@@ -29141,6 +29435,7 @@
       var md = wysiwygEditor.markdownArea.value;
       if (md) {
         wysiwygEditor.editableArea.innerHTML = wysiwygEditor._markdownToHtml(md);
+        if (window._normalizeTableAlignAttrs) window._normalizeTableAlignAttrs(wysiwygEditor.editableArea);
         populateRawHtmlBlocks(wysiwygEditor.editableArea);
       }
     }

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.css
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.css
@@ -458,6 +458,78 @@
  height: 16px;
 }
 
+.md-ctt-separator {
+ display: inline-block;
+ width: 1px;
+ align-self: stretch;
+ margin: 2px 3px;
+ background-color: var(--md-default-fg-color--lighter, #ccc);
+}
+
+.md-ctt-button-active {
+ background-color: var(--md-accent-fg-color--transparent, rgba(0, 123, 255, 0.12));
+ border-color: var(--md-accent-fg-color, #007bff);
+ color: var(--md-accent-fg-color, #007bff);
+}
+
+.md-ctt-settings-popover {
+ position: absolute;
+ background-color: var(--md-default-bg-color, #fff);
+ border: 1px solid var(--md-default-fg-color--lighter, #ccc);
+ box-shadow: var(--md-shadow-z2, 0 4px 12px rgba(0,0,0,0.15));
+ border-radius: 6px;
+ padding: 10px 12px;
+ z-index: 100000;
+ min-width: 180px;
+ font-size: 13px;
+ color: var(--md-default-fg-color, #333);
+}
+
+.md-ctt-settings-label {
+ display: block;
+ font-weight: 600;
+ margin-bottom: 4px;
+ font-size: 12px;
+ color: var(--md-default-fg-color--light, #555);
+}
+
+.md-ctt-settings-row {
+ display: flex;
+ align-items: center;
+ gap: 6px;
+ margin-bottom: 6px;
+}
+
+.md-ctt-settings-inline-label {
+ font-size: 13px;
+ white-space: nowrap;
+}
+
+.md-ctt-settings-input {
+ width: 64px;
+ padding: 3px 6px;
+ border: 1px solid var(--md-default-fg-color--lighter, #ccc);
+ border-radius: 4px;
+ font-size: 13px;
+ background-color: var(--md-default-bg-color, #fff);
+ color: var(--md-default-fg-color, #333);
+}
+
+.md-ctt-settings-input:focus {
+ outline: none;
+ border-color: var(--md-accent-fg-color, #007bff);
+}
+
+.md-ctt-settings-checkbox-label {
+ display: flex;
+ align-items: center;
+ gap: 6px;
+ margin-top: 4px;
+ font-size: 13px;
+ color: var(--md-default-fg-color, #333);
+ cursor: pointer;
+}
+
 .md-image-dialog {
  padding: 20px;
  border: 1px solid var(--md-default-fg-color--lighter, #ccc);

--- a/mkdocs_live_wysiwyg_plugin/vendor/editor.js
+++ b/mkdocs_live_wysiwyg_plugin/vendor/editor.js
@@ -19,6 +19,30 @@ const ICON_TABLE_INSERT_ROW_ABOVE = `<svg viewBox="0 0 24 24" fill="none"><g fil
 const ICON_TABLE_INSERT_ROW_BELOW = `<svg viewBox="0 0 24 24" fill="none"><g fill="#999"><rect x="3" y="6" width="5" height="3" rx=".5"/><rect x="9" y="6" width="5" height="3" rx=".5"/><rect x="15" y="6" width="5" height="3" rx=".5"/></g><g fill="#4a90e2"><rect x="3" y="11" width="5" height="3" rx=".5"/><rect x="9" y="11" width="5" height="3" rx=".5"/><rect x="15" y="11" width="5" height="3" rx=".5"/></g><path stroke="#4a90e2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M12 16v4M10 19l2 2 2-2"/></svg>`;
 const ICON_TABLE_INSERT_COL_LEFT = `<svg viewBox="0 0 24 24" fill="none"><g fill="#4a90e2"><rect x="9" y="6" width="3" height="4" rx=".5"/><rect x="9" y="11" width="3" height="4" rx=".5"/><rect x="9" y="16" width="3" height="4" rx=".5"/></g><g fill="#999"><rect x="14" y="6" width="3" height="4" rx=".5"/><rect x="14" y="11" width="3" height="4" rx=".5"/><rect x="14" y="16" width="3" height="4" rx=".5"/></g><path stroke="#4a90e2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M7 12H3M4 10l-2 2 2 2"/></svg>`;
 const ICON_TABLE_INSERT_COL_RIGHT = `<svg viewBox="0 0 24 24" fill="none"><g fill="#999"><rect x="7" y="6" width="3" height="4" rx=".5"/><rect x="7" y="11" width="3" height="4" rx=".5"/><rect x="7" y="16" width="3" height="4" rx=".5"/></g><g fill="#4a90e2"><rect x="12" y="6" width="3" height="4" rx=".5"/><rect x="12" y="11" width="3" height="4" rx=".5"/><rect x="12" y="16" width="3" height="4" rx=".5"/></g><path stroke="#4a90e2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M17 12h4M20 10l2 2-2 2"/></svg>`;
+const ICON_ALIGN_LEFT = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="10" x2="15" y2="10"/><line x1="3" y1="14" x2="18" y2="14"/><line x1="3" y1="18" x2="13" y2="18"/></svg>`;
+const ICON_ALIGN_CENTER = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="6" y1="10" x2="18" y2="10"/><line x1="4" y1="14" x2="20" y2="14"/><line x1="7" y1="18" x2="17" y2="18"/></svg>`;
+const ICON_ALIGN_RIGHT = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="9" y1="10" x2="21" y2="10"/><line x1="6" y1="14" x2="21" y2="14"/><line x1="11" y1="18" x2="21" y2="18"/></svg>`;
+const ICON_TABLE_DELETE_ROW = `<svg viewBox="0 0 24 24" fill="none"><g fill="#e25c5c"><rect x="3" y="10" width="5" height="3" rx=".5"/><rect x="9" y="10" width="5" height="3" rx=".5"/><rect x="15" y="10" width="5" height="3" rx=".5"/></g><g fill="#999"><rect x="3" y="15" width="5" height="3" rx=".5"/><rect x="9" y="15" width="5" height="3" rx=".5"/><rect x="15" y="15" width="5" height="3" rx=".5"/></g><path stroke="#e25c5c" stroke-width="2" stroke-linecap="round" d="M8 4l8 0M9 3l6 6M15 3l-6 6"/></svg>`;
+const ICON_TABLE_DELETE_COL = `<svg viewBox="0 0 24 24" fill="none"><g fill="#e25c5c"><rect x="9" y="6" width="3" height="4" rx=".5"/><rect x="9" y="11" width="3" height="4" rx=".5"/><rect x="9" y="16" width="3" height="4" rx=".5"/></g><g fill="#999"><rect x="14" y="6" width="3" height="4" rx=".5"/><rect x="14" y="11" width="3" height="4" rx=".5"/><rect x="14" y="16" width="3" height="4" rx=".5"/></g><path stroke="#e25c5c" stroke-width="2" stroke-linecap="round" d="M4 2v8M1 3l6 6M7 3l-6 6"/></svg>`;
+const ICON_TABLE_SETTINGS = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
+
+function _getCellAlign(cell) {
+    if (!cell) return '';
+    return (cell.style.textAlign || cell.getAttribute('align') || '').toLowerCase();
+}
+
+function _normalizeTableAlignAttrs(container) {
+    if (!container) return;
+    const cells = container.querySelectorAll('th[align], td[align]');
+    for (let i = 0; i < cells.length; i++) {
+        const val = (cells[i].getAttribute('align') || '').toLowerCase();
+        if (val && val !== 'left') {
+            cells[i].style.textAlign = val;
+        }
+        cells[i].removeAttribute('align');
+    }
+}
+window._normalizeTableAlignAttrs = _normalizeTableAlignAttrs;
 
 class MarkdownWYSIWYG {
     constructor(elementId, options = {}) {
@@ -339,14 +363,25 @@ class MarkdownWYSIWYG {
         this.contextualTableToolbar = document.createElement('div');
         this.contextualTableToolbar.classList.add('md-contextual-table-toolbar');
 
-        const buttons = [
+        const insertButtons = [
             { id: 'insertRowAbove', label: ICON_TABLE_INSERT_ROW_ABOVE, title: 'Insert Row Above', action: () => this._insertRowWysiwyg(true) },
             { id: 'insertRowBelow', label: ICON_TABLE_INSERT_ROW_BELOW, title: 'Insert Row Below', action: () => this._insertRowWysiwyg(false) },
             { id: 'insertColLeft', label: ICON_TABLE_INSERT_COL_LEFT, title: 'Insert Column Left', action: () => this._insertColumnWysiwyg(true) },
             { id: 'insertColRight', label: ICON_TABLE_INSERT_COL_RIGHT, title: 'Insert Column Right', action: () => this._insertColumnWysiwyg(false) },
         ];
 
-        buttons.forEach(btnConfig => {
+        const deleteButtons = [
+            { id: 'deleteRow', label: ICON_TABLE_DELETE_ROW, title: 'Delete Row', action: () => this._deleteRowWysiwyg() },
+            { id: 'deleteCol', label: ICON_TABLE_DELETE_COL, title: 'Delete Column', action: () => this._deleteColumnWysiwyg() },
+        ];
+
+        const alignButtons = [
+            { id: 'alignLeft', label: ICON_ALIGN_LEFT, title: 'Align Left', align: 'left' },
+            { id: 'alignCenter', label: ICON_ALIGN_CENTER, title: 'Align Center', align: 'center' },
+            { id: 'alignRight', label: ICON_ALIGN_RIGHT, title: 'Align Right', align: 'right' },
+        ];
+
+        const addButton = (btnConfig) => {
             const button = document.createElement('button');
             button.type = 'button';
             button.classList.add('md-contextual-table-toolbar-button', `md-ctt-button-${btnConfig.id}`);
@@ -355,11 +390,42 @@ class MarkdownWYSIWYG {
             button.addEventListener('click', (e) => {
                 e.stopPropagation();
                 if (this.currentTableSelectionInfo) {
-                    btnConfig.action();
+                    if (btnConfig.action) btnConfig.action();
+                    else if (btnConfig.align) this._setColumnAlignment(btnConfig.align);
                 }
             });
             this.contextualTableToolbar.appendChild(button);
+        };
+
+        insertButtons.forEach(addButton);
+
+        const sep0 = document.createElement('span');
+        sep0.classList.add('md-ctt-separator');
+        this.contextualTableToolbar.appendChild(sep0);
+
+        deleteButtons.forEach(addButton);
+
+        const sep = document.createElement('span');
+        sep.classList.add('md-ctt-separator');
+        this.contextualTableToolbar.appendChild(sep);
+
+        alignButtons.forEach(addButton);
+
+        const sep2 = document.createElement('span');
+        sep2.classList.add('md-ctt-separator');
+        this.contextualTableToolbar.appendChild(sep2);
+
+        const gearBtn = document.createElement('button');
+        gearBtn.type = 'button';
+        gearBtn.classList.add('md-contextual-table-toolbar-button', 'md-ctt-button-tableSettings');
+        gearBtn.innerHTML = ICON_TABLE_SETTINGS;
+        gearBtn.title = 'Table Settings';
+        gearBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (this.currentTableSelectionInfo) this._toggleTableSettingsPopover(gearBtn);
         });
+        this.contextualTableToolbar.appendChild(gearBtn);
+
         this.editorWrapper.appendChild(this.contextualTableToolbar);
     }
 
@@ -388,12 +454,15 @@ class MarkdownWYSIWYG {
         this.contextualTableToolbar.style.top = `${top}px`;
         this.contextualTableToolbar.style.left = `${left}px`;
 
+        this._updateAlignmentButtonStates();
+
         this._boundListeners.closeContextualTableToolbarOnEsc = (e) => this._handlePopupEscKey(e, this._hideContextualTableToolbar.bind(this));
         document.addEventListener('click', this._boundListeners.closeContextualTableToolbarOnClickOutside, true);
         document.addEventListener('keydown', this._boundListeners.closeContextualTableToolbarOnEsc, true);
     }
 
     _hideContextualTableToolbar() {
+        this._hideTableSettingsPopover();
         if (this.contextualTableToolbar) {
             this.contextualTableToolbar.style.display = 'none';
         }
@@ -405,6 +474,9 @@ class MarkdownWYSIWYG {
     }
 
     _closeContextualTableToolbarOnClickOutside(event) {
+        if (this._tableSettingsPopover && this._tableSettingsPopover.contains(event.target)) {
+            return;
+        }
         if (this.contextualTableToolbar &&
             !this.contextualTableToolbar.contains(event.target) &&
             !this._findParentElement(event.target, ['TD', 'TH'])) {
@@ -416,6 +488,12 @@ class MarkdownWYSIWYG {
 
     _handlePopupEscKey(event, hideMethod) {
         if (event.key === 'Escape') {
+            if (this._tableSettingsPopover) {
+                this._hideTableSettingsPopover();
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
             hideMethod();
             event.preventDefault();
             event.stopPropagation();
@@ -519,6 +597,234 @@ class MarkdownWYSIWYG {
 
         this._finalizeUpdate(this.editableArea.innerHTML);
         this._showContextualTableToolbar(newFocusedCellInCurrentRow || currentCell);
+    }
+
+    _deleteRowWysiwyg() {
+        if (!this.currentTableSelectionInfo) return;
+        const { row: currentRow, table, cellIndex } = this.currentTableSelectionInfo;
+
+        const allRows = Array.from(table.rows);
+        if (allRows.length <= 2) {
+            const p = document.createElement('p');
+            p.innerHTML = '&#8203;';
+            table.parentNode.insertBefore(p, table);
+            table.parentNode.removeChild(table);
+            this._hideContextualTableToolbar();
+            this._focusCell(p);
+            this._finalizeUpdate(this.editableArea.innerHTML);
+            return;
+        }
+
+        const rowIdx = allRows.indexOf(currentRow);
+        currentRow.parentNode.removeChild(currentRow);
+
+        const remaining = Array.from(table.rows);
+        const nextRow = remaining[Math.min(rowIdx, remaining.length - 1)];
+        const cellToFocus = nextRow ? (nextRow.cells[cellIndex] || nextRow.cells[0]) : null;
+
+        if (cellToFocus) {
+            this._focusCell(cellToFocus);
+            this.currentTableSelectionInfo = {
+                cell: cellToFocus,
+                row: nextRow,
+                table: table,
+                cellIndex: cellToFocus.cellIndex,
+                rowIndex: nextRow.rowIndex
+            };
+            this._finalizeUpdate(this.editableArea.innerHTML);
+            this._showContextualTableToolbar(cellToFocus);
+        } else {
+            this._hideContextualTableToolbar();
+            this._finalizeUpdate(this.editableArea.innerHTML);
+        }
+    }
+
+    _deleteColumnWysiwyg() {
+        if (!this.currentTableSelectionInfo) return;
+        const { table, cellIndex } = this.currentTableSelectionInfo;
+
+        const colCount = table.rows[0] ? table.rows[0].cells.length : 0;
+        if (colCount <= 1) {
+            const p = document.createElement('p');
+            p.innerHTML = '&#8203;';
+            table.parentNode.insertBefore(p, table);
+            table.parentNode.removeChild(table);
+            this._hideContextualTableToolbar();
+            this._focusCell(p);
+            this._finalizeUpdate(this.editableArea.innerHTML);
+            return;
+        }
+
+        for (const row of table.rows) {
+            if (row.cells[cellIndex]) {
+                row.deleteCell(cellIndex);
+            }
+        }
+
+        const focusIdx = Math.min(cellIndex, table.rows[0].cells.length - 1);
+        const currentRow = this.currentTableSelectionInfo.row;
+        const cellToFocus = currentRow.cells[focusIdx] || currentRow.cells[0];
+
+        if (cellToFocus) {
+            this._focusCell(cellToFocus);
+            this.currentTableSelectionInfo = {
+                cell: cellToFocus,
+                row: currentRow,
+                table: table,
+                cellIndex: cellToFocus.cellIndex,
+                rowIndex: currentRow.rowIndex
+            };
+            this._finalizeUpdate(this.editableArea.innerHTML);
+            this._showContextualTableToolbar(cellToFocus);
+        } else {
+            this._hideContextualTableToolbar();
+            this._finalizeUpdate(this.editableArea.innerHTML);
+        }
+    }
+
+    _setColumnAlignment(alignment) {
+        if (!this.currentTableSelectionInfo) return;
+        const { table, cellIndex } = this.currentTableSelectionInfo;
+        for (const row of table.rows) {
+            const cell = row.cells[cellIndex];
+            if (cell) {
+                cell.removeAttribute('align');
+                if (alignment === 'left') {
+                    cell.style.textAlign = '';
+                } else {
+                    cell.style.textAlign = alignment;
+                }
+            }
+        }
+        this._finalizeUpdate(this.editableArea.innerHTML);
+        this._updateAlignmentButtonStates();
+    }
+
+    _updateAlignmentButtonStates() {
+        if (!this.contextualTableToolbar || !this.currentTableSelectionInfo) return;
+        const { table, cellIndex } = this.currentTableSelectionInfo;
+        const headerRow = table.querySelector('thead tr') || table.querySelector('tr');
+        const headerCell = headerRow ? headerRow.cells[cellIndex] : null;
+        const align = _getCellAlign(headerCell);
+        const currentAlign = align || 'left';
+        const btnMap = { alignLeft: 'left', alignCenter: 'center', alignRight: 'right' };
+        for (const [id, val] of Object.entries(btnMap)) {
+            const btn = this.contextualTableToolbar.querySelector(`.md-ctt-button-${id}`);
+            if (btn) {
+                if (val === currentAlign) btn.classList.add('md-ctt-button-active');
+                else btn.classList.remove('md-ctt-button-active');
+            }
+        }
+    }
+
+    _toggleTableSettingsPopover(anchorBtn) {
+        if (this._tableSettingsPopover && this._tableSettingsPopover.parentNode) {
+            this._hideTableSettingsPopover();
+        } else {
+            this._showTableSettingsPopover(anchorBtn);
+        }
+    }
+
+    _showTableSettingsPopover(anchorBtn) {
+        this._hideTableSettingsPopover();
+        const table = this.currentTableSelectionInfo ? this.currentTableSelectionInfo.table : null;
+        if (!table) return;
+
+        const popover = document.createElement('div');
+        popover.classList.add('md-ctt-settings-popover');
+
+        const getGlobal = window._getGlobalTableWidth ? window._getGlobalTableWidth() : 120;
+
+        const widthRow = document.createElement('div');
+        widthRow.classList.add('md-ctt-settings-row');
+
+        const widthLabel = document.createElement('span');
+        widthLabel.classList.add('md-ctt-settings-inline-label');
+        widthLabel.textContent = 'Max width';
+        widthRow.appendChild(widthLabel);
+
+        const widthInput = document.createElement('input');
+        widthInput.type = 'number';
+        widthInput.min = '20';
+        widthInput.classList.add('md-ctt-settings-input');
+        widthInput.value = getGlobal;
+        widthInput.tabIndex = 1;
+        widthInput.addEventListener('change', () => {
+            const v = parseInt(widthInput.value, 10);
+            if (v > 0 && window._setGlobalTableWidth) window._setGlobalTableWidth(v);
+        });
+        widthRow.appendChild(widthInput);
+        popover.appendChild(widthRow);
+
+        const minimalRow = document.createElement('label');
+        minimalRow.classList.add('md-ctt-settings-checkbox-label');
+        const minimalCb = document.createElement('input');
+        minimalCb.type = 'checkbox';
+        minimalCb.tabIndex = 2;
+        minimalCb.checked = window._getMinimalTables ? window._getMinimalTables() : false;
+        minimalCb.addEventListener('change', () => {
+            if (window._setMinimalTables) window._setMinimalTables(minimalCb.checked);
+        });
+        minimalRow.appendChild(minimalCb);
+        minimalRow.appendChild(document.createTextNode(' Minimal tables'));
+        popover.appendChild(minimalRow);
+
+        popover.addEventListener('click', (e) => e.stopPropagation());
+        popover.addEventListener('mousedown', (e) => e.stopPropagation());
+
+        this.editorWrapper.appendChild(popover);
+        this._tableSettingsPopover = popover;
+
+        const btnRect = anchorBtn.getBoundingClientRect();
+        const wrapperRect = this.editorWrapper.getBoundingClientRect();
+        popover.style.top = (btnRect.bottom - wrapperRect.top + 4) + 'px';
+        popover.style.right = (wrapperRect.right - btnRect.right) + 'px';
+
+        if (window._attachDialogKeyboard) {
+            window._attachDialogKeyboard(popover, {
+                category: 'settings',
+                onDismiss: () => { this._hideTableSettingsPopover(); },
+                autoFocus: widthInput
+            });
+        } else {
+            requestAnimationFrame(() => { widthInput.focus(); });
+        }
+
+        this._tableSettingsCloseHandler = (ev) => {
+            if (popover.contains(ev.target) || ev.target === anchorBtn || anchorBtn.contains(ev.target)) return;
+            this._hideTableSettingsPopover();
+        };
+        document.addEventListener('mousedown', this._tableSettingsCloseHandler, true);
+    }
+
+    _hideTableSettingsPopover() {
+        if (this._tableSettingsCloseHandler) {
+            document.removeEventListener('mousedown', this._tableSettingsCloseHandler, true);
+            this._tableSettingsCloseHandler = null;
+        }
+        if (this._tableSettingsPopover && this._tableSettingsPopover.parentNode) {
+            this._tableSettingsPopover.parentNode.removeChild(this._tableSettingsPopover);
+        }
+        this._tableSettingsPopover = null;
+    }
+
+    _computeMinimumTableWidth() {
+        const table = this.currentTableSelectionInfo ? this.currentTableSelectionInfo.table : null;
+        if (!table) return 0;
+        if (window._computeNaturalTableWidth) return window._computeNaturalTableWidth(table);
+        const rows = table.querySelectorAll('tr');
+        if (!rows.length) return 0;
+        const colCount = rows[0].cells.length;
+        const maxWidths = new Array(colCount).fill(3);
+        for (let r = 0; r < rows.length; r++) {
+            for (let c = 0; c < rows[r].cells.length && c < colCount; c++) {
+                const text = (rows[r].cells[c].textContent || '').replace(/[\u200B\u200C\u200D]/g, '').trim();
+                if (text.length > maxWidths[c]) maxWidths[c] = text.length;
+            }
+        }
+        let total = 1;
+        for (let c = 0; c < colCount; c++) total += maxWidths[c] + 3;
+        return total;
     }
 
     _focusCell(cellElement) {
@@ -908,6 +1214,7 @@ class MarkdownWYSIWYG {
         if (mode === 'wysiwyg') {
             if (!isInitialSetup) {
                 this.editableArea.innerHTML = this._markdownToHtml(this.markdownArea.value);
+                _normalizeTableAlignAttrs(this.editableArea);
             }
             this.editableArea.style.display = 'block';
             this.markdownEditorContainer.style.display = 'none';
@@ -1631,6 +1938,7 @@ class MarkdownWYSIWYG {
 
             if (this.currentMode === 'wysiwyg') {
                 this.editableArea.innerHTML = contentToRestore;
+                _normalizeTableAlignAttrs(this.editableArea);
             } else {
                 this.markdownArea.value = contentToRestore;
                 this._updateMarkdownLineNumbers();
@@ -1743,6 +2051,12 @@ class MarkdownWYSIWYG {
         }
     }
 
+    _isEmptyBlock(el) {
+        if (!el) return false;
+        const text = el.textContent || '';
+        return text === '' || text === '\u200B';
+    }
+
     _insertTableWysiwyg(rows, cols) {
         if (isNaN(rows) || isNaN(cols) || rows < 1 || cols < 1) {
             return;
@@ -1792,15 +2106,31 @@ class MarkdownWYSIWYG {
             tbody.appendChild(br);
         }
 
-        rangeToUse.deleteContents();
-        const fragment = document.createDocumentFragment();
-        fragment.appendChild(table);
+        const blockParent = this._findParentElement(
+            rangeToUse.commonAncestorContainer,
+            ['H1','H2','H3','H4','H5','H6','P','BLOCKQUOTE','LI']
+        );
 
         const pAfter = document.createElement('p');
         pAfter.innerHTML = '&#8203;';
-        fragment.appendChild(pAfter);
 
-        rangeToUse.insertNode(fragment);
+        if (blockParent && this.editableArea.contains(blockParent) && blockParent !== this.editableArea) {
+            if (blockParent.nodeName === 'P' && this._isEmptyBlock(blockParent)) {
+                blockParent.parentNode.insertBefore(table, blockParent);
+                blockParent.parentNode.insertBefore(pAfter, blockParent);
+                blockParent.parentNode.removeChild(blockParent);
+            } else {
+                const ref = blockParent.nextSibling;
+                blockParent.parentNode.insertBefore(table, ref);
+                blockParent.parentNode.insertBefore(pAfter, table.nextSibling);
+            }
+        } else {
+            rangeToUse.deleteContents();
+            const fragment = document.createDocumentFragment();
+            fragment.appendChild(table);
+            fragment.appendChild(pAfter);
+            rangeToUse.insertNode(fragment);
+        }
 
         let firstCellToFocus = null;
         if (rows >= 1 && cols >= 1 && thead.firstChild && thead.firstChild.firstChild) {
@@ -1815,10 +2145,11 @@ class MarkdownWYSIWYG {
             this.currentTableSelectionInfo = { cell: firstCellToFocus, row: row, table: table, cellIndex: firstCellToFocus.cellIndex, rowIndex: row.rowIndex };
             this._showContextualTableToolbar(firstCellToFocus);
         } else {
-            rangeToUse.setStart(pAfter, pAfter.childNodes.length > 0 ? 1 : 0);
-            rangeToUse.collapse(true);
+            const newRange = document.createRange();
+            newRange.setStart(pAfter, pAfter.childNodes.length > 0 ? 1 : 0);
+            newRange.collapse(true);
             selection.removeAllRanges();
-            selection.addRange(rangeToUse);
+            selection.addRange(newRange);
         }
         this.savedRangeInfo = null;
         this._finalizeUpdate(this.editableArea.innerHTML);
@@ -2674,6 +3005,28 @@ class MarkdownWYSIWYG {
                     return `\`\`\`\n${preTextContent}\`\`\`\n\n`;
                 }
                 if (node.nodeName.match(/^H[1-6]$/)) {
+                    const hasBlockChild = Array.from(node.childNodes).some(c => this._isBlockElement(c));
+                    if (hasBlockChild) {
+                        const level = parseInt(node.nodeName[1]);
+                        let md = '';
+                        let inlineBuf = '';
+                        for (let ci = 0; ci < node.childNodes.length; ci++) {
+                            const child = node.childNodes[ci];
+                            if (this._isBlockElement(child)) {
+                                if (inlineBuf.trim()) {
+                                    md += `${'#'.repeat(level)} ${inlineBuf.trim()}\n\n`;
+                                    inlineBuf = '';
+                                }
+                                md += this._nodeToMarkdownRecursive(child, options);
+                            } else {
+                                inlineBuf += this._nodeToMarkdownRecursive(child, options);
+                            }
+                        }
+                        if (inlineBuf.trim()) {
+                            md += `${'#'.repeat(level)} ${inlineBuf.trim()}\n\n`;
+                        }
+                        return md;
+                    }
                     return `${'#'.repeat(parseInt(node.nodeName[1]))} ${this._processInlineContainerRecursive(node, options).trim()}\n\n`;
                 }
                 if (node.nodeName === 'HR') {
@@ -2748,9 +3101,21 @@ class MarkdownWYSIWYG {
 
 
                 tableMarkdown = headerMdContent;
-                // Add separator line if there was a header or we have columns
+                // Add separator line with alignment markers from header cell styles
                 if (headerMdContent.trim() !== '' || colCount > 0) {
-                    tableMarkdown += `|${' --- |'.repeat(colCount)}\n`;
+                    let headerRow = tHeadNode ? tHeadNode.querySelector('tr') : null;
+                    if (!headerRow && firstTBodyRowUsedAsHeader && tBodyNode) {
+                        headerRow = tBodyNode.querySelector('tr');
+                    }
+                    const headerCellNodes = headerRow ? Array.from(headerRow.querySelectorAll('th, td')) : [];
+                    let sepParts = '';
+                    for (let ci = 0; ci < colCount; ci++) {
+                        const align = _getCellAlign(headerCellNodes[ci]);
+                        if (align === 'center') sepParts += ' :---: |';
+                        else if (align === 'right') sepParts += ' ---: |';
+                        else sepParts += ' --- |';
+                    }
+                    tableMarkdown += `|${sepParts}\n`;
                 }
 
                 // Process TBODY
@@ -2804,6 +3169,7 @@ class MarkdownWYSIWYG {
     setValue(markdown, isInitialSetup = false) {
         const html = this._markdownToHtml(markdown);
         this.editableArea.innerHTML = html;
+        _normalizeTableAlignAttrs(this.editableArea);
         this.markdownArea.value = markdown || '';
 
         if (this.currentMode === 'markdown') {


### PR DESCRIPTION
UI changes:

- Tables get a settings gear.
- Tables can now delete rows or columns.
- Tables can align columns left, right, or center.

Fixes:

- Changes to only `mkdocs.yml` no longer write out all documents with frontmatter.
- Fix complex yaml frontmatter corruption
- Tables preserve formatting and can be column-aligned
- Tables are block-element aware when inserted.
- Headings now ensure there's separation with block elements even if there's malformed DOM in WYSIWYG mode.
- Table settings gear and width awareness for pretty ASCII tables