### PR TITLE
Mermaid diagramming enhancements

### DIFF
--- a/docs/design/DESIGN-architecture-overview.md
+++ b/docs/design/DESIGN-architecture-overview.md
@@ -124,6 +124,8 @@ UI Subsystem
   |-- Mermaid Subsystem
   |     |-- Mermaid Mode (UI, Layer 3 in mode hierarchy)
   |     |-- Vendor Subsystem (mermaid.js + mermaid-live-editor)
+  |     |-- Monaco Subsystem (embedded code editor API + runtime discovery)
+  |     |-- Mermaid Diagram Selection (SVG click-to-select + load monitor)
   |     |-- MkDocs YAML Mermaid Config (server-side detection + client-side auto-fix)
   |-- Toolbars
   |-- Content Editing
@@ -181,6 +183,8 @@ Mermaid-related design documents are organized under `docs/design/mermaid/` whil
 
 - [DESIGN-mermaid-mode.md](mermaid/DESIGN-mermaid-mode.md) -- Layer 3 UI mode for mermaid diagram editing.
 - [DESIGN-vendor-subsystem.md](mermaid/DESIGN-vendor-subsystem.md) -- Vendored mermaid.js and mermaid-live-editor.
+- [DESIGN-monaco-subsystem.md](mermaid/DESIGN-monaco-subsystem.md) -- Embedded Monaco code editor API, runtime discovery, and content access paths.
+- [DESIGN-mermaid-diagram-selection.md](mermaid/DESIGN-mermaid-diagram-selection.md) -- SVG click-to-select heuristics, text normalization, initial load monitor.
 - [DESIGN-mkdocs-yml-mermaid-config.md](mermaid/DESIGN-mkdocs-yml-mermaid-config.md) -- Server-side config detection and client-side auto-fix.
 
 #### Toolbars

--- a/docs/design/mermaid/DESIGN-mermaid-diagram-selection.md
+++ b/docs/design/mermaid/DESIGN-mermaid-diagram-selection.md
@@ -1,0 +1,362 @@
+# Mermaid Diagram Selection Heuristics
+
+When a user clicks on text in the rendered mermaid SVG diagram (inside the mermaid-live-editor iframe), the corresponding text is selected and highlighted in the Monaco code editor and scrolled into view. This subsystem is implemented entirely within the bridge script (vendor patch P1). Context-aware disambiguation ensures that clicking duplicate text (e.g., "Storage" appearing twice) selects the correct occurrence in the source code.
+
+## SVG DOM Structure
+
+The mermaid rendering library produces an SVG inside `div#container`:
+
+```
+div#container
+  svg#graph-N.flowchart
+    g.svg-pan-zoom_viewport [transform: matrix(...)]
+      g
+        g.root
+          g.nodes
+            g.node#flowchart-NodeId-N [transform: translate(x, y)]
+              rect.basic.label-container
+              g.label
+                foreignObject
+                  div
+                    span.nodeLabel
+                      p   <-- clickable text: "navData"
+          g.edgeLabels
+            g.edgeLabel [transform: translate(x, y)]
+              g.label
+                foreignObject
+                  div
+                    span.edgeLabel
+                      p   <-- clickable text: "commits as"
+```
+
+### Key Selectors
+
+There are two categories of clickable text in mermaid SVGs: HTML elements inside `<foreignObject>` (which use `innerHTML` for extraction) and native SVG `<text>`/`<tspan>` elements (which use `textContent`).
+
+#### HTML-in-SVG Selectors (foreignObject `<p>` elements)
+
+| Element | Selector | Diagram Types |
+|---|---|---|
+| Node labels | `g.node .nodeLabel p` | Flowchart, Block, State, Mindmap, Kanban, Requirement |
+| Edge labels | `g.edgeLabel .edgeLabel p` | Flowchart, Block |
+| Cluster/subgraph labels | `g.cluster-label .nodeLabel p` | Flowchart (subgraphs), Kanban (columns) |
+| Class name labels | `.label-group .nodeLabel p` | Class |
+| Class member labels | `.members-group .nodeLabel p` | Class |
+| Class method labels | `.methods-group .nodeLabel p` | Class |
+| ER entity/attribute labels | `.label.name .nodeLabel p`, `.label.attribute-type .nodeLabel p`, `.label.attribute-name .nodeLabel p` | Entity Relationship |
+| Journey section labels | `div.journey-section > div.label` | User Journey |
+| Journey task labels | `div.task > div.label` | User Journey |
+| ZenUML participant names | `.zenuml label.name` | ZenUML |
+| ZenUML conditions | `.zenuml label.condition` | ZenUML |
+| ZenUML interface annotations | `.zenuml label.interface` | ZenUML |
+| ZenUML diagram title | `.zenuml div.title.text-skin-title` | ZenUML |
+| ZenUML lifeline group names | `.zenuml span.text-skin-lifeline-group-name` | ZenUML |
+| ZenUML message labels | `.zenuml .message > .name` | ZenUML |
+| ZenUML fragment labels | `.zenuml .fragment .header .collapsible-header > label` | ZenUML |
+
+#### Native SVG Text Selectors (`<text>` and `<tspan>` elements)
+
+| Element | Selector | Diagram Types |
+|---|---|---|
+| Message labels | `text.messageText` | Sequence |
+| Actor names | `text.actor tspan` | Sequence |
+| Service/group labels | `tspan.text-inner-tspan` | Architecture |
+| Packet field labels | `text.packetLabel` | Packet |
+| Packet title | `text.packetTitle` | Packet |
+| Pie legend | `.legend text` | Pie |
+| Pie title | `text.pieTitleText` | Pie |
+| Quadrant labels | `.quadrant text` | Quadrant |
+| Data point labels | `.data-point text` | Quadrant |
+| Axis labels | `.labels .label text` | Quadrant |
+| Chart title | `.title text` | Quadrant |
+| Radar axis labels | `text.radarAxisLabel` | Radar |
+| Radar title | `text.radarTitle` | Radar |
+| Radar legend | `text.radarLegendText` | Radar |
+| Branch labels | `.branchLabel text tspan` | Git |
+| Commit labels | `text.commit-label` | Git |
+| Task text | `text.taskText` | Gantt |
+| Section titles | `text.sectionTitle tspan` | Gantt |
+| Chart title | `text.titleText` | Gantt |
+| C4 person/system labels | `g.person-man text tspan` | C4 |
+| C4 relation/boundary labels | `tspan[alignment-baseline='mathematical']` | C4 |
+| Sankey node labels | `g.node-labels text` | Sankey |
+| Timeline node labels | `g.timeline-node tspan` | Timeline |
+| Treemap section labels | `text.treemapSectionLabel` | Treemap |
+| Treemap item labels | `text.treemapLabel` | Treemap |
+| Journey actor legend | `text.legend tspan` | User Journey |
+| XY/chart title | `g.chart-title text` | XY |
+
+## Pan/Zoom Tracking
+
+The SVG uses the `svg-pan-zoom` library which applies a CSS `transform: matrix(...)` on `g.svg-pan-zoom_viewport`. Since the text elements are **children** of this viewport group, they naturally follow the pan/zoom transform. No separate overlay repositioning is needed. Click events on the `<foreignObject>` / `<p>` elements inside the SVG fire correctly regardless of the current zoom/pan state because they are part of the SVG DOM tree.
+
+No external overlay divs are created. Click handlers are attached directly to the SVG text elements.
+
+## Initial SVG Load Monitor
+
+The mermaid-live-editor iframe does not always reliably render the diagram on first load. The bridge includes a session-establishment monitor that verifies the diagram loads successfully.
+
+### Monitor Algorithm
+
+1. `_monitorSvgLoad()` starts on bridge initialization
+2. Polls every 500ms for `document.querySelector("#container svg")`
+3. The SVG is considered "loaded" when the `<svg>` exists and contains at least one `<g class="node">`, `<text>`, `<g class="root">`, or `<foreignObject>` element (confirming the diagram rendered, not just an empty SVG shell). The broader check covers diagram types without `g.node` (Sequence, Packet, Pie, Quadrant, Radar) and `foreignObject` covers ZenUML which renders HTML inside the SVG.
+4. **Success**: Stop polling, call `_onSvgLoaded()` to attach click handlers. Reset the reload counter in `sessionStorage`.
+5. **Timeout**: Call `window.location.reload()` to refresh the iframe. The bridge re-initializes on reload and retries with a progressively longer timeout.
+6. The monitor runs once per session — after initial confirmation, no further SVG monitoring occurs
+
+### Tiered Reload Strategy
+
+The reload timeout uses a tiered backoff tracked via `sessionStorage` (`live-wysiwyg-reload-count`):
+
+| Attempt | Timeout | Polls |
+|---|---|---|
+| 1–3 | 1.5s | 3 |
+| 4 | 2.0s | 4 |
+| 5 | 2.5s | 5 |
+| 6 | 3.0s | 6 |
+| N (N > 3) | 0.5 × (N + 1) s | N + 1 |
+
+On successful load, the counter resets to zero. This keeps initial loads snappy (1.5s) while giving complex diagrams that fail the first few attempts progressively more time to render.
+
+### Sequence
+
+```
+Bridge init
+  |
+  v
+_monitorSvgLoad() reads reload count from sessionStorage, computes maxPolls
+  |
+  polls every 500ms
+  |
+  +-- SVG with g.node/text/root/foreignObject found? --> clear sessionStorage --> _onSvgLoaded() --> done
+  |
+  +-- maxPolls elapsed? --> increment sessionStorage counter --> location.reload() --> retry with longer timeout
+```
+
+## Text Search Heuristics
+
+When the user clicks a text element in the SVG, `_findTextInCode(code, searchText, contextHint)` locates the corresponding text in the mermaid source code. The `contextHint` is the nearest ancestor `<g>` element's `id`, extracted by `_getContextHint(el)`.
+
+### Step 1: Normalize Clicked Text
+
+1. Replace `<br>` / `<br/>` / `<br />` with spaces
+2. Strip remaining HTML tags
+3. Decode HTML entities (`&lt;` → `<`, `&gt;` → `>`, `&amp;` → `&`, etc.) using a `<textarea>` element
+4. Normalize Unicode guillemets: `«` (`\u00AB`) → `<<`, `»` (`\u00BB`) → `>>`
+5. Collapse all whitespace to single spaces
+6. Trim leading/trailing whitespace
+
+Entity decoding (step 3) is essential because `innerHTML` returns entity-encoded text. For example, Requirement diagrams render `<<Requirement>>` which `innerHTML` gives as `&lt;&lt;Requirement&gt;&gt;`. Without decoding, this would never match the source keyword `requirement`.
+
+Guillemet normalization (step 4) handles ZenUML, which renders `<<interface>>` annotations using Unicode guillemet characters (`«interface»`) rather than ASCII `<<`/`>>`. Normalizing to ASCII ensures consistent matching against source text.
+
+Example: `"Nav Snapshots.<br>Saving snapshot differences"` → `"Nav Snapshots. Saving snapshot differences"`
+Example: `"&lt;&lt;Requirement&gt;&gt;"` → `"<<Requirement>>"`
+Example: `"«BFF»"` → `"<<BFF>>"`
+
+### Step 2: Search Mermaid Code
+
+Mermaid diagram code uses specific syntax patterns for labeling nodes and edges:
+
+| Pattern | Example | Label Extracted |
+|---|---|---|
+| Node with brackets | `NavSnaps["Nav Snapshots.<br>Saving snapshot differences"]` | `Nav Snapshots. Saving snapshot differences` |
+| Node with parens | `A(Round node)` | `Round node` |
+| Node with braces | `B{Diamond}` | `Diamond` |
+| Node bare ID | `navData` | `navData` |
+| Edge label with pipes | `-->\|"commits as"\|` | `commits as` |
+| Edge label with pipes (unquoted) | `-->\|commits as\|` | `commits as` |
+
+The search scans each line of the code using a four-tier strategy. All tiers collect **all** matches and apply context-aware disambiguation when multiple matches exist (see § Context-Aware Disambiguation below).
+
+#### Tier 1: Bracket/Delimiter Extraction
+
+1. Extract text content from within `["..."]`, `("...")`, `{"..."}`, and `|"..."|` / `|...|` delimiters
+2. Strip `<br>` / `<br/>` tags from the extracted content and normalize whitespace
+3. Compare the normalized extracted text against the normalized clicked text
+4. On match, return `{ lineNumber, startColumn, endColumn }` pointing to the full delimiter expression (1-based, for Monaco)
+
+This tier handles Flowchart, Block, and other bracket-based diagram syntaxes.
+
+#### Tier 2: Whole-Line Match
+
+If no bracket pattern matches, compare the full trimmed line against the normalized clicked text. Collects **all** matching lines. This handles Mindmap nodes where each label is on its own indented line, and ER attribute lines like `float price` that appear identically in multiple entity blocks.
+
+#### Tier 3: Substring Match (Case-Sensitive)
+
+If tiers 1 and 2 fail, search for the normalized text as a case-sensitive substring within each line. Collects **all** matching lines (not just the first). This tier handles:
+
+- **Class diagrams**: `Animal`, `+int age`, `+isMammal()` in lines like `Animal : +int age` or `class Duck{`
+- **ER diagrams**: `CUSTOMER`, `string`, `id`, `places` in lines like `CUSTOMER ||--o{ ORDER : places`
+- **State diagrams**: `Still`, `Moving` in lines like `[*] --> Still`
+- **Sequence diagrams**: actor names and message text
+- **Kanban**: column names, item text, assigned values
+- **Requirement diagrams**: `test_req`, `test_entity`, `<<satisfies>>` labels
+
+#### Tier 4: Substring Match (Case-Insensitive)
+
+If tier 3 finds no matches, retry with case-insensitive comparison (`toLowerCase()` on both sides). This handles diagram types where the rendered text uses different casing than the source — e.g., Requirement diagrams render `Risk: High` and `Verification: Test` but the source uses `risk: high` and `verifymethod: test`.
+
+### Context-Aware Disambiguation
+
+When multiple lines match the same text (any tier), a **context hint** is used to select the best match. The context hint is the `id` attribute of the nearest ancestor `<g>` element in the SVG DOM tree. For example:
+
+| Diagram Type | SVG Node ID Example | Extracted Tokens |
+|---|---|---|
+| Flowchart | `flowchart-ContentMod-0` | `ContentMod` |
+| Class | `classId-Duck-5` | `Duck` |
+| ER | `entity-CUSTOMER-0`, `entity-ORDER_ITEM-2` | `CUSTOMER`, `ORDER_ITEM` |
+| State | `state-Still-3` | `Still` |
+| Architecture | `server`, `disk1` | `server`, `disk1` |
+| Requirement | `test_entity`, `test_req` | `test`, `entity` / `test`, `req` |
+| Kanban | `id8` | *(numeric — no useful tokens)* |
+
+#### Token Extraction
+
+The context hint ID is split by `-` separators only (underscores are preserved to keep compound names like `ORDER_ITEM` intact). Purely numeric segments and common prefixes (`classId`, `entity`, `state`, `flowchart`) are filtered out. The full original ID is also kept as a token.
+
+#### Proximity Scoring
+
+For each candidate match, the algorithm searches within a ±10-line window for any line containing a hint token. The match with the smallest distance to a context token wins. When two matches have equal distance, the **"after context" tiebreaker** applies: the match that appears AFTER (below) the context token line is preferred over one that appears before it. This ensures matches inside a block (e.g., `float price` after `ORDER_ITEM {`) are preferred over matches that merely happen to be near a mention of the token. If no token appears within the window, the first match is returned as fallback.
+
+This solves several previously-broken cases:
+- **Sample 4 (ER)**: Clicking `string` under `CUSTOMER` selects the `string` in `CUSTOMER`'s attribute block, not `ORDER`'s
+- **Sample 7 (Architecture)**: Clicking `Storage` on `disk1` selects `disk1(disk)[Storage]`, not `disk2(disk)[Storage]`
+- **Sample 12 (Kanban)**: Clicking `knsv` under a specific task prefers the match nearest that task's section
+- **Sample 17 (Requirement)**: Clicking `Type: simulation` under `test_entity` selects the line within the `element test_entity {}` block
+
+## ER Attribute Pair Handler
+
+Entity Relationship diagrams render each attribute as a pair of sibling `<g>` elements: `g.label.attribute-type` (e.g., `string`) and `g.label.attribute-name` (e.g., `name`). Clicking either element in isolation would search for just `"string"` or `"name"`, which produces ambiguous matches across multiple entities.
+
+The bridge includes a dedicated ER handler that runs **before** the general click handler. It:
+
+1. Queries all `g.label.attribute-type` groups in the SVG
+2. For each, finds the next sibling `g.label.attribute-name`
+3. Combines both texts: `"string" + " " + "name"` → `"string name"`
+4. Binds a click handler to both `<p>` elements that searches for the combined text
+5. Marks both elements as `data-live-wysiwyg-click-bound` so the general handler skips them
+
+This ensures the search text `"string name"` uniquely matches the correct source line within the correct entity block. Combined with context-aware disambiguation (using the parent entity's `g[id]`), even identical attribute pairs across entities (e.g., `float price` in both PRODUCT and ORDER_ITEM) are correctly resolved.
+
+## Monaco Integration
+
+The selection is applied via the Monaco editor API. See [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md) for the full API reference.
+
+### Editor Discovery
+
+`_getMonacoEditor()` discovers the editor instance via `window.monaco.editor.getEditors()`. The `window.monaco` global is made available by an AMD shim that the bridge defines before Monaco loads — see [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md) § AMD Global Shim for the full mechanism and upgrade archaeology procedure.
+
+The result is cached in `_cachedEditor` for subsequent clicks. The cache is invalidated if `getModel()` throws or returns falsy.
+
+### Selection Application
+
+```javascript
+var sel = { startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + len };
+editor.setSelection(sel);
+editor.revealRangeInCenter(sel);
+editor.focus();
+```
+
+- `setSelection` highlights the matched text in the editor
+- `revealRangeInCenter` scrolls the editor so the selection appears at approximately 50% vertical
+- `focus` ensures the editor receives keyboard input after the click
+
+## ZenUML Dedicated Binding
+
+ZenUML diagrams render HTML inside `<foreignObject>` within the SVG, rather than using standard mermaid `g.node` structures. This requires a dedicated binding path separate from both the general HTML-in-SVG and native SVG text handlers.
+
+### Why a Separate Path
+
+ZenUML elements live inside a `.zenuml` container within the `<foreignObject>`. While the general HTML-in-SVG handler queries inside `#container svg`, ZenUML elements are accessible via `document.querySelectorAll` but may not be reachable through the SVG container query due to `foreignObject` DOM boundary behavior. The dedicated path queries ZenUML elements directly from `document`.
+
+### Selectors
+
+The ZenUML binding queries a combined selector:
+
+```
+.zenuml label.name
+.zenuml label.condition
+.zenuml label.interface
+.zenuml div.title.text-skin-title
+.zenuml span.text-skin-lifeline-group-name
+.zenuml .message > .name
+.zenuml .fragment .header .collapsible-header > label
+```
+
+These cover participant names, interface annotations (e.g., `<<BFF>>`), message labels, lifeline group names, conditions, and fragment labels (Alt, Par).
+
+### pointer-events
+
+ZenUML's CSS sets `pointer-events: none` on several parent containers (`.life-line-layer`, `.message-container`), which blocks click events from reaching child elements. The bridge injects CSS rules with `!important` to override this:
+
+```css
+.zenuml .life-line-layer .participant { pointer-events: auto !important; }
+.zenuml .life-line-layer .lifeline-group-container > div:first-child { pointer-events: auto !important; }
+.zenuml .message-container .message { pointer-events: auto !important; }
+```
+
+Additionally, each bound ZenUML element has `style.pointerEvents = "auto"` set directly.
+
+### Known Limitations
+
+Some ZenUML elements (participant names like `Client`, `OrderController`, service names) may remain non-clickable depending on the ZenUML version's CSS layering. The current implementation covers message labels, fragment labels, conditions, and interface annotations reliably.
+
+## SVG Link Interception (Kanban Ticket Links)
+
+Some diagram types (notably Kanban) render `<a>` elements with `xlink:href` inside the SVG (e.g., ticket links to GitHub). Since the iframe sandbox prevents `target="_blank"`, these links are intercepted by the same generic link intercept handler (Service 5) that handles menu links.
+
+For SVG `<a>` elements, `link.href` returns an `SVGAnimatedString` object rather than a plain string. The bridge resolves URLs via `_resolveHref()` which checks `link.href.baseVal`, `getAttribute("href")`, and `getAttributeNS("http://www.w3.org/1999/xlink", "href")` as fallbacks.
+
+Resolved URLs are validated against the domain allow-list and forwarded to the parent via `postMessage` for opening in a new tab.
+
+## Lifecycle
+
+1. **Bridge init**: `_monitorSvgLoad()` begins polling
+2. **SVG confirmed**: `_onSvgLoaded()` calls `_attachClickHandlers()` which binds handlers in order: (a) ER attribute pair handler, (b) general HTML-in-SVG `<p>` elements, (c) native SVG `<text>`/`<tspan>` elements, (d) ZenUML-specific elements via `document.querySelectorAll`. Each phase marks bound elements to prevent double-binding.
+3. **User clicks SVG text**: Handler extracts text (via `innerHTML` for HTML elements, `textContent` for SVG/ZenUML elements) and a context hint (nearest ancestor `g[id]`), searches code with disambiguation, discovers Monaco editor, applies selection
+4. **Session ends**: Bridge is torn down with the iframe on mermaid mode exit. No cleanup needed — the iframe is removed from the DOM entirely.
+
+Click handlers are attached once after the initial SVG load. They persist for the duration of the mermaid editing session. If the diagram re-renders (e.g., user edits the code), the SVG DOM is replaced and the click handlers are lost. The bridge observes `#container` for child mutations and re-attaches handlers when the SVG is replaced.
+
+## Browser Compatibility
+
+The bridge script targets **Blink** (Chrome/Edge), **Gecko** (Firefox), and **WebKit** (Safari). See [DESIGN-browser-compatibility.md](../ui/DESIGN-browser-compatibility.md) for the full compatibility framework.
+
+### Language Level
+
+The entire bridge script is written in **ES5** syntax — `var` declarations, `function` expressions, no arrow functions, no template literals, no destructuring. This avoids any transpilation concerns and ensures compatibility with all three engines.
+
+### API Surface Audit
+
+| API | Blink | Gecko | WebKit | Notes |
+|---|---|---|---|---|
+| `Object.getOwnPropertyNames` | 5+ | 4+ | 5+ | Core to editor discovery |
+| `Object.getOwnPropertySymbols` | 38+ | 36+ | 9+ | Wrapped in try/catch; graceful no-op if unavailable |
+| `MutationObserver` | 26+ | 14+ | 7+ | SVG re-render detection |
+| `fetch` | 42+ | 39+ | 10.1+ | Session PUT (mermaid-live-editor itself requires this) |
+| `localStorage` | 4+ | 3.5+ | 4+ | `getItem` wrapped in try/catch per compat doc |
+| `el.innerHTML` on `<p>` in foreignObject | Yes | Yes | Yes | HTML element inside SVG; standard HTML API applies |
+| `el.dataset` on `<p>` in foreignObject | Yes | Yes | Yes | HTML element inside SVG |
+| `el.style.cursor` on `<p>` in foreignObject | Yes | Yes | Yes | HTML element inside SVG |
+| `querySelectorAll` with compound selectors | Yes | Yes | Yes | `g.node .nodeLabel p` etc. |
+| `String()` on `Symbol` values | 38+ | 36+ | 9+ | Used in debug logging only |
+
+### Considerations
+
+- **No `Array.from`**: The bridge uses `for` loops to iterate NodeLists and arguments, avoiding Gecko/WebKit `Array.from` inconsistencies on non-iterable objects.
+- **No `for...of`**: Avoids requiring Symbol.iterator support on older engines.
+- **No `let`/`const`**: `var` hoisting is consistent across all engines; avoids temporal dead zone edge cases.
+- **`Object.getOwnPropertySymbols` fallback**: If unavailable (extremely old engine), the try/catch ensures `_probeElement` still functions using `getOwnPropertyNames` alone.
+- **SVG foreignObject event propagation**: Click events on `<p>` elements inside `<foreignObject>` propagate correctly through the SVG DOM in all three engines. `stopPropagation()` prevents the click from bubbling to the SVG pan/zoom handler.
+- **Monaco widget storage**: The minified Monaco bundle stores its editor reference identically across browsers (same JS bundle). The property name is determined by the minifier, not the browser engine.
+
+## Cross-References
+
+- **Monaco Subsystem**: [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md) — editor API, runtime discovery, content access paths
+- **Vendor Subsystem**: [DESIGN-vendor-subsystem.md](DESIGN-vendor-subsystem.md) — bridge script (P1), upgrade verification for SVG selectors
+- **Mermaid Mode**: [DESIGN-mermaid-mode.md](DESIGN-mermaid-mode.md) — Layer 3 UI mode, iframe lifecycle, overlay DOM
+- **Keyboard Isolation**: [DESIGN-centralized-keyboard.md](../ui/DESIGN-centralized-keyboard.md) § Mermaid Mode — bridge keyboard interception
+- **Readonly Selection Heuristics**: [DESIGN-readonly-selection-heuristics.md](../ui/DESIGN-readonly-selection-heuristics.md) — analogous text selection heuristics for the WYSIWYG editor (different subsystem, similar pattern)
+- **Browser Compatibility**: [DESIGN-browser-compatibility.md](../ui/DESIGN-browser-compatibility.md) — engine detection, API audit framework, workaround catalog

--- a/docs/design/mermaid/DESIGN-mermaid-mode.md
+++ b/docs/design/mermaid/DESIGN-mermaid-mode.md
@@ -261,6 +261,8 @@ The API server (`api_server.py`) serves the vendored mermaid-live-editor static 
 - **Mermaid Session Server**: [DESIGN-mermaid-session-server.md](../backend/DESIGN-mermaid-session-server.md) — session-based content brokering between parent and iframe via the API server (POST/GET/PUT/DELETE lifecycle, server-mediated content exchange)
 - **Keyboard Isolation**: [DESIGN-centralized-keyboard.md](../ui/DESIGN-centralized-keyboard.md) § Mermaid Mode Keyboard Isolation — two-document keyboard architecture (parent Tier 2 guards + iframe bridge capture-phase interception)
 - **Vendor Subsystem**: [DESIGN-vendor-subsystem.md](DESIGN-vendor-subsystem.md) — bridge script (P1), preventDefault override (P8), upgrade procedures, patch inventory
+- **Monaco Subsystem**: [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md) — embedded code editor API, runtime discovery, content access paths
+- **Mermaid Diagram Selection**: [DESIGN-mermaid-diagram-selection.md](DESIGN-mermaid-diagram-selection.md) — SVG click-to-select heuristics, initial load monitor, text normalization
 - **Dialog UX**: [DESIGN-popup-dialog-ux.md](../ui/DESIGN-popup-dialog-ux.md) — ESC overlay-escalation pattern reused by the bridge's ESC handler
 - **Modes of Operation**: `docs/design/ui/DESIGN-modes-of-operation.md` — Layer 3 in the mode hierarchy
 - **MkDocs YAML Config**: [DESIGN-mkdocs-yml-mermaid-config.md](DESIGN-mkdocs-yml-mermaid-config.md) — superfences detection and auto-fix

--- a/docs/design/mermaid/DESIGN-monaco-subsystem.md
+++ b/docs/design/mermaid/DESIGN-monaco-subsystem.md
@@ -1,0 +1,248 @@
+# Monaco Subsystem
+
+Monaco is the code editor embedded within the vendored mermaid-live-editor SvelteKit app. It provides the text editing surface where users write mermaid diagram code. This document captures the runtime API surface, content access paths, and discovery mechanism used by the bridge script.
+
+## Bundle Location
+
+Monaco is bundled (not loaded from CDN) inside the SvelteKit build output. The main chunk filename changes on every build (content-hashed). As of the current vendored build the chunk is:
+
+```
+vendor/mermaid-live-editor/_app/immutable/chunks/Dvs79aKq.js
+```
+
+By default there is **no** `window.monaco` global. Monaco is loaded as ES modules within the SvelteKit Vite bundle. However, the bundle contains a conditional that exposes the global when AMD is detected (see "AMD Global Shim" below). Public API method names (`setSelection`, `getModel`, `revealRangeInCenter`, `focus`, `getEditors`, etc.) are preserved in the minified bundle because they are part of Monaco's public interface.
+
+## Editor Container DOM
+
+```
+div#editor [data-keybinding-context="1"][data-mode-id="mermaid"]
+  div.monaco-editor[role="code"][data-uri="internal://mermaid.mmd"]
+    div.overflow-guard [data-mprt="3"]
+    div.overflowingContentWidgets [data-mprt="2"]
+    div.overflowingOverlayWidgets [data-mprt="5"]
+```
+
+**Important**: `div#editor` (with `data-mode-id="mermaid"`) is the **outer wrapper**. The `div.monaco-editor` is a **child** of `div#editor`, not a parent. Earlier versions of this document incorrectly described the relationship.
+
+## Runtime Discovery — AMD Global Shim
+
+Monaco's bundled code contains a conditional that exposes the full API to `globalThis.monaco`:
+
+```javascript
+// Minified pattern (variable names change per build):
+(typeof define === "function" && define.amd) && (globalThis.monaco = Yo);
+```
+
+Where `Yo` (or equivalent in a future build) is the Monaco namespace with `Yo.editor`, `Yo.languages`, etc.
+
+The bridge script runs in `<head>` before any ES modules load. It defines a minimal AMD shim:
+
+```javascript
+if (typeof window.define !== "function") {
+  window.define = function() {};
+  window.define.amd = true;
+}
+```
+
+This causes Monaco's conditional to evaluate to `true`, resulting in `globalThis.monaco` being populated with the full public API. The `getEditors()` method on `monaco.editor` returns all `IStandaloneCodeEditor` instances.
+
+### Discovery Algorithm
+
+```javascript
+function _getMonacoEditor() {
+  if (_cachedEditor) {
+    try { if (_cachedEditor.getModel()) return _cachedEditor; }
+    catch(ex) {}
+    _cachedEditor = null;
+  }
+  if (window.monaco && window.monaco.editor &&
+      typeof window.monaco.editor.getEditors === "function") {
+    var editors = window.monaco.editor.getEditors();
+    for (var i = 0; i < editors.length; i++) {
+      if (editors[i] && typeof editors[i].getModel === "function") {
+        _cachedEditor = editors[i];
+        return _cachedEditor;
+      }
+    }
+  }
+  return null;
+}
+```
+
+### Why the AMD Shim Is Safe
+
+- The `define.amd` conditional in Monaco **only** gates the `globalThis.monaco` assignment. All other Monaco functionality (editor creation, language services, workers) operates through ES module imports unaffected by this flag.
+- A separate conditional checks `typeof globalThis.require.config === "function"` to configure AMD paths. Since we do **not** define `require.config`, this path is not taken.
+- SvelteKit/Vite apps do not use AMD loaders. No other code in the mermaid-live-editor checks for `define.amd`.
+
+## Minified Symbol Archaeology (Upgrade Guide)
+
+After a vendor upgrade, **all minified variable names change**. The following procedure locates the key internal symbols in the new Monaco chunk. This is only needed if the AMD shim approach stops working in a future Monaco version.
+
+### Step 1 — Identify the Monaco Chunk
+
+```bash
+# The Monaco chunk is the only one containing setSelection, revealRangeInCenter, AND getModel
+rg 'setSelection|revealRangeInCenter|getModel\(\)' \
+  vendor/mermaid-live-editor/_app/immutable/chunks/ \
+  --files-with-matches
+```
+
+Expect one file (e.g. `Dvs79aKq.js`). This is the main Monaco + app chunk.
+
+### Step 2 — Find `listCodeEditors` (Internal Editor Service Method)
+
+```bash
+rg -o '.{0,80}listCodeEditors.{0,80}' <monaco-chunk>
+```
+
+In the current build this yields:
+
+```
+delete this._codeEditors[e.getId()]&&this._onCodeEditorRemove.fire(e)}
+  listCodeEditors(){return Object.keys(this._codeEditors).map(e=>this._codeEditors[e])}
+```
+
+This is the `ICodeEditorService.listCodeEditors()` implementation.
+
+### Step 3 — Find the Public API Wrapper
+
+```bash
+rg -o '.{0,30}listCodeEditors.{0,30}' <monaco-chunk> | grep 'function'
+```
+
+Look for a standalone function wrapping the service call:
+
+```
+function _Ve(){return it.get(Yt).listCodeEditors()}
+```
+
+Here `_Ve` is the minified name for the public `getEditors()` function. `it` is the DI service locator; `Yt` is the `ICodeEditorService` token.
+
+### Step 4 — Find the Public API Object
+
+```bash
+rg -o '.{0,100}create:.*getEditors:.{0,200}' <monaco-chunk>
+```
+
+This reveals the factory function:
+
+```
+function jVe(){return{create:gVe,getEditors:_Ve,getDiffEditors:bVe,onDidCreateEditor:pVe,...}}
+```
+
+| Minified | Public API | Purpose |
+|---|---|---|
+| `gVe` | `monaco.editor.create()` | Create a standalone editor |
+| `_Ve` | `monaco.editor.getEditors()` | List all editor instances |
+| `bVe` | `monaco.editor.getDiffEditors()` | List all diff editor instances |
+
+### Step 5 — Find the Namespace Assignment
+
+```bash
+rg -o '.{0,20}globalThis\.monaco.{0,100}' <monaco-chunk>
+```
+
+Reveals the conditional global:
+
+```
+(typeof define==="function"&&define.amd)&&(globalThis.monaco=Yo);
+```
+
+Where `Yo` is the Monaco namespace variable. Confirm it has the editor API:
+
+```bash
+rg -o '.{0,30}Yo\.editor.{0,50}' <monaco-chunk>
+# Expected: Yo.editor=jVe()
+```
+
+### Step 6 — Verify the AMD Shim Still Works
+
+After upgrading, test that defining `window.define` with `define.amd = true` before Monaco loads results in `window.monaco` being populated. If Monaco removes the AMD conditional in a future version, an alternative approach is needed (see "Fallback: Vendor Chunk Patch" below).
+
+### Fallback: Vendor Chunk Patch
+
+If the AMD shim stops working (e.g., Monaco removes the `define.amd` check), add a new patch to `patch-mermaid-vendor.py` that modifies the Monaco chunk directly:
+
+1. Find the conditional: `(typeof define==="function"&&define.amd)&&(globalThis.monaco=<VAR>)`
+2. Replace the condition with `true`: `(true)&&(globalThis.monaco=<VAR>)`
+
+This is fragile across builds but is captured in the upgrade verification checklist. The namespace variable name must be updated in the patch after each build.
+
+## Key API Methods
+
+All methods below are available on the editor instance returned by `_getMonacoEditor()`. Line and column numbers are **1-based**.
+
+### Editor Instance Methods
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `setSelection` | `(selection: ISelection) => void` | Set the text selection in the editor |
+| `getSelection` | `() => ISelection` | Get the current text selection |
+| `setPosition` | `(position: IPosition) => void` | Set the cursor position |
+| `getPosition` | `() => IPosition` | Get the current cursor position |
+| `revealRangeInCenter` | `(range: IRange) => void` | Scroll the editor so the range appears at ~50% vertical |
+| `revealLineInCenter` | `(lineNumber: number) => void` | Scroll the editor so the line appears at ~50% vertical |
+| `focus` | `() => void` | Focus the editor, making it receive keyboard input |
+| `getModel` | `() => ITextModel` | Get the text model backing the editor |
+| `getValue` | `(eol?: number, preserveBOM?: boolean) => string` | Get full editor text (delegates to model) |
+| `setValue` | `(value: string) => void` | Replace all editor text |
+| `hasTextFocus` | `() => boolean` | Whether the editor's textarea has focus |
+
+### Text Model Methods
+
+Available on the object returned by `editor.getModel()`:
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `getValue` | `(eol?, preserveBOM?) => string` | Get the full text content |
+| `getLineContent` | `(lineNumber: number) => string` | Get text of a specific line |
+| `getLineCount` | `() => number` | Total number of lines |
+| `findMatches` | `(searchString, searchScope, isRegex, matchCase, wordSeparators, captureMatches) => FindMatch[]` | Find all matches of a pattern |
+
+### Interfaces
+
+**ISelection / IRange** (all fields 1-based):
+
+```
+{ startLineNumber, startColumn, endLineNumber, endColumn }
+```
+
+**IPosition**:
+
+```
+{ lineNumber, column }
+```
+
+**FindMatch**:
+
+```
+{ range: IRange, matches: string[] }
+```
+
+## Content Access Paths
+
+The bridge reads mermaid diagram code through three paths, in order of preference:
+
+| Path | Mechanism | Reliability |
+|---|---|---|
+| **Primary** | `localStorage.getItem("codeStore")` → `JSON.parse(raw).code` | Always has complete content. The mermaid-live-editor persists its Svelte store under the `codeStore` key. |
+| **Alternative** | `editor.getModel().getValue()` | Requires editor instance discovery. Returns complete content. |
+| **Fallback** | DOM `.view-lines .view-line` text extraction | Subject to Monaco's viewport virtualization — lines outside the visible viewport may not be in the DOM. Unreliable for full content. |
+
+The bridge's periodic sync (1s) uses the primary path. The SVG text click handler uses the primary path for code search and the alternative path as a backup.
+
+## Limitations
+
+- **Viewport virtualization**: Monaco only renders lines that are currently visible in the scroll viewport. DOM-based text extraction (`.view-line` elements) will miss lines outside the viewport. Always prefer `localStorage` or `getModel().getValue()` for full content access.
+- **AMD shim dependency**: The global `window.monaco` is only available because the bridge defines `window.define.amd = true` before Monaco loads. If a future Monaco build removes the AMD conditional, the "Fallback: Vendor Chunk Patch" approach must be used instead.
+- **Minified symbol names change per build**: Every content-hashed rebuild produces different variable names (`_Ve`, `gVe`, `Yo`, etc.). Only the public API method names (`setSelection`, `getModel`, `getEditors`, `create`, etc.) are stable. The "Minified Symbol Archaeology" procedure must be re-run after each vendor upgrade to verify the AMD shim still works.
+- **Single editor assumption**: `getEditors()[0]` assumes only one `IStandaloneCodeEditor` exists in the mermaid-live-editor. If the app ever creates multiple editors, the discovery must be updated to select the correct one (e.g., by matching the model URI `internal://mermaid.mmd`).
+
+## Cross-References
+
+- **Vendor Subsystem**: [DESIGN-vendor-subsystem.md](DESIGN-vendor-subsystem.md) — bridge script patches, upgrade procedures, offline audit
+- **Mermaid Mode**: [DESIGN-mermaid-mode.md](DESIGN-mermaid-mode.md) — Layer 3 UI mode lifecycle, iframe embedding
+- **Keyboard Isolation**: [DESIGN-centralized-keyboard.md](../ui/DESIGN-centralized-keyboard.md) § Mermaid Mode — bridge capture-phase keyboard interception
+- **Mermaid Diagram Selection**: [DESIGN-mermaid-diagram-selection.md](DESIGN-mermaid-diagram-selection.md) — SVG click-to-select using Monaco API
+- **Mermaid Session Server**: [DESIGN-mermaid-session-server.md](../backend/DESIGN-mermaid-session-server.md) — session-based content brokering

--- a/docs/design/mermaid/DESIGN-vendor-subsystem.md
+++ b/docs/design/mermaid/DESIGN-vendor-subsystem.md
@@ -96,7 +96,7 @@ The patches address two categories of issues:
 
 | ID | Patch | What it fixes | Files affected |
 |---|---|---|---|
-| **P1** | Bridge script injection | Injects the postMessage bridge into `edit.html` (primary) and `index.html` (fallback) so the iframe can communicate with the parent WYSIWYG editor | `edit.html`, `index.html` |
+| **P1** | Bridge script injection | Injects the postMessage bridge into `edit.html` (primary) and `index.html` (fallback) so the iframe can communicate with the parent WYSIWYG editor. Also includes the SVG load monitor (service 3), diagram selection click handlers (service 4), and the AMD global shim for Monaco discovery (service 5). See [DESIGN-mermaid-diagram-selection.md](DESIGN-mermaid-diagram-selection.md) and [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md). | `edit.html`, `index.html` |
 | **P2** | Canonical link removal | Removes `<link rel="canonical" href="https://mermaid.ai/live" />` — external reference irrelevant in an iframe | All `.html` files |
 | **P3** | Manifest link removal | Removes `<link rel="manifest">` — PWA features are irrelevant in an iframe, and `manifest.json` contains root-absolute paths (`/favicon.png`, `/edit`) that break under a sub-path | All `.html` files |
 | **P4** | 404.html base path fix | Changes `base: ""` to dynamic `new URL(".", location)` computation and converts all root-absolute paths (`/_app/...`) to relative (`./`) — the upstream adapter-static generates 404.html differently from other pages | `404.html` |
@@ -118,6 +118,10 @@ The upstream codebase may change between versions. After building a new version,
 7. **P7**: Check if `service-worker.js` exists in the build output
 
 8. **P8**: Embedded inside P1 (bridge script). Verify the vendor's keyboard handling hasn't changed in ways that would require adjusting the `_hasVisibleOverlay()` selectors or the `preventDefault` override. Test ESC, Ctrl+S, and Ctrl+. from inside the editor.
+
+9. **SVG Load Monitor** (service 3 in P1): Verify `div#container` still contains the rendered SVG. Verify `<g class="node">` is still present in rendered mermaid SVGs (used to confirm diagram load vs empty SVG shell). Verify `svg-pan-zoom_viewport` class is still used for pan/zoom transforms.
+
+10. **Diagram Selection** (service 4 in P1): Verify `.nodeLabel` and `.edgeLabel` CSS classes are still used in mermaid SVG output for node and edge label text. Verify the Monaco editor still stores its widget reference on the `[data-mode-id]` DOM element (the bridge discovers it via property enumeration looking for `setSelection` and `getModel` methods). Test clicking on SVG text elements to confirm selection works in the Monaco editor.
 
 The patch script reports which patches were applied; if a patch reports "no matching files," the upstream may have changed and the patch should be re-examined.
 
@@ -150,7 +154,7 @@ grep -rn 'https://' vendor/mermaid-live-editor/ --include='*.js' --include='*.ht
 
 ### PostMessage Bridge + Keyboard Isolation Layer
 
-The bridge script is injected into `edit.html` (primary entry point) and `index.html` (fallback) by patch P1. It provides two services:
+The bridge script is injected into `edit.html` (primary entry point) and `index.html` (fallback) by patch P1. It provides four services:
 
 **1. Content Sync via Session API** — reads the diagram code from `localStorage` (where the mermaid-live-editor persists its Svelte store under the `codeStore` key, same-origin with the iframe) and PUTs it to the API server's mermaid session endpoint (`PUT /mermaid-session/{id}`). The parent GETs the code from the same endpoint on exit. See [DESIGN-mermaid-session-server.md](../backend/DESIGN-mermaid-session-server.md) for the full session lifecycle.
 
@@ -169,6 +173,12 @@ The bridge script is injected into `edit.html` (primary entry point) and `index.
 - **Ctrl+. → Suppressed**: `stopImmediatePropagation` prevents vendor handling. Mode toggle is not valid in mermaid mode.
 - **P8 (preventDefault override)**: Monkey-patches `Event.prototype.preventDefault` to no-op for parent-controlled shortcut keys. Defensive layer ensuring no vendor handler can suppress ESC, Ctrl+S, or Ctrl+.
 - **Regular editing keys**: Pass through to the vendor editor normally.
+
+**3. SVG Load Monitor** — polls for `document.querySelector("#container svg")` containing `<g class="node">` to confirm the diagram rendered successfully. If the SVG does not appear within 8 seconds (16 polls at 500ms), reloads the iframe via `window.location.reload()`. Runs once per session — after initial confirmation, no further monitoring. See [DESIGN-mermaid-diagram-selection.md](DESIGN-mermaid-diagram-selection.md) § Initial SVG Load Monitor.
+
+**4. Diagram Selection** — after the SVG load monitor confirms the diagram is rendered, attaches click handlers to all SVG text elements (`.nodeLabel p` for node labels, `.edgeLabel p` for edge labels). When clicked, the handler extracts the text content, searches the mermaid code (via `localStorage`) for the matching line, discovers the Monaco editor instance via `window.monaco.editor.getEditors()`, and calls `editor.setSelection()` + `editor.revealRangeInCenter()` + `editor.focus()` to highlight and scroll to the corresponding code. A `MutationObserver` on `#container` re-attaches handlers when the SVG is replaced (e.g., after code edits). See [DESIGN-mermaid-diagram-selection.md](DESIGN-mermaid-diagram-selection.md) and [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md).
+
+**5. AMD Global Shim** — defines `window.define` with `define.amd = true` before Monaco loads. This causes Monaco's bundled code to set `globalThis.monaco`, exposing the full public API (`monaco.editor.getEditors()`, `monaco.editor.create()`, etc.) without modifying vendor JS files. See [DESIGN-monaco-subsystem.md](DESIGN-monaco-subsystem.md) § AMD Global Shim.
 
 ### API Server: Sub-Path Routing Support
 

--- a/docs/design/ui/DESIGN-browser-compatibility.md
+++ b/docs/design/ui/DESIGN-browser-compatibility.md
@@ -225,6 +225,20 @@ Safari (WebKit) on macOS shows a momentary horizontal scroll indicator on the `.
 
 **Fix**: `overflow-x: hidden` is set explicitly on both `.md-editable-area` (in `editor.css`) and `.live-wysiwyg-focus-main` (in `_getFocusModeCSS`). This tells the browser horizontal scrolling is not possible, suppressing the elastic bounce indicator. Content already wraps via `word-wrap: break-word`, and child elements that need horizontal scrolling (code blocks, tables) handle their own overflow internally. The focus-main container exhibits the same behavior when a sidebar (e.g., TOC) is hidden, since the flex grid narrows and Safari treats the freed space as scrollable.
 
+### Mermaid Bridge: Monaco Editor Discovery
+
+The mermaid-live-editor iframe embeds a bundled Monaco editor with no global `monaco` object. The bridge script discovers the editor instance by enumerating DOM properties on elements within `div#editor` and `div.monaco-editor`, using both `Object.getOwnPropertyNames()` (for non-enumerable string-keyed properties) and `Object.getOwnPropertySymbols()` (for Symbol-keyed properties). The `getOwnPropertySymbols` call is wrapped in try/catch since it is only needed on engines where Monaco uses Symbol-based storage.
+
+This approach is browser-agnostic: the Monaco bundle is identical across engines, so the minified property names are consistent. No engine-specific branching is needed.
+
+### Mermaid Bridge: SVG foreignObject Click Events
+
+Click handlers are attached to `<p>` elements inside `<foreignObject>` elements within the SVG diagram. These `<p>` elements are HTML-namespace elements, so standard HTML event handling applies. `stopPropagation()` prevents the click from reaching the `svg-pan-zoom` library's event listener on the parent SVG. Behavior is consistent across Blink, Gecko, and WebKit.
+
+### Mermaid Bridge: ES5 Constraint
+
+The bridge script (vendor patch P1) is injected into the mermaid-live-editor's `<head>` before SvelteKit bootstraps. It is written entirely in ES5 (`var`, `function`, no arrow functions, no `let`/`const`, no template literals) to avoid any engine-version requirements beyond what the SvelteKit app itself demands.
+
 ## Cross-References
 
 - `browser-compatibility.mdc` — Rule file with coding standards for using the compat layer
@@ -239,3 +253,4 @@ Safari (WebKit) on macOS shows a momentary horizontal scroll indicator on the `.
 - `DESIGN-focus-nav-menu.md` — Chrome location restrictions
 - `DESIGN-modes-of-operation.md` — Fullscreen API usage
 - `DESIGN-unified-content-undo.md` — `execCommand('undo')` and browser undo stack
+- `DESIGN-mermaid-diagram-selection.md` — Mermaid SVG click-to-select bridge; cross-browser API audit table

--- a/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
+++ b/mkdocs_live_wysiwyg_plugin/live-wysiwyg-integration.js
@@ -26129,6 +26129,31 @@
           }
         });
       }
+
+      if (data.type === 'live-wysiwyg-open-url' && typeof data.url === 'string') {
+        var _allowedDomains = [
+          'discord.com',
+          'discord.gg',
+          'github.com',
+          'mermaid.js.org'
+        ];
+        try {
+          var _u = new URL(data.url);
+          if (_u.protocol === 'https:' || _u.protocol === 'http:') {
+            var _allowed = false;
+            for (var _di = 0; _di < _allowedDomains.length; _di++) {
+              if (_u.hostname === _allowedDomains[_di] ||
+                  _u.hostname.endsWith('.' + _allowedDomains[_di])) {
+                _allowed = true;
+                break;
+              }
+            }
+            if (_allowed) {
+              window.open(data.url, '_blank');
+            }
+          }
+        } catch (_urlErr) {}
+      }
     }
     overlay._mermaidMessageHandler = onMermaidMessage;
     window.addEventListener('message', onMermaidMessage);

--- a/mkdocs_live_wysiwyg_plugin/vendor/mermaid-live-editor/edit.html
+++ b/mkdocs_live_wysiwyg_plugin/vendor/mermaid-live-editor/edit.html
@@ -22,12 +22,12 @@
 		<link rel="modulepreload" href="./_app/immutable/chunks/DsnmJJEf.js">
 		<link rel="modulepreload" href="./_app/immutable/chunks/8VNsxgWr.js">
 		<link rel="modulepreload" href="./_app/immutable/chunks/CdO6MHp9.js">
-  <script>
+<script>
 (function(){
   /* ===================================================================
    * PostMessage Bridge + Keyboard Isolation Layer
    *
-   * Injected by patch P1 into edit.html and index.html.  Two services:
+   * Injected by patch P1 into edit.html and index.html.  Six services:
    *
    * 1. CONTENT SYNC — reads editor content from the mermaid-live-editor's
    *    localStorage ("codeStore" key) and PUTs it to the API server's
@@ -37,11 +37,44 @@
    * 2. KEYBOARD ISOLATION — intercepts ESC, Ctrl+S, Ctrl+. at capture
    *    phase.  See DESIGN-centralized-keyboard.md § Mermaid Mode.
    *
+   * 3. SVG LOAD MONITOR — polls for the rendered SVG in #container to
+   *    confirm initial diagram load.  Reloads the iframe on timeout.
+   *    See DESIGN-mermaid-diagram-selection.md § Initial SVG Load Monitor.
+   *
+   * 4. DIAGRAM SELECTION — attaches click handlers to SVG text elements
+   *    (node labels + edge labels) that select the corresponding text in
+   *    the Monaco editor and scroll it into view.
+   *    See DESIGN-mermaid-diagram-selection.md.
+   *
+   * Sentinel: live-wysiwyg-mermaid-init (used by patch idempotency check)
+   *
+   * 5. LINK INTERCEPT + MENU CLEANUP — intercepts all <a> clicks,
+   *    blocks internal links (New, Duplicate), and forwards allowed
+   *    external URLs to the parent via postMessage for opening in a
+   *    new tab.  Uses a domain allow-list for security.
+   *
+   * 6. AMD GLOBAL SHIM — defines window.define.amd before Monaco loads
+   *    so that Monaco's conditional (typeof define==="function"&&define.amd)
+   *    evaluates to true and sets globalThis.monaco.  This gives the bridge
+   *    access to monaco.editor.getEditors() for editor instance discovery.
+   *    See DESIGN-monaco-subsystem.md § AMD Global Shim.
+   *
    * P8 (preventDefault override) neutralizes vendor preventDefault()
    * for parent-controlled shortcut keys as a defensive layer.
    * =================================================================== */
 
-  /* --- P8: preventDefault override for parent-controlled shortcuts --- */
+  var _hideAiStyle = document.createElement("style");
+  _hideAiStyle.textContent =
+    ".button-container-for-animation { display: none !important; }" +
+    "[monaco-view-zone] { display: none !important; }" +
+    ".cgmr.suggestion-icon { display: none !important; }";
+  document.head.appendChild(_hideAiStyle);
+
+  if (typeof window.define !== "function") {
+    window.define = function() {};
+    window.define.amd = true;
+  }
+
   var _origPreventDefault = Event.prototype.preventDefault;
   Event.prototype.preventDefault = function() {
     if (this instanceof KeyboardEvent) {
@@ -53,7 +86,6 @@
     return _origPreventDefault.call(this);
   };
 
-  /* --- Session ID from URL query param --- */
   var _sessionId = (function() {
     var m = window.location.search.match(/[?&]session=([^&#]+)/);
     return m ? m[1] : "";
@@ -91,24 +123,15 @@
     } catch(ex) {}
   }
 
-  console.log("[BRIDGE] script executing, session=" + _sessionId);
-
-  /* --- Periodic sync: read localStorage, PUT to server --- */
   var _lastSentCode = "";
-  var _syncCount = 0;
   setInterval(function() {
     var code = _readEditorCode();
-    _syncCount++;
-    if (_syncCount <= 5 || _syncCount % 10 === 0) {
-      console.log("[BRIDGE] sync #" + _syncCount + " code length=" + code.length + " changed=" + (code !== _lastSentCode));
-    }
     if (code && code !== _lastSentCode) {
       _lastSentCode = code;
       _putSession(code);
     }
   }, 1000);
 
-  /* --- Overlay detection for ESC escalation --- */
   function _isActuallyVisible(el) {
     if (!el) return false;
     var r = el.getBoundingClientRect();
@@ -123,26 +146,38 @@
       ".context-view",
       ".monaco-hover",
       ".find-widget.visible",
-      ".parameter-hints-widget.visible"
+      ".parameter-hints-widget.visible",
+      ".monaco-dialog-box",
+      ".rename-box",
+      ".monaco-menu",
+      ".quick-input-widget",
+      "[data-dialog-content]",
+      "[data-popover-content]"
     ];
     for (var i = 0; i < selectors.length; i++) {
       var el = document.querySelector(selectors[i]);
       if (el && _isActuallyVisible(el)) return true;
     }
+    var shadowHosts = document.querySelectorAll(".shadow-root-host");
+    for (var s = 0; s < shadowHosts.length; s++) {
+      var sr = shadowHosts[s].shadowRoot;
+      if (!sr) continue;
+      for (var j = 0; j < selectors.length; j++) {
+        var shadowEl = sr.querySelector(selectors[j]);
+        if (shadowEl && _isActuallyVisible(shadowEl)) return true;
+      }
+    }
     return false;
   }
 
-  /* --- Close helper: PUT final code, then signal parent --- */
   function _closeAndSignal(save) {
     var code = _readEditorCode();
-    console.log("[BRIDGE] closeAndSignal code=" + code.length + " save=" + !!save);
     _putSession(code);
     var msg = { type: "live-wysiwyg-mermaid-close" };
     if (save) msg.save = true;
     try { window.parent.postMessage(msg, "*"); } catch(ex) {}
   }
 
-  /* --- Parent → Iframe: request-close handler --- */
   window.addEventListener("message", function(evt) {
     var data = evt.data;
     if (!data || typeof data !== "object") return;
@@ -151,14 +186,19 @@
     }
   });
 
-  /* --- Keyboard Isolation (capture phase) --- */
+  function _hasMultipleCursors() {
+    var cursors = document.querySelectorAll(".cursors-layer .cursor");
+    var visible = 0;
+    for (var i = 0; i < cursors.length; i++) {
+      if (cursors[i].offsetWidth > 0 || cursors[i].offsetHeight > 0) visible++;
+    }
+    return visible > 1;
+  }
+
   document.addEventListener("keydown", function(e) {
     if (e.key === "Escape") {
-      setTimeout(function() {
-        if (!_hasVisibleOverlay()) {
-          _closeAndSignal();
-        }
-      }, 50);
+      if (_hasVisibleOverlay() || _hasMultipleCursors()) return;
+      _closeAndSignal();
       return;
     }
     if ((e.ctrlKey || e.metaKey) && e.key === "s") {
@@ -171,6 +211,570 @@
       return;
     }
   }, true);
+
+  /* --- Link Intercept + Menu Cleanup (service 6) --- */
+
+  var _allowedLinkDomains = [
+    "discord.com",
+    "discord.gg",
+    "github.com",
+    "mermaid.js.org"
+  ];
+
+  var _hiddenMenuLabels = ["New", "Duplicate"];
+
+  function _isAllowedUrl(href) {
+    try {
+      var u = new URL(href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+      for (var i = 0; i < _allowedLinkDomains.length; i++) {
+        var d = _allowedLinkDomains[i];
+        if (u.hostname === d || u.hostname.endsWith("." + d)) return true;
+      }
+    } catch(ex) {}
+    return false;
+  }
+
+  function _resolveHref(link) {
+    if (link.href && typeof link.href === "string") return link.href;
+    if (link.href && link.href.baseVal) return link.href.baseVal;
+    var h = link.getAttribute("href") || link.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+    return h || "";
+  }
+
+  document.addEventListener("click", function(e) {
+    var link = e.target.closest ? (e.target.closest("a[href]") || e.target.closest("a")) : null;
+    if (!link) return;
+    var href = _resolveHref(link);
+    if (!href) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (_isAllowedUrl(href)) {
+      try {
+        window.parent.postMessage({
+          type: "live-wysiwyg-open-url",
+          url: href
+        }, "*");
+      } catch(ex) {}
+    }
+  }, true);
+
+  function _cleanupMenu(popover) {
+    var links = popover.querySelectorAll("a");
+    for (var i = 0; i < links.length; i++) {
+      var text = (links[i].textContent || "").trim();
+      for (var h = 0; h < _hiddenMenuLabels.length; h++) {
+        if (text === _hiddenMenuLabels[h]) {
+          links[i].style.display = "none";
+          break;
+        }
+      }
+    }
+  }
+
+  var _menuObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-popover-content")) {
+          _cleanupMenu(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-popover-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupMenu(inner[k]);
+      }
+    }
+  });
+  _menuObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  function _cleanupPrivacyDialog(dialog) {
+    var paragraphs = dialog.querySelectorAll("p");
+    for (var i = 0; i < paragraphs.length; i++) {
+      var text = (paragraphs[i].textContent || "").trim();
+      if (text.indexOf("No privacy policy") === 0) {
+        paragraphs[i].textContent = "This is a custom Mermaid Live Editor built for mkdocs-live-wysiwyg plugin.";
+        var pFeature = document.createElement("p");
+        pFeature.textContent = "Exclusive to this editor: There's a new feature added which allows you to click on diagram elements.";
+        paragraphs[i].parentNode.insertBefore(pFeature, paragraphs[i].nextSibling);
+        var ul = document.createElement("ul");
+        var li1 = document.createElement("li");
+        li1.textContent = "Clicking elements will select text in the editor.";
+        ul.appendChild(li1);
+        var li2 = document.createElement("li");
+        li2.textContent = "The default layout has also been changed specifically for mkdocs-live-wysiwyg.";
+        ul.appendChild(li2);
+        pFeature.parentNode.insertBefore(ul, pFeature.nextSibling);
+        var pSelfHosted = document.createElement("p");
+        pSelfHosted.textContent = "This is a self-hosted instance (on your computer) of Mermaid Live Editor with no internet requirements.";
+        ul.parentNode.insertBefore(pSelfHosted, ul.nextSibling);
+      }
+      if (text.indexOf("If you are self-hosting") === 0) {
+        paragraphs[i].style.display = "none";
+      }
+    }
+  }
+
+  var _dialogObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-dialog-content")) {
+          _cleanupPrivacyDialog(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-dialog-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupPrivacyDialog(inner[k]);
+      }
+    }
+  });
+  _dialogObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _cardsCleanedUp = false;
+  function _cleanupCards() {
+    if (_cardsCleanedUp) return;
+    var toolbars = document.querySelectorAll('.card [role="toolbar"]');
+    var found = 0;
+    for (var i = 0; i < toolbars.length; i++) {
+      var text = (toolbars[i].textContent || "").trim();
+      var card = toolbars[i].closest(".card");
+      if (!card) continue;
+      if (text.indexOf("Actions") !== -1) {
+        card.style.display = "none";
+        found++;
+      }
+      if (text.indexOf("Sample Diagrams") !== -1) {
+        if (card.classList.contains("isOpen")) {
+          toolbars[i].click();
+        }
+        found++;
+      }
+    }
+    var shareBtn = document.querySelector('button[data-dialog-trigger]');
+    if (shareBtn && (shareBtn.textContent || "").trim() === "Share") {
+      shareBtn.style.display = "none";
+      found++;
+    }
+    var expandLink = document.querySelector('a[title="Full Screen"]');
+    if (expandLink) {
+      expandLink.style.display = "none";
+      found++;
+    }
+    if (found >= 4) _cardsCleanedUp = true;
+  }
+
+  var _cardObserver = new MutationObserver(function() {
+    if (_cardsCleanedUp) { _cardObserver.disconnect(); return; }
+    _cleanupCards();
+  });
+  _cardObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _panesEqualized = false;
+  function _equalizePanes() {
+    if (_panesEqualized) return;
+    var resizer = document.getElementById("paneforge-3");
+    if (!resizer) return;
+    var prev = resizer.previousElementSibling;
+    var next = resizer.nextElementSibling;
+    if (!prev || !next) return;
+    prev.style.flexBasis = "50%";
+    next.style.flexBasis = "50%";
+    _panesEqualized = true;
+  }
+
+  var _paneObserver = new MutationObserver(function() {
+    if (_panesEqualized) { _paneObserver.disconnect(); return; }
+    _equalizePanes();
+  });
+  _paneObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  /* --- SVG Load Monitor + Diagram Selection (services 3 & 4) --- */
+
+  var _cachedEditor = null;
+
+  function _getMonacoEditor() {
+    if (_cachedEditor) {
+      try { if (_cachedEditor.getModel()) return _cachedEditor; } catch(ex) {}
+      _cachedEditor = null;
+    }
+    if (window.monaco && window.monaco.editor &&
+        typeof window.monaco.editor.getEditors === "function") {
+      var editors = window.monaco.editor.getEditors();
+      for (var i = 0; i < editors.length; i++) {
+        try {
+          if (editors[i] && typeof editors[i].getModel === "function" && editors[i].getModel()) {
+            _cachedEditor = editors[i];
+            console.log("[BRIDGE-SEL] Editor found via monaco.editor.getEditors() [" + i + "/" + editors.length + "]");
+            return _cachedEditor;
+          }
+        } catch(ex) {}
+      }
+      console.log("[BRIDGE-SEL] monaco.editor.getEditors() returned " + editors.length + " editor(s), none with a valid model");
+    } else {
+      console.log("[BRIDGE-SEL] window.monaco not available (AMD shim may not have triggered)");
+    }
+    return null;
+  }
+
+  var _entityDecodeEl = document.createElement("textarea");
+  function _decodeEntities(str) {
+    _entityDecodeEl.innerHTML = str;
+    return _entityDecodeEl.value;
+  }
+
+  function _normalizeText(text) {
+    var s = (text || "")
+      .replace(/<br\s*\/?>/gi, " ")
+      .replace(/<[^>]+>/g, "");
+    s = _decodeEntities(s);
+    s = s.replace(/\u00AB/g, "<<").replace(/\u00BB/g, ">>");
+    return s.replace(/\s+/g, " ").trim();
+  }
+
+  function _getContextHint(el) {
+    var node = el;
+    while (node && node !== document && node.nodeType === 1) {
+      if (node.id && node.tagName && node.tagName.toLowerCase() === "g") return node.id;
+      node = node.parentNode;
+    }
+    return "";
+  }
+
+  function _extractHintTokens(hint) {
+    if (!hint) return [];
+    var parts = hint.split("-");
+    var tokens = [];
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i];
+      if (/^\d+$/.test(p) || p.length <= 1) continue;
+      if (/^(classId|entity|state|flowchart)$/i.test(p)) continue;
+      tokens.push(p);
+    }
+    if (hint.length > 1 && tokens.indexOf(hint) === -1) tokens.unshift(hint);
+    return tokens;
+  }
+
+  function _pickBestMatch(matches, lines, contextHint) {
+    var tokens = _extractHintTokens(contextHint);
+    if (tokens.length === 0) return matches[0];
+    var best = matches[0];
+    var bestDist = 9999;
+    var bestAfter = false;
+    for (var m = 0; m < matches.length; m++) {
+      var mLine = matches[m].lineNumber - 1;
+      for (var t = 0; t < tokens.length; t++) {
+        for (var off = 0; off <= 10; off++) {
+          var above = mLine - off;
+          var below = mLine + off;
+          var foundAbove = above >= 0 && lines[above].indexOf(tokens[t]) !== -1;
+          var foundBelow = below < lines.length && lines[below].indexOf(tokens[t]) !== -1;
+          if (foundAbove || foundBelow) {
+            var isAfter = foundAbove && !foundBelow;
+            if (off < bestDist || (off === bestDist && isAfter && !bestAfter)) {
+              bestDist = off;
+              best = matches[m];
+              bestAfter = isAfter;
+            }
+          }
+        }
+      }
+    }
+    console.log("[BRIDGE-SEL] Disambiguated " + matches.length + " matches via hint '" + contextHint + "', best line " + best.lineNumber + " (dist=" + bestDist + ")");
+    return best;
+  }
+
+  function _findTextInCode(code, searchText, contextHint) {
+    if (!code || !searchText) { console.log("[BRIDGE-SEL] _findTextInCode: empty code or searchText"); return null; }
+    var normSearch = _normalizeText(searchText);
+    if (!normSearch) { console.log("[BRIDGE-SEL] _findTextInCode: normalized search is empty"); return null; }
+    console.log("[BRIDGE-SEL] Searching for: '" + normSearch + "' in " + code.split("\n").length + " lines");
+    var lines = code.split("\n");
+    var bracketMatches = [];
+    var wholeLineMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var bracketPatterns = [
+        /\["([^"]*?)"\]/g,
+        /\[([^\]]*?)\]/g,
+        /\("([^"]*?)"\)/g,
+        /\(([^)]*?)\)/g,
+        /\{"([^"]*?)"\}/g,
+        /\{([^}]*?)\}/g,
+        /\|"([^"]*?)"\|/g,
+        /\|([^|]*?)\|/g
+      ];
+      for (var p = 0; p < bracketPatterns.length; p++) {
+        var rx = bracketPatterns[p];
+        var m;
+        rx.lastIndex = 0;
+        while ((m = rx.exec(line)) !== null) {
+          var extracted = _normalizeText(m[1]);
+          if (extracted === normSearch) {
+            bracketMatches.push({
+              lineNumber: i + 1,
+              startColumn: m.index + 1,
+              endColumn: m.index + m[0].length + 1
+            });
+          }
+        }
+      }
+      var trimmed = line.trim();
+      if (_normalizeText(trimmed) === normSearch) {
+        var leadingSpaces = line.length - line.replace(/^\s+/, "").length;
+        wholeLineMatches.push({
+          lineNumber: i + 1,
+          startColumn: leadingSpaces + 1,
+          endColumn: line.length + 1
+        });
+      }
+    }
+    if (bracketMatches.length === 1 || (bracketMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (bracket) line " + bracketMatches[0].lineNumber);
+      return bracketMatches[0];
+    }
+    if (bracketMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + bracketMatches.length + " bracket matches, disambiguating");
+      return _pickBestMatch(bracketMatches, lines, contextHint);
+    }
+    if (wholeLineMatches.length === 1 || (wholeLineMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (whole-line) line " + wholeLineMatches[0].lineNumber);
+      return wholeLineMatches[0];
+    }
+    if (wholeLineMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + wholeLineMatches.length + " whole-line matches, disambiguating");
+      return _pickBestMatch(wholeLineMatches, lines, contextHint);
+    }
+    var subMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var idx = lines[i].indexOf(normSearch);
+      if (idx !== -1) {
+        subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+      }
+    }
+    if (subMatches.length === 0) {
+      var lower = normSearch.toLowerCase();
+      for (var i = 0; i < lines.length; i++) {
+        var idx = lines[i].toLowerCase().indexOf(lower);
+        if (idx !== -1) {
+          subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+        }
+      }
+      if (subMatches.length > 0) console.log("[BRIDGE-SEL] " + subMatches.length + " case-insensitive match(es) for '" + normSearch + "'");
+    }
+    if (subMatches.length === 0) {
+      console.log("[BRIDGE-SEL] NO MATCH found for '" + normSearch + "'");
+      return null;
+    }
+    if (subMatches.length === 1 || !contextHint) {
+      console.log("[BRIDGE-SEL] MATCH (substring) line " + subMatches[0].lineNumber + ": '" + normSearch + "'" + (subMatches.length > 1 ? " (" + subMatches.length + " candidates, no hint)" : ""));
+      return subMatches[0];
+    }
+    return _pickBestMatch(subMatches, lines, contextHint);
+  }
+
+  function _handleSvgTextClick(textContent, contextHint) {
+    console.log("[BRIDGE-SEL] Click handler fired, raw text: '" + textContent + "', hint: '" + (contextHint || "") + "'");
+    var code = _readEditorCode();
+    if (!code) { console.log("[BRIDGE-SEL] _readEditorCode returned empty"); return; }
+    console.log("[BRIDGE-SEL] Code length: " + code.length);
+    var match = _findTextInCode(code, textContent, contextHint);
+    if (!match) { console.log("[BRIDGE-SEL] No match found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Match: line=" + match.lineNumber + " col=" + match.startColumn + "-" + match.endColumn);
+    var editor = _getMonacoEditor();
+    if (!editor) { console.log("[BRIDGE-SEL] Monaco editor not found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Editor found, applying selection...");
+    try {
+      var sel = {
+        startLineNumber: match.lineNumber,
+        startColumn: match.startColumn,
+        endLineNumber: match.lineNumber,
+        endColumn: match.endColumn
+      };
+      editor.setSelection(sel);
+      editor.revealRangeInCenter(sel);
+      editor.focus();
+      console.log("[BRIDGE-SEL] Selection applied successfully");
+    } catch(ex) { console.log("[BRIDGE-SEL] Error applying selection:", ex); }
+  }
+
+  var _svgTextSelectors = [
+    "text.messageText",
+    "text.actor tspan",
+    "tspan.text-inner-tspan",
+    "text.packetLabel",
+    "text.packetTitle",
+    ".legend text",
+    "text.pieTitleText",
+    ".quadrant text",
+    ".data-point text",
+    ".labels .label text",
+    ".title text",
+    "text.radarAxisLabel",
+    "text.radarTitle",
+    "text.radarLegendText",
+    ".cluster-label .nodeLabel p",
+    ".label.name .nodeLabel p",
+    ".label.attribute-type .nodeLabel p",
+    ".label.attribute-name .nodeLabel p",
+    ".label-group .nodeLabel p",
+    ".members-group .nodeLabel p",
+    ".methods-group .nodeLabel p",
+    ".branchLabel text tspan",
+    "text.commit-label",
+    "text.taskText",
+    "text.sectionTitle tspan",
+    "text.titleText",
+    "g.person-man text tspan",
+    "tspan[alignment-baseline='mathematical']",
+    "g.node-labels text",
+    "g.timeline-node tspan",
+    "text.treemapSectionLabel",
+    "text.treemapLabel",
+    "text.legend tspan",
+    "g.chart-title text"
+  ];
+
+  function _attachClickHandlers() {
+    var container = document.querySelector("#container svg");
+    if (!container) { console.log("[BRIDGE-SEL] _attachClickHandlers: no #container svg"); return; }
+    var bound = 0;
+
+    var erTypeGroups = container.querySelectorAll("g.label.attribute-type");
+    for (var t = 0; t < erTypeGroups.length; t++) {
+      var typeG = erTypeGroups[t];
+      var typeP = typeG.querySelector(".nodeLabel p");
+      if (!typeP) continue;
+      var nameG = typeG.nextElementSibling;
+      while (nameG && !nameG.classList.contains("attribute-name")) {
+        nameG = nameG.nextElementSibling;
+      }
+      if (!nameG) continue;
+      var nameP = nameG.querySelector(".nodeLabel p");
+      if (!nameP) continue;
+      var typeText = (typeP.textContent || "").trim();
+      var nameText = (nameP.textContent || "").trim();
+      if (!typeText || !nameText) continue;
+      var combined = typeText + " " + nameText;
+      var hint = _getContextHint(typeP);
+      var pair = [typeP, nameP];
+      for (var e = 0; e < pair.length; e++) {
+        if (pair[e].dataset && pair[e].dataset.liveWysiwygClickBound) continue;
+        if (pair[e].dataset) pair[e].dataset.liveWysiwygClickBound = "1";
+        else pair[e].setAttribute("data-live-wysiwyg-click-bound", "1");
+        pair[e].style.cursor = "pointer";
+        pair[e].addEventListener("click", (function(combinedText, ctxHint) {
+          return function(ev) {
+            ev.stopPropagation();
+            _handleSvgTextClick(combinedText, ctxHint);
+          };
+        })(combined, hint));
+        bound++;
+      }
+    }
+
+    var htmlEls = container.querySelectorAll(
+      "g.node .nodeLabel p, g.edgeLabel .edgeLabel p, g.cluster-label .nodeLabel p, div.journey-section > div.label, div.task > div.label, .zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name"
+    );
+    for (var i = 0; i < htmlEls.length; i++) {
+      var el = htmlEls[i];
+      if (el.dataset && el.dataset.liveWysiwygClickBound) continue;
+      if (el.dataset) el.dataset.liveWysiwygClickBound = "1";
+      else el.setAttribute("data-live-wysiwyg-click-bound", "1");
+      el.style.cursor = "pointer";
+      el.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.innerHTML, _getContextHint(textEl));
+        };
+      })(el));
+      bound++;
+    }
+
+    var svgEls = container.querySelectorAll(_svgTextSelectors.join(", "));
+    for (var j = 0; j < svgEls.length; j++) {
+      var svgEl = svgEls[j];
+      if (svgEl.getAttribute("data-live-wysiwyg-click-bound")) continue;
+      var txt = (svgEl.textContent || "").trim();
+      if (!txt) continue;
+      svgEl.setAttribute("data-live-wysiwyg-click-bound", "1");
+      svgEl.style.cursor = "pointer";
+      svgEl.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, _getContextHint(textEl));
+        };
+      })(svgEl));
+      bound++;
+    }
+
+    var zenSel = ".zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name, .zenuml .fragment .header .collapsible-header > label";
+    var zenEls = document.querySelectorAll(zenSel);
+    for (var z = 0; z < zenEls.length; z++) {
+      var ze = zenEls[z];
+      if (ze.dataset && ze.dataset.liveWysiwygClickBound) continue;
+      ze.dataset.liveWysiwygClickBound = "1";
+      ze.style.cursor = "pointer";
+      ze.style.pointerEvents = "auto";
+      ze.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, "");
+        };
+      })(ze));
+      bound++;
+    }
+
+    console.log("[BRIDGE-SEL] Bound click handlers on " + bound + " new elements (" + htmlEls.length + " html + " + svgEls.length + " svg + " + zenEls.length + " zenuml candidates)");
+  }
+
+  function _svgHasContent(svg) {
+    return svg && (svg.querySelector("g.node") || svg.querySelector("text") || svg.querySelector(".root") || svg.querySelector("foreignObject"));
+  }
+
+  function _onSvgLoaded() {
+    console.log("[BRIDGE-SEL] SVG loaded, attaching click handlers");
+    _attachClickHandlers();
+    var container = document.querySelector("#container");
+    if (container) {
+      var observer = new MutationObserver(function() {
+        var svg = container.querySelector("svg");
+        if (_svgHasContent(svg)) {
+          console.log("[BRIDGE-SEL] SVG mutation detected, re-attaching click handlers");
+          _attachClickHandlers();
+        }
+      });
+      observer.observe(container, { childList: true, subtree: true });
+    }
+  }
+
+  function _monitorSvgLoad() {
+    var reloadKey = "live-wysiwyg-reload-count";
+    var reloadCount = 0;
+    try { reloadCount = parseInt(sessionStorage.getItem(reloadKey), 10) || 0; } catch(e) {}
+    var maxPolls = reloadCount < 3 ? 3 : 3 + (reloadCount - 2);
+    var polls = 0;
+    console.log("[BRIDGE-SEL] Starting SVG load monitor (attempt " + (reloadCount + 1) + ", timeout " + (maxPolls * 500) + "ms)");
+    var timer = setInterval(function() {
+      polls++;
+      var svg = document.querySelector("#container svg");
+      if (_svgHasContent(svg)) {
+        console.log("[BRIDGE-SEL] SVG confirmed loaded after " + polls + " poll(s)");
+        clearInterval(timer);
+        try { sessionStorage.removeItem(reloadKey); } catch(e) {}
+        _onSvgLoaded();
+        return;
+      }
+      if (polls >= maxPolls) {
+        console.log("[BRIDGE-SEL] SVG load timeout after " + maxPolls + " polls (attempt " + (reloadCount + 1) + "), reloading");
+        clearInterval(timer);
+        try { sessionStorage.setItem(reloadKey, String(reloadCount + 1)); } catch(e) {}
+        window.location.reload();
+      }
+    }, 500);
+  }
+
+  _monitorSvgLoad();
 })();
 </script></head>
   <body>

--- a/mkdocs_live_wysiwyg_plugin/vendor/mermaid-live-editor/index.html
+++ b/mkdocs_live_wysiwyg_plugin/vendor/mermaid-live-editor/index.html
@@ -22,12 +22,12 @@
 		<link rel="modulepreload" href="./_app/immutable/chunks/DsnmJJEf.js">
 		<link rel="modulepreload" href="./_app/immutable/chunks/8VNsxgWr.js">
 		<link rel="modulepreload" href="./_app/immutable/chunks/CdO6MHp9.js">
-  <script>
+<script>
 (function(){
   /* ===================================================================
    * PostMessage Bridge + Keyboard Isolation Layer
    *
-   * Injected by patch P1 into edit.html and index.html.  Two services:
+   * Injected by patch P1 into edit.html and index.html.  Six services:
    *
    * 1. CONTENT SYNC — reads editor content from the mermaid-live-editor's
    *    localStorage ("codeStore" key) and PUTs it to the API server's
@@ -37,11 +37,44 @@
    * 2. KEYBOARD ISOLATION — intercepts ESC, Ctrl+S, Ctrl+. at capture
    *    phase.  See DESIGN-centralized-keyboard.md § Mermaid Mode.
    *
+   * 3. SVG LOAD MONITOR — polls for the rendered SVG in #container to
+   *    confirm initial diagram load.  Reloads the iframe on timeout.
+   *    See DESIGN-mermaid-diagram-selection.md § Initial SVG Load Monitor.
+   *
+   * 4. DIAGRAM SELECTION — attaches click handlers to SVG text elements
+   *    (node labels + edge labels) that select the corresponding text in
+   *    the Monaco editor and scroll it into view.
+   *    See DESIGN-mermaid-diagram-selection.md.
+   *
+   * Sentinel: live-wysiwyg-mermaid-init (used by patch idempotency check)
+   *
+   * 5. LINK INTERCEPT + MENU CLEANUP — intercepts all <a> clicks,
+   *    blocks internal links (New, Duplicate), and forwards allowed
+   *    external URLs to the parent via postMessage for opening in a
+   *    new tab.  Uses a domain allow-list for security.
+   *
+   * 6. AMD GLOBAL SHIM — defines window.define.amd before Monaco loads
+   *    so that Monaco's conditional (typeof define==="function"&&define.amd)
+   *    evaluates to true and sets globalThis.monaco.  This gives the bridge
+   *    access to monaco.editor.getEditors() for editor instance discovery.
+   *    See DESIGN-monaco-subsystem.md § AMD Global Shim.
+   *
    * P8 (preventDefault override) neutralizes vendor preventDefault()
    * for parent-controlled shortcut keys as a defensive layer.
    * =================================================================== */
 
-  /* --- P8: preventDefault override for parent-controlled shortcuts --- */
+  var _hideAiStyle = document.createElement("style");
+  _hideAiStyle.textContent =
+    ".button-container-for-animation { display: none !important; }" +
+    "[monaco-view-zone] { display: none !important; }" +
+    ".cgmr.suggestion-icon { display: none !important; }";
+  document.head.appendChild(_hideAiStyle);
+
+  if (typeof window.define !== "function") {
+    window.define = function() {};
+    window.define.amd = true;
+  }
+
   var _origPreventDefault = Event.prototype.preventDefault;
   Event.prototype.preventDefault = function() {
     if (this instanceof KeyboardEvent) {
@@ -53,7 +86,6 @@
     return _origPreventDefault.call(this);
   };
 
-  /* --- Session ID from URL query param --- */
   var _sessionId = (function() {
     var m = window.location.search.match(/[?&]session=([^&#]+)/);
     return m ? m[1] : "";
@@ -91,24 +123,15 @@
     } catch(ex) {}
   }
 
-  console.log("[BRIDGE] script executing, session=" + _sessionId);
-
-  /* --- Periodic sync: read localStorage, PUT to server --- */
   var _lastSentCode = "";
-  var _syncCount = 0;
   setInterval(function() {
     var code = _readEditorCode();
-    _syncCount++;
-    if (_syncCount <= 5 || _syncCount % 10 === 0) {
-      console.log("[BRIDGE] sync #" + _syncCount + " code length=" + code.length + " changed=" + (code !== _lastSentCode));
-    }
     if (code && code !== _lastSentCode) {
       _lastSentCode = code;
       _putSession(code);
     }
   }, 1000);
 
-  /* --- Overlay detection for ESC escalation --- */
   function _isActuallyVisible(el) {
     if (!el) return false;
     var r = el.getBoundingClientRect();
@@ -123,26 +146,38 @@
       ".context-view",
       ".monaco-hover",
       ".find-widget.visible",
-      ".parameter-hints-widget.visible"
+      ".parameter-hints-widget.visible",
+      ".monaco-dialog-box",
+      ".rename-box",
+      ".monaco-menu",
+      ".quick-input-widget",
+      "[data-dialog-content]",
+      "[data-popover-content]"
     ];
     for (var i = 0; i < selectors.length; i++) {
       var el = document.querySelector(selectors[i]);
       if (el && _isActuallyVisible(el)) return true;
     }
+    var shadowHosts = document.querySelectorAll(".shadow-root-host");
+    for (var s = 0; s < shadowHosts.length; s++) {
+      var sr = shadowHosts[s].shadowRoot;
+      if (!sr) continue;
+      for (var j = 0; j < selectors.length; j++) {
+        var shadowEl = sr.querySelector(selectors[j]);
+        if (shadowEl && _isActuallyVisible(shadowEl)) return true;
+      }
+    }
     return false;
   }
 
-  /* --- Close helper: PUT final code, then signal parent --- */
   function _closeAndSignal(save) {
     var code = _readEditorCode();
-    console.log("[BRIDGE] closeAndSignal code=" + code.length + " save=" + !!save);
     _putSession(code);
     var msg = { type: "live-wysiwyg-mermaid-close" };
     if (save) msg.save = true;
     try { window.parent.postMessage(msg, "*"); } catch(ex) {}
   }
 
-  /* --- Parent → Iframe: request-close handler --- */
   window.addEventListener("message", function(evt) {
     var data = evt.data;
     if (!data || typeof data !== "object") return;
@@ -151,14 +186,19 @@
     }
   });
 
-  /* --- Keyboard Isolation (capture phase) --- */
+  function _hasMultipleCursors() {
+    var cursors = document.querySelectorAll(".cursors-layer .cursor");
+    var visible = 0;
+    for (var i = 0; i < cursors.length; i++) {
+      if (cursors[i].offsetWidth > 0 || cursors[i].offsetHeight > 0) visible++;
+    }
+    return visible > 1;
+  }
+
   document.addEventListener("keydown", function(e) {
     if (e.key === "Escape") {
-      setTimeout(function() {
-        if (!_hasVisibleOverlay()) {
-          _closeAndSignal();
-        }
-      }, 50);
+      if (_hasVisibleOverlay() || _hasMultipleCursors()) return;
+      _closeAndSignal();
       return;
     }
     if ((e.ctrlKey || e.metaKey) && e.key === "s") {
@@ -171,6 +211,570 @@
       return;
     }
   }, true);
+
+  /* --- Link Intercept + Menu Cleanup (service 6) --- */
+
+  var _allowedLinkDomains = [
+    "discord.com",
+    "discord.gg",
+    "github.com",
+    "mermaid.js.org"
+  ];
+
+  var _hiddenMenuLabels = ["New", "Duplicate"];
+
+  function _isAllowedUrl(href) {
+    try {
+      var u = new URL(href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+      for (var i = 0; i < _allowedLinkDomains.length; i++) {
+        var d = _allowedLinkDomains[i];
+        if (u.hostname === d || u.hostname.endsWith("." + d)) return true;
+      }
+    } catch(ex) {}
+    return false;
+  }
+
+  function _resolveHref(link) {
+    if (link.href && typeof link.href === "string") return link.href;
+    if (link.href && link.href.baseVal) return link.href.baseVal;
+    var h = link.getAttribute("href") || link.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+    return h || "";
+  }
+
+  document.addEventListener("click", function(e) {
+    var link = e.target.closest ? (e.target.closest("a[href]") || e.target.closest("a")) : null;
+    if (!link) return;
+    var href = _resolveHref(link);
+    if (!href) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (_isAllowedUrl(href)) {
+      try {
+        window.parent.postMessage({
+          type: "live-wysiwyg-open-url",
+          url: href
+        }, "*");
+      } catch(ex) {}
+    }
+  }, true);
+
+  function _cleanupMenu(popover) {
+    var links = popover.querySelectorAll("a");
+    for (var i = 0; i < links.length; i++) {
+      var text = (links[i].textContent || "").trim();
+      for (var h = 0; h < _hiddenMenuLabels.length; h++) {
+        if (text === _hiddenMenuLabels[h]) {
+          links[i].style.display = "none";
+          break;
+        }
+      }
+    }
+  }
+
+  var _menuObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-popover-content")) {
+          _cleanupMenu(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-popover-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupMenu(inner[k]);
+      }
+    }
+  });
+  _menuObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  function _cleanupPrivacyDialog(dialog) {
+    var paragraphs = dialog.querySelectorAll("p");
+    for (var i = 0; i < paragraphs.length; i++) {
+      var text = (paragraphs[i].textContent || "").trim();
+      if (text.indexOf("No privacy policy") === 0) {
+        paragraphs[i].textContent = "This is a custom Mermaid Live Editor built for mkdocs-live-wysiwyg plugin.";
+        var pFeature = document.createElement("p");
+        pFeature.textContent = "Exclusive to this editor: There's a new feature added which allows you to click on diagram elements.";
+        paragraphs[i].parentNode.insertBefore(pFeature, paragraphs[i].nextSibling);
+        var ul = document.createElement("ul");
+        var li1 = document.createElement("li");
+        li1.textContent = "Clicking elements will select text in the editor.";
+        ul.appendChild(li1);
+        var li2 = document.createElement("li");
+        li2.textContent = "The default layout has also been changed specifically for mkdocs-live-wysiwyg.";
+        ul.appendChild(li2);
+        pFeature.parentNode.insertBefore(ul, pFeature.nextSibling);
+        var pSelfHosted = document.createElement("p");
+        pSelfHosted.textContent = "This is a self-hosted instance (on your computer) of Mermaid Live Editor with no internet requirements.";
+        ul.parentNode.insertBefore(pSelfHosted, ul.nextSibling);
+      }
+      if (text.indexOf("If you are self-hosting") === 0) {
+        paragraphs[i].style.display = "none";
+      }
+    }
+  }
+
+  var _dialogObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-dialog-content")) {
+          _cleanupPrivacyDialog(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-dialog-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupPrivacyDialog(inner[k]);
+      }
+    }
+  });
+  _dialogObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _cardsCleanedUp = false;
+  function _cleanupCards() {
+    if (_cardsCleanedUp) return;
+    var toolbars = document.querySelectorAll('.card [role="toolbar"]');
+    var found = 0;
+    for (var i = 0; i < toolbars.length; i++) {
+      var text = (toolbars[i].textContent || "").trim();
+      var card = toolbars[i].closest(".card");
+      if (!card) continue;
+      if (text.indexOf("Actions") !== -1) {
+        card.style.display = "none";
+        found++;
+      }
+      if (text.indexOf("Sample Diagrams") !== -1) {
+        if (card.classList.contains("isOpen")) {
+          toolbars[i].click();
+        }
+        found++;
+      }
+    }
+    var shareBtn = document.querySelector('button[data-dialog-trigger]');
+    if (shareBtn && (shareBtn.textContent || "").trim() === "Share") {
+      shareBtn.style.display = "none";
+      found++;
+    }
+    var expandLink = document.querySelector('a[title="Full Screen"]');
+    if (expandLink) {
+      expandLink.style.display = "none";
+      found++;
+    }
+    if (found >= 4) _cardsCleanedUp = true;
+  }
+
+  var _cardObserver = new MutationObserver(function() {
+    if (_cardsCleanedUp) { _cardObserver.disconnect(); return; }
+    _cleanupCards();
+  });
+  _cardObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _panesEqualized = false;
+  function _equalizePanes() {
+    if (_panesEqualized) return;
+    var resizer = document.getElementById("paneforge-3");
+    if (!resizer) return;
+    var prev = resizer.previousElementSibling;
+    var next = resizer.nextElementSibling;
+    if (!prev || !next) return;
+    prev.style.flexBasis = "50%";
+    next.style.flexBasis = "50%";
+    _panesEqualized = true;
+  }
+
+  var _paneObserver = new MutationObserver(function() {
+    if (_panesEqualized) { _paneObserver.disconnect(); return; }
+    _equalizePanes();
+  });
+  _paneObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  /* --- SVG Load Monitor + Diagram Selection (services 3 & 4) --- */
+
+  var _cachedEditor = null;
+
+  function _getMonacoEditor() {
+    if (_cachedEditor) {
+      try { if (_cachedEditor.getModel()) return _cachedEditor; } catch(ex) {}
+      _cachedEditor = null;
+    }
+    if (window.monaco && window.monaco.editor &&
+        typeof window.monaco.editor.getEditors === "function") {
+      var editors = window.monaco.editor.getEditors();
+      for (var i = 0; i < editors.length; i++) {
+        try {
+          if (editors[i] && typeof editors[i].getModel === "function" && editors[i].getModel()) {
+            _cachedEditor = editors[i];
+            console.log("[BRIDGE-SEL] Editor found via monaco.editor.getEditors() [" + i + "/" + editors.length + "]");
+            return _cachedEditor;
+          }
+        } catch(ex) {}
+      }
+      console.log("[BRIDGE-SEL] monaco.editor.getEditors() returned " + editors.length + " editor(s), none with a valid model");
+    } else {
+      console.log("[BRIDGE-SEL] window.monaco not available (AMD shim may not have triggered)");
+    }
+    return null;
+  }
+
+  var _entityDecodeEl = document.createElement("textarea");
+  function _decodeEntities(str) {
+    _entityDecodeEl.innerHTML = str;
+    return _entityDecodeEl.value;
+  }
+
+  function _normalizeText(text) {
+    var s = (text || "")
+      .replace(/<br\s*\/?>/gi, " ")
+      .replace(/<[^>]+>/g, "");
+    s = _decodeEntities(s);
+    s = s.replace(/\u00AB/g, "<<").replace(/\u00BB/g, ">>");
+    return s.replace(/\s+/g, " ").trim();
+  }
+
+  function _getContextHint(el) {
+    var node = el;
+    while (node && node !== document && node.nodeType === 1) {
+      if (node.id && node.tagName && node.tagName.toLowerCase() === "g") return node.id;
+      node = node.parentNode;
+    }
+    return "";
+  }
+
+  function _extractHintTokens(hint) {
+    if (!hint) return [];
+    var parts = hint.split("-");
+    var tokens = [];
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i];
+      if (/^\d+$/.test(p) || p.length <= 1) continue;
+      if (/^(classId|entity|state|flowchart)$/i.test(p)) continue;
+      tokens.push(p);
+    }
+    if (hint.length > 1 && tokens.indexOf(hint) === -1) tokens.unshift(hint);
+    return tokens;
+  }
+
+  function _pickBestMatch(matches, lines, contextHint) {
+    var tokens = _extractHintTokens(contextHint);
+    if (tokens.length === 0) return matches[0];
+    var best = matches[0];
+    var bestDist = 9999;
+    var bestAfter = false;
+    for (var m = 0; m < matches.length; m++) {
+      var mLine = matches[m].lineNumber - 1;
+      for (var t = 0; t < tokens.length; t++) {
+        for (var off = 0; off <= 10; off++) {
+          var above = mLine - off;
+          var below = mLine + off;
+          var foundAbove = above >= 0 && lines[above].indexOf(tokens[t]) !== -1;
+          var foundBelow = below < lines.length && lines[below].indexOf(tokens[t]) !== -1;
+          if (foundAbove || foundBelow) {
+            var isAfter = foundAbove && !foundBelow;
+            if (off < bestDist || (off === bestDist && isAfter && !bestAfter)) {
+              bestDist = off;
+              best = matches[m];
+              bestAfter = isAfter;
+            }
+          }
+        }
+      }
+    }
+    console.log("[BRIDGE-SEL] Disambiguated " + matches.length + " matches via hint '" + contextHint + "', best line " + best.lineNumber + " (dist=" + bestDist + ")");
+    return best;
+  }
+
+  function _findTextInCode(code, searchText, contextHint) {
+    if (!code || !searchText) { console.log("[BRIDGE-SEL] _findTextInCode: empty code or searchText"); return null; }
+    var normSearch = _normalizeText(searchText);
+    if (!normSearch) { console.log("[BRIDGE-SEL] _findTextInCode: normalized search is empty"); return null; }
+    console.log("[BRIDGE-SEL] Searching for: '" + normSearch + "' in " + code.split("\n").length + " lines");
+    var lines = code.split("\n");
+    var bracketMatches = [];
+    var wholeLineMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var bracketPatterns = [
+        /\["([^"]*?)"\]/g,
+        /\[([^\]]*?)\]/g,
+        /\("([^"]*?)"\)/g,
+        /\(([^)]*?)\)/g,
+        /\{"([^"]*?)"\}/g,
+        /\{([^}]*?)\}/g,
+        /\|"([^"]*?)"\|/g,
+        /\|([^|]*?)\|/g
+      ];
+      for (var p = 0; p < bracketPatterns.length; p++) {
+        var rx = bracketPatterns[p];
+        var m;
+        rx.lastIndex = 0;
+        while ((m = rx.exec(line)) !== null) {
+          var extracted = _normalizeText(m[1]);
+          if (extracted === normSearch) {
+            bracketMatches.push({
+              lineNumber: i + 1,
+              startColumn: m.index + 1,
+              endColumn: m.index + m[0].length + 1
+            });
+          }
+        }
+      }
+      var trimmed = line.trim();
+      if (_normalizeText(trimmed) === normSearch) {
+        var leadingSpaces = line.length - line.replace(/^\s+/, "").length;
+        wholeLineMatches.push({
+          lineNumber: i + 1,
+          startColumn: leadingSpaces + 1,
+          endColumn: line.length + 1
+        });
+      }
+    }
+    if (bracketMatches.length === 1 || (bracketMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (bracket) line " + bracketMatches[0].lineNumber);
+      return bracketMatches[0];
+    }
+    if (bracketMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + bracketMatches.length + " bracket matches, disambiguating");
+      return _pickBestMatch(bracketMatches, lines, contextHint);
+    }
+    if (wholeLineMatches.length === 1 || (wholeLineMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (whole-line) line " + wholeLineMatches[0].lineNumber);
+      return wholeLineMatches[0];
+    }
+    if (wholeLineMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + wholeLineMatches.length + " whole-line matches, disambiguating");
+      return _pickBestMatch(wholeLineMatches, lines, contextHint);
+    }
+    var subMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var idx = lines[i].indexOf(normSearch);
+      if (idx !== -1) {
+        subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+      }
+    }
+    if (subMatches.length === 0) {
+      var lower = normSearch.toLowerCase();
+      for (var i = 0; i < lines.length; i++) {
+        var idx = lines[i].toLowerCase().indexOf(lower);
+        if (idx !== -1) {
+          subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+        }
+      }
+      if (subMatches.length > 0) console.log("[BRIDGE-SEL] " + subMatches.length + " case-insensitive match(es) for '" + normSearch + "'");
+    }
+    if (subMatches.length === 0) {
+      console.log("[BRIDGE-SEL] NO MATCH found for '" + normSearch + "'");
+      return null;
+    }
+    if (subMatches.length === 1 || !contextHint) {
+      console.log("[BRIDGE-SEL] MATCH (substring) line " + subMatches[0].lineNumber + ": '" + normSearch + "'" + (subMatches.length > 1 ? " (" + subMatches.length + " candidates, no hint)" : ""));
+      return subMatches[0];
+    }
+    return _pickBestMatch(subMatches, lines, contextHint);
+  }
+
+  function _handleSvgTextClick(textContent, contextHint) {
+    console.log("[BRIDGE-SEL] Click handler fired, raw text: '" + textContent + "', hint: '" + (contextHint || "") + "'");
+    var code = _readEditorCode();
+    if (!code) { console.log("[BRIDGE-SEL] _readEditorCode returned empty"); return; }
+    console.log("[BRIDGE-SEL] Code length: " + code.length);
+    var match = _findTextInCode(code, textContent, contextHint);
+    if (!match) { console.log("[BRIDGE-SEL] No match found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Match: line=" + match.lineNumber + " col=" + match.startColumn + "-" + match.endColumn);
+    var editor = _getMonacoEditor();
+    if (!editor) { console.log("[BRIDGE-SEL] Monaco editor not found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Editor found, applying selection...");
+    try {
+      var sel = {
+        startLineNumber: match.lineNumber,
+        startColumn: match.startColumn,
+        endLineNumber: match.lineNumber,
+        endColumn: match.endColumn
+      };
+      editor.setSelection(sel);
+      editor.revealRangeInCenter(sel);
+      editor.focus();
+      console.log("[BRIDGE-SEL] Selection applied successfully");
+    } catch(ex) { console.log("[BRIDGE-SEL] Error applying selection:", ex); }
+  }
+
+  var _svgTextSelectors = [
+    "text.messageText",
+    "text.actor tspan",
+    "tspan.text-inner-tspan",
+    "text.packetLabel",
+    "text.packetTitle",
+    ".legend text",
+    "text.pieTitleText",
+    ".quadrant text",
+    ".data-point text",
+    ".labels .label text",
+    ".title text",
+    "text.radarAxisLabel",
+    "text.radarTitle",
+    "text.radarLegendText",
+    ".cluster-label .nodeLabel p",
+    ".label.name .nodeLabel p",
+    ".label.attribute-type .nodeLabel p",
+    ".label.attribute-name .nodeLabel p",
+    ".label-group .nodeLabel p",
+    ".members-group .nodeLabel p",
+    ".methods-group .nodeLabel p",
+    ".branchLabel text tspan",
+    "text.commit-label",
+    "text.taskText",
+    "text.sectionTitle tspan",
+    "text.titleText",
+    "g.person-man text tspan",
+    "tspan[alignment-baseline='mathematical']",
+    "g.node-labels text",
+    "g.timeline-node tspan",
+    "text.treemapSectionLabel",
+    "text.treemapLabel",
+    "text.legend tspan",
+    "g.chart-title text"
+  ];
+
+  function _attachClickHandlers() {
+    var container = document.querySelector("#container svg");
+    if (!container) { console.log("[BRIDGE-SEL] _attachClickHandlers: no #container svg"); return; }
+    var bound = 0;
+
+    var erTypeGroups = container.querySelectorAll("g.label.attribute-type");
+    for (var t = 0; t < erTypeGroups.length; t++) {
+      var typeG = erTypeGroups[t];
+      var typeP = typeG.querySelector(".nodeLabel p");
+      if (!typeP) continue;
+      var nameG = typeG.nextElementSibling;
+      while (nameG && !nameG.classList.contains("attribute-name")) {
+        nameG = nameG.nextElementSibling;
+      }
+      if (!nameG) continue;
+      var nameP = nameG.querySelector(".nodeLabel p");
+      if (!nameP) continue;
+      var typeText = (typeP.textContent || "").trim();
+      var nameText = (nameP.textContent || "").trim();
+      if (!typeText || !nameText) continue;
+      var combined = typeText + " " + nameText;
+      var hint = _getContextHint(typeP);
+      var pair = [typeP, nameP];
+      for (var e = 0; e < pair.length; e++) {
+        if (pair[e].dataset && pair[e].dataset.liveWysiwygClickBound) continue;
+        if (pair[e].dataset) pair[e].dataset.liveWysiwygClickBound = "1";
+        else pair[e].setAttribute("data-live-wysiwyg-click-bound", "1");
+        pair[e].style.cursor = "pointer";
+        pair[e].addEventListener("click", (function(combinedText, ctxHint) {
+          return function(ev) {
+            ev.stopPropagation();
+            _handleSvgTextClick(combinedText, ctxHint);
+          };
+        })(combined, hint));
+        bound++;
+      }
+    }
+
+    var htmlEls = container.querySelectorAll(
+      "g.node .nodeLabel p, g.edgeLabel .edgeLabel p, g.cluster-label .nodeLabel p, div.journey-section > div.label, div.task > div.label, .zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name"
+    );
+    for (var i = 0; i < htmlEls.length; i++) {
+      var el = htmlEls[i];
+      if (el.dataset && el.dataset.liveWysiwygClickBound) continue;
+      if (el.dataset) el.dataset.liveWysiwygClickBound = "1";
+      else el.setAttribute("data-live-wysiwyg-click-bound", "1");
+      el.style.cursor = "pointer";
+      el.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.innerHTML, _getContextHint(textEl));
+        };
+      })(el));
+      bound++;
+    }
+
+    var svgEls = container.querySelectorAll(_svgTextSelectors.join(", "));
+    for (var j = 0; j < svgEls.length; j++) {
+      var svgEl = svgEls[j];
+      if (svgEl.getAttribute("data-live-wysiwyg-click-bound")) continue;
+      var txt = (svgEl.textContent || "").trim();
+      if (!txt) continue;
+      svgEl.setAttribute("data-live-wysiwyg-click-bound", "1");
+      svgEl.style.cursor = "pointer";
+      svgEl.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, _getContextHint(textEl));
+        };
+      })(svgEl));
+      bound++;
+    }
+
+    var zenSel = ".zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name, .zenuml .fragment .header .collapsible-header > label";
+    var zenEls = document.querySelectorAll(zenSel);
+    for (var z = 0; z < zenEls.length; z++) {
+      var ze = zenEls[z];
+      if (ze.dataset && ze.dataset.liveWysiwygClickBound) continue;
+      ze.dataset.liveWysiwygClickBound = "1";
+      ze.style.cursor = "pointer";
+      ze.style.pointerEvents = "auto";
+      ze.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, "");
+        };
+      })(ze));
+      bound++;
+    }
+
+    console.log("[BRIDGE-SEL] Bound click handlers on " + bound + " new elements (" + htmlEls.length + " html + " + svgEls.length + " svg + " + zenEls.length + " zenuml candidates)");
+  }
+
+  function _svgHasContent(svg) {
+    return svg && (svg.querySelector("g.node") || svg.querySelector("text") || svg.querySelector(".root") || svg.querySelector("foreignObject"));
+  }
+
+  function _onSvgLoaded() {
+    console.log("[BRIDGE-SEL] SVG loaded, attaching click handlers");
+    _attachClickHandlers();
+    var container = document.querySelector("#container");
+    if (container) {
+      var observer = new MutationObserver(function() {
+        var svg = container.querySelector("svg");
+        if (_svgHasContent(svg)) {
+          console.log("[BRIDGE-SEL] SVG mutation detected, re-attaching click handlers");
+          _attachClickHandlers();
+        }
+      });
+      observer.observe(container, { childList: true, subtree: true });
+    }
+  }
+
+  function _monitorSvgLoad() {
+    var reloadKey = "live-wysiwyg-reload-count";
+    var reloadCount = 0;
+    try { reloadCount = parseInt(sessionStorage.getItem(reloadKey), 10) || 0; } catch(e) {}
+    var maxPolls = reloadCount < 3 ? 3 : 3 + (reloadCount - 2);
+    var polls = 0;
+    console.log("[BRIDGE-SEL] Starting SVG load monitor (attempt " + (reloadCount + 1) + ", timeout " + (maxPolls * 500) + "ms)");
+    var timer = setInterval(function() {
+      polls++;
+      var svg = document.querySelector("#container svg");
+      if (_svgHasContent(svg)) {
+        console.log("[BRIDGE-SEL] SVG confirmed loaded after " + polls + " poll(s)");
+        clearInterval(timer);
+        try { sessionStorage.removeItem(reloadKey); } catch(e) {}
+        _onSvgLoaded();
+        return;
+      }
+      if (polls >= maxPolls) {
+        console.log("[BRIDGE-SEL] SVG load timeout after " + maxPolls + " polls (attempt " + (reloadCount + 1) + "), reloading");
+        clearInterval(timer);
+        try { sessionStorage.setItem(reloadKey, String(reloadCount + 1)); } catch(e) {}
+        window.location.reload();
+      }
+    }, 500);
+  }
+
+  _monitorSvgLoad();
 })();
 </script></head>
   <body>

--- a/scripts/patch-mermaid-vendor.py
+++ b/scripts/patch-mermaid-vendor.py
@@ -26,7 +26,7 @@ BRIDGE_SCRIPT = r'''<script>
   /* ===================================================================
    * PostMessage Bridge + Keyboard Isolation Layer
    *
-   * Injected by patch P1 into edit.html and index.html.  Two services:
+   * Injected by patch P1 into edit.html and index.html.  Six services:
    *
    * 1. CONTENT SYNC — reads editor content from the mermaid-live-editor's
    *    localStorage ("codeStore" key) and PUTs it to the API server's
@@ -36,9 +36,43 @@ BRIDGE_SCRIPT = r'''<script>
    * 2. KEYBOARD ISOLATION — intercepts ESC, Ctrl+S, Ctrl+. at capture
    *    phase.  See DESIGN-centralized-keyboard.md § Mermaid Mode.
    *
+   * 3. SVG LOAD MONITOR — polls for the rendered SVG in #container to
+   *    confirm initial diagram load.  Reloads the iframe on timeout.
+   *    See DESIGN-mermaid-diagram-selection.md § Initial SVG Load Monitor.
+   *
+   * 4. DIAGRAM SELECTION — attaches click handlers to SVG text elements
+   *    (node labels + edge labels) that select the corresponding text in
+   *    the Monaco editor and scroll it into view.
+   *    See DESIGN-mermaid-diagram-selection.md.
+   *
+   * Sentinel: live-wysiwyg-mermaid-init (used by patch idempotency check)
+   *
+   * 5. LINK INTERCEPT + MENU CLEANUP — intercepts all <a> clicks,
+   *    blocks internal links (New, Duplicate), and forwards allowed
+   *    external URLs to the parent via postMessage for opening in a
+   *    new tab.  Uses a domain allow-list for security.
+   *
+   * 6. AMD GLOBAL SHIM — defines window.define.amd before Monaco loads
+   *    so that Monaco's conditional (typeof define==="function"&&define.amd)
+   *    evaluates to true and sets globalThis.monaco.  This gives the bridge
+   *    access to monaco.editor.getEditors() for editor instance discovery.
+   *    See DESIGN-monaco-subsystem.md § AMD Global Shim.
+   *
    * P8 (preventDefault override) neutralizes vendor preventDefault()
    * for parent-controlled shortcut keys as a defensive layer.
    * =================================================================== */
+
+  var _hideAiStyle = document.createElement("style");
+  _hideAiStyle.textContent =
+    ".button-container-for-animation { display: none !important; }" +
+    "[monaco-view-zone] { display: none !important; }" +
+    ".cgmr.suggestion-icon { display: none !important; }";
+  document.head.appendChild(_hideAiStyle);
+
+  if (typeof window.define !== "function") {
+    window.define = function() {};
+    window.define.amd = true;
+  }
 
   var _origPreventDefault = Event.prototype.preventDefault;
   Event.prototype.preventDefault = function() {
@@ -111,11 +145,26 @@ BRIDGE_SCRIPT = r'''<script>
       ".context-view",
       ".monaco-hover",
       ".find-widget.visible",
-      ".parameter-hints-widget.visible"
+      ".parameter-hints-widget.visible",
+      ".monaco-dialog-box",
+      ".rename-box",
+      ".monaco-menu",
+      ".quick-input-widget",
+      "[data-dialog-content]",
+      "[data-popover-content]"
     ];
     for (var i = 0; i < selectors.length; i++) {
       var el = document.querySelector(selectors[i]);
       if (el && _isActuallyVisible(el)) return true;
+    }
+    var shadowHosts = document.querySelectorAll(".shadow-root-host");
+    for (var s = 0; s < shadowHosts.length; s++) {
+      var sr = shadowHosts[s].shadowRoot;
+      if (!sr) continue;
+      for (var j = 0; j < selectors.length; j++) {
+        var shadowEl = sr.querySelector(selectors[j]);
+        if (shadowEl && _isActuallyVisible(shadowEl)) return true;
+      }
     }
     return false;
   }
@@ -136,13 +185,19 @@ BRIDGE_SCRIPT = r'''<script>
     }
   });
 
+  function _hasMultipleCursors() {
+    var cursors = document.querySelectorAll(".cursors-layer .cursor");
+    var visible = 0;
+    for (var i = 0; i < cursors.length; i++) {
+      if (cursors[i].offsetWidth > 0 || cursors[i].offsetHeight > 0) visible++;
+    }
+    return visible > 1;
+  }
+
   document.addEventListener("keydown", function(e) {
     if (e.key === "Escape") {
-      setTimeout(function() {
-        if (!_hasVisibleOverlay()) {
-          _closeAndSignal();
-        }
-      }, 50);
+      if (_hasVisibleOverlay() || _hasMultipleCursors()) return;
+      _closeAndSignal();
       return;
     }
     if ((e.ctrlKey || e.metaKey) && e.key === "s") {
@@ -155,6 +210,570 @@ BRIDGE_SCRIPT = r'''<script>
       return;
     }
   }, true);
+
+  /* --- Link Intercept + Menu Cleanup (service 6) --- */
+
+  var _allowedLinkDomains = [
+    "discord.com",
+    "discord.gg",
+    "github.com",
+    "mermaid.js.org"
+  ];
+
+  var _hiddenMenuLabels = ["New", "Duplicate"];
+
+  function _isAllowedUrl(href) {
+    try {
+      var u = new URL(href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return false;
+      for (var i = 0; i < _allowedLinkDomains.length; i++) {
+        var d = _allowedLinkDomains[i];
+        if (u.hostname === d || u.hostname.endsWith("." + d)) return true;
+      }
+    } catch(ex) {}
+    return false;
+  }
+
+  function _resolveHref(link) {
+    if (link.href && typeof link.href === "string") return link.href;
+    if (link.href && link.href.baseVal) return link.href.baseVal;
+    var h = link.getAttribute("href") || link.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+    return h || "";
+  }
+
+  document.addEventListener("click", function(e) {
+    var link = e.target.closest ? (e.target.closest("a[href]") || e.target.closest("a")) : null;
+    if (!link) return;
+    var href = _resolveHref(link);
+    if (!href) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (_isAllowedUrl(href)) {
+      try {
+        window.parent.postMessage({
+          type: "live-wysiwyg-open-url",
+          url: href
+        }, "*");
+      } catch(ex) {}
+    }
+  }, true);
+
+  function _cleanupMenu(popover) {
+    var links = popover.querySelectorAll("a");
+    for (var i = 0; i < links.length; i++) {
+      var text = (links[i].textContent || "").trim();
+      for (var h = 0; h < _hiddenMenuLabels.length; h++) {
+        if (text === _hiddenMenuLabels[h]) {
+          links[i].style.display = "none";
+          break;
+        }
+      }
+    }
+  }
+
+  var _menuObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-popover-content")) {
+          _cleanupMenu(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-popover-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupMenu(inner[k]);
+      }
+    }
+  });
+  _menuObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  function _cleanupPrivacyDialog(dialog) {
+    var paragraphs = dialog.querySelectorAll("p");
+    for (var i = 0; i < paragraphs.length; i++) {
+      var text = (paragraphs[i].textContent || "").trim();
+      if (text.indexOf("No privacy policy") === 0) {
+        paragraphs[i].textContent = "This is a custom Mermaid Live Editor built for mkdocs-live-wysiwyg plugin.";
+        var pFeature = document.createElement("p");
+        pFeature.textContent = "Exclusive to this editor: There's a new feature added which allows you to click on diagram elements.";
+        paragraphs[i].parentNode.insertBefore(pFeature, paragraphs[i].nextSibling);
+        var ul = document.createElement("ul");
+        var li1 = document.createElement("li");
+        li1.textContent = "Clicking elements will select text in the editor.";
+        ul.appendChild(li1);
+        var li2 = document.createElement("li");
+        li2.textContent = "The default layout has also been changed specifically for mkdocs-live-wysiwyg.";
+        ul.appendChild(li2);
+        pFeature.parentNode.insertBefore(ul, pFeature.nextSibling);
+        var pSelfHosted = document.createElement("p");
+        pSelfHosted.textContent = "This is a self-hosted instance (on your computer) of Mermaid Live Editor with no internet requirements.";
+        ul.parentNode.insertBefore(pSelfHosted, ul.nextSibling);
+      }
+      if (text.indexOf("If you are self-hosting") === 0) {
+        paragraphs[i].style.display = "none";
+      }
+    }
+  }
+
+  var _dialogObserver = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      var added = mutations[i].addedNodes;
+      for (var j = 0; j < added.length; j++) {
+        var node = added[j];
+        if (node.nodeType !== 1) continue;
+        if (node.hasAttribute && node.hasAttribute("data-dialog-content")) {
+          _cleanupPrivacyDialog(node);
+        }
+        var inner = node.querySelectorAll ? node.querySelectorAll("[data-dialog-content]") : [];
+        for (var k = 0; k < inner.length; k++) _cleanupPrivacyDialog(inner[k]);
+      }
+    }
+  });
+  _dialogObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _cardsCleanedUp = false;
+  function _cleanupCards() {
+    if (_cardsCleanedUp) return;
+    var toolbars = document.querySelectorAll('.card [role="toolbar"]');
+    var found = 0;
+    for (var i = 0; i < toolbars.length; i++) {
+      var text = (toolbars[i].textContent || "").trim();
+      var card = toolbars[i].closest(".card");
+      if (!card) continue;
+      if (text.indexOf("Actions") !== -1) {
+        card.style.display = "none";
+        found++;
+      }
+      if (text.indexOf("Sample Diagrams") !== -1) {
+        if (card.classList.contains("isOpen")) {
+          toolbars[i].click();
+        }
+        found++;
+      }
+    }
+    var shareBtn = document.querySelector('button[data-dialog-trigger]');
+    if (shareBtn && (shareBtn.textContent || "").trim() === "Share") {
+      shareBtn.style.display = "none";
+      found++;
+    }
+    var expandLink = document.querySelector('a[title="Full Screen"]');
+    if (expandLink) {
+      expandLink.style.display = "none";
+      found++;
+    }
+    if (found >= 4) _cardsCleanedUp = true;
+  }
+
+  var _cardObserver = new MutationObserver(function() {
+    if (_cardsCleanedUp) { _cardObserver.disconnect(); return; }
+    _cleanupCards();
+  });
+  _cardObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  var _panesEqualized = false;
+  function _equalizePanes() {
+    if (_panesEqualized) return;
+    var resizer = document.getElementById("paneforge-3");
+    if (!resizer) return;
+    var prev = resizer.previousElementSibling;
+    var next = resizer.nextElementSibling;
+    if (!prev || !next) return;
+    prev.style.flexBasis = "50%";
+    next.style.flexBasis = "50%";
+    _panesEqualized = true;
+  }
+
+  var _paneObserver = new MutationObserver(function() {
+    if (_panesEqualized) { _paneObserver.disconnect(); return; }
+    _equalizePanes();
+  });
+  _paneObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  /* --- SVG Load Monitor + Diagram Selection (services 3 & 4) --- */
+
+  var _cachedEditor = null;
+
+  function _getMonacoEditor() {
+    if (_cachedEditor) {
+      try { if (_cachedEditor.getModel()) return _cachedEditor; } catch(ex) {}
+      _cachedEditor = null;
+    }
+    if (window.monaco && window.monaco.editor &&
+        typeof window.monaco.editor.getEditors === "function") {
+      var editors = window.monaco.editor.getEditors();
+      for (var i = 0; i < editors.length; i++) {
+        try {
+          if (editors[i] && typeof editors[i].getModel === "function" && editors[i].getModel()) {
+            _cachedEditor = editors[i];
+            console.log("[BRIDGE-SEL] Editor found via monaco.editor.getEditors() [" + i + "/" + editors.length + "]");
+            return _cachedEditor;
+          }
+        } catch(ex) {}
+      }
+      console.log("[BRIDGE-SEL] monaco.editor.getEditors() returned " + editors.length + " editor(s), none with a valid model");
+    } else {
+      console.log("[BRIDGE-SEL] window.monaco not available (AMD shim may not have triggered)");
+    }
+    return null;
+  }
+
+  var _entityDecodeEl = document.createElement("textarea");
+  function _decodeEntities(str) {
+    _entityDecodeEl.innerHTML = str;
+    return _entityDecodeEl.value;
+  }
+
+  function _normalizeText(text) {
+    var s = (text || "")
+      .replace(/<br\s*\/?>/gi, " ")
+      .replace(/<[^>]+>/g, "");
+    s = _decodeEntities(s);
+    s = s.replace(/\u00AB/g, "<<").replace(/\u00BB/g, ">>");
+    return s.replace(/\s+/g, " ").trim();
+  }
+
+  function _getContextHint(el) {
+    var node = el;
+    while (node && node !== document && node.nodeType === 1) {
+      if (node.id && node.tagName && node.tagName.toLowerCase() === "g") return node.id;
+      node = node.parentNode;
+    }
+    return "";
+  }
+
+  function _extractHintTokens(hint) {
+    if (!hint) return [];
+    var parts = hint.split("-");
+    var tokens = [];
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i];
+      if (/^\d+$/.test(p) || p.length <= 1) continue;
+      if (/^(classId|entity|state|flowchart)$/i.test(p)) continue;
+      tokens.push(p);
+    }
+    if (hint.length > 1 && tokens.indexOf(hint) === -1) tokens.unshift(hint);
+    return tokens;
+  }
+
+  function _pickBestMatch(matches, lines, contextHint) {
+    var tokens = _extractHintTokens(contextHint);
+    if (tokens.length === 0) return matches[0];
+    var best = matches[0];
+    var bestDist = 9999;
+    var bestAfter = false;
+    for (var m = 0; m < matches.length; m++) {
+      var mLine = matches[m].lineNumber - 1;
+      for (var t = 0; t < tokens.length; t++) {
+        for (var off = 0; off <= 10; off++) {
+          var above = mLine - off;
+          var below = mLine + off;
+          var foundAbove = above >= 0 && lines[above].indexOf(tokens[t]) !== -1;
+          var foundBelow = below < lines.length && lines[below].indexOf(tokens[t]) !== -1;
+          if (foundAbove || foundBelow) {
+            var isAfter = foundAbove && !foundBelow;
+            if (off < bestDist || (off === bestDist && isAfter && !bestAfter)) {
+              bestDist = off;
+              best = matches[m];
+              bestAfter = isAfter;
+            }
+          }
+        }
+      }
+    }
+    console.log("[BRIDGE-SEL] Disambiguated " + matches.length + " matches via hint '" + contextHint + "', best line " + best.lineNumber + " (dist=" + bestDist + ")");
+    return best;
+  }
+
+  function _findTextInCode(code, searchText, contextHint) {
+    if (!code || !searchText) { console.log("[BRIDGE-SEL] _findTextInCode: empty code or searchText"); return null; }
+    var normSearch = _normalizeText(searchText);
+    if (!normSearch) { console.log("[BRIDGE-SEL] _findTextInCode: normalized search is empty"); return null; }
+    console.log("[BRIDGE-SEL] Searching for: '" + normSearch + "' in " + code.split("\n").length + " lines");
+    var lines = code.split("\n");
+    var bracketMatches = [];
+    var wholeLineMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var bracketPatterns = [
+        /\["([^"]*?)"\]/g,
+        /\[([^\]]*?)\]/g,
+        /\("([^"]*?)"\)/g,
+        /\(([^)]*?)\)/g,
+        /\{"([^"]*?)"\}/g,
+        /\{([^}]*?)\}/g,
+        /\|"([^"]*?)"\|/g,
+        /\|([^|]*?)\|/g
+      ];
+      for (var p = 0; p < bracketPatterns.length; p++) {
+        var rx = bracketPatterns[p];
+        var m;
+        rx.lastIndex = 0;
+        while ((m = rx.exec(line)) !== null) {
+          var extracted = _normalizeText(m[1]);
+          if (extracted === normSearch) {
+            bracketMatches.push({
+              lineNumber: i + 1,
+              startColumn: m.index + 1,
+              endColumn: m.index + m[0].length + 1
+            });
+          }
+        }
+      }
+      var trimmed = line.trim();
+      if (_normalizeText(trimmed) === normSearch) {
+        var leadingSpaces = line.length - line.replace(/^\s+/, "").length;
+        wholeLineMatches.push({
+          lineNumber: i + 1,
+          startColumn: leadingSpaces + 1,
+          endColumn: line.length + 1
+        });
+      }
+    }
+    if (bracketMatches.length === 1 || (bracketMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (bracket) line " + bracketMatches[0].lineNumber);
+      return bracketMatches[0];
+    }
+    if (bracketMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + bracketMatches.length + " bracket matches, disambiguating");
+      return _pickBestMatch(bracketMatches, lines, contextHint);
+    }
+    if (wholeLineMatches.length === 1 || (wholeLineMatches.length > 1 && !contextHint)) {
+      console.log("[BRIDGE-SEL] MATCH (whole-line) line " + wholeLineMatches[0].lineNumber);
+      return wholeLineMatches[0];
+    }
+    if (wholeLineMatches.length > 1) {
+      console.log("[BRIDGE-SEL] " + wholeLineMatches.length + " whole-line matches, disambiguating");
+      return _pickBestMatch(wholeLineMatches, lines, contextHint);
+    }
+    var subMatches = [];
+    for (var i = 0; i < lines.length; i++) {
+      var idx = lines[i].indexOf(normSearch);
+      if (idx !== -1) {
+        subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+      }
+    }
+    if (subMatches.length === 0) {
+      var lower = normSearch.toLowerCase();
+      for (var i = 0; i < lines.length; i++) {
+        var idx = lines[i].toLowerCase().indexOf(lower);
+        if (idx !== -1) {
+          subMatches.push({ lineNumber: i + 1, startColumn: idx + 1, endColumn: idx + normSearch.length + 1 });
+        }
+      }
+      if (subMatches.length > 0) console.log("[BRIDGE-SEL] " + subMatches.length + " case-insensitive match(es) for '" + normSearch + "'");
+    }
+    if (subMatches.length === 0) {
+      console.log("[BRIDGE-SEL] NO MATCH found for '" + normSearch + "'");
+      return null;
+    }
+    if (subMatches.length === 1 || !contextHint) {
+      console.log("[BRIDGE-SEL] MATCH (substring) line " + subMatches[0].lineNumber + ": '" + normSearch + "'" + (subMatches.length > 1 ? " (" + subMatches.length + " candidates, no hint)" : ""));
+      return subMatches[0];
+    }
+    return _pickBestMatch(subMatches, lines, contextHint);
+  }
+
+  function _handleSvgTextClick(textContent, contextHint) {
+    console.log("[BRIDGE-SEL] Click handler fired, raw text: '" + textContent + "', hint: '" + (contextHint || "") + "'");
+    var code = _readEditorCode();
+    if (!code) { console.log("[BRIDGE-SEL] _readEditorCode returned empty"); return; }
+    console.log("[BRIDGE-SEL] Code length: " + code.length);
+    var match = _findTextInCode(code, textContent, contextHint);
+    if (!match) { console.log("[BRIDGE-SEL] No match found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Match: line=" + match.lineNumber + " col=" + match.startColumn + "-" + match.endColumn);
+    var editor = _getMonacoEditor();
+    if (!editor) { console.log("[BRIDGE-SEL] Monaco editor not found, aborting"); return; }
+    console.log("[BRIDGE-SEL] Editor found, applying selection...");
+    try {
+      var sel = {
+        startLineNumber: match.lineNumber,
+        startColumn: match.startColumn,
+        endLineNumber: match.lineNumber,
+        endColumn: match.endColumn
+      };
+      editor.setSelection(sel);
+      editor.revealRangeInCenter(sel);
+      editor.focus();
+      console.log("[BRIDGE-SEL] Selection applied successfully");
+    } catch(ex) { console.log("[BRIDGE-SEL] Error applying selection:", ex); }
+  }
+
+  var _svgTextSelectors = [
+    "text.messageText",
+    "text.actor tspan",
+    "tspan.text-inner-tspan",
+    "text.packetLabel",
+    "text.packetTitle",
+    ".legend text",
+    "text.pieTitleText",
+    ".quadrant text",
+    ".data-point text",
+    ".labels .label text",
+    ".title text",
+    "text.radarAxisLabel",
+    "text.radarTitle",
+    "text.radarLegendText",
+    ".cluster-label .nodeLabel p",
+    ".label.name .nodeLabel p",
+    ".label.attribute-type .nodeLabel p",
+    ".label.attribute-name .nodeLabel p",
+    ".label-group .nodeLabel p",
+    ".members-group .nodeLabel p",
+    ".methods-group .nodeLabel p",
+    ".branchLabel text tspan",
+    "text.commit-label",
+    "text.taskText",
+    "text.sectionTitle tspan",
+    "text.titleText",
+    "g.person-man text tspan",
+    "tspan[alignment-baseline='mathematical']",
+    "g.node-labels text",
+    "g.timeline-node tspan",
+    "text.treemapSectionLabel",
+    "text.treemapLabel",
+    "text.legend tspan",
+    "g.chart-title text"
+  ];
+
+  function _attachClickHandlers() {
+    var container = document.querySelector("#container svg");
+    if (!container) { console.log("[BRIDGE-SEL] _attachClickHandlers: no #container svg"); return; }
+    var bound = 0;
+
+    var erTypeGroups = container.querySelectorAll("g.label.attribute-type");
+    for (var t = 0; t < erTypeGroups.length; t++) {
+      var typeG = erTypeGroups[t];
+      var typeP = typeG.querySelector(".nodeLabel p");
+      if (!typeP) continue;
+      var nameG = typeG.nextElementSibling;
+      while (nameG && !nameG.classList.contains("attribute-name")) {
+        nameG = nameG.nextElementSibling;
+      }
+      if (!nameG) continue;
+      var nameP = nameG.querySelector(".nodeLabel p");
+      if (!nameP) continue;
+      var typeText = (typeP.textContent || "").trim();
+      var nameText = (nameP.textContent || "").trim();
+      if (!typeText || !nameText) continue;
+      var combined = typeText + " " + nameText;
+      var hint = _getContextHint(typeP);
+      var pair = [typeP, nameP];
+      for (var e = 0; e < pair.length; e++) {
+        if (pair[e].dataset && pair[e].dataset.liveWysiwygClickBound) continue;
+        if (pair[e].dataset) pair[e].dataset.liveWysiwygClickBound = "1";
+        else pair[e].setAttribute("data-live-wysiwyg-click-bound", "1");
+        pair[e].style.cursor = "pointer";
+        pair[e].addEventListener("click", (function(combinedText, ctxHint) {
+          return function(ev) {
+            ev.stopPropagation();
+            _handleSvgTextClick(combinedText, ctxHint);
+          };
+        })(combined, hint));
+        bound++;
+      }
+    }
+
+    var htmlEls = container.querySelectorAll(
+      "g.node .nodeLabel p, g.edgeLabel .edgeLabel p, g.cluster-label .nodeLabel p, div.journey-section > div.label, div.task > div.label, .zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name"
+    );
+    for (var i = 0; i < htmlEls.length; i++) {
+      var el = htmlEls[i];
+      if (el.dataset && el.dataset.liveWysiwygClickBound) continue;
+      if (el.dataset) el.dataset.liveWysiwygClickBound = "1";
+      else el.setAttribute("data-live-wysiwyg-click-bound", "1");
+      el.style.cursor = "pointer";
+      el.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.innerHTML, _getContextHint(textEl));
+        };
+      })(el));
+      bound++;
+    }
+
+    var svgEls = container.querySelectorAll(_svgTextSelectors.join(", "));
+    for (var j = 0; j < svgEls.length; j++) {
+      var svgEl = svgEls[j];
+      if (svgEl.getAttribute("data-live-wysiwyg-click-bound")) continue;
+      var txt = (svgEl.textContent || "").trim();
+      if (!txt) continue;
+      svgEl.setAttribute("data-live-wysiwyg-click-bound", "1");
+      svgEl.style.cursor = "pointer";
+      svgEl.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, _getContextHint(textEl));
+        };
+      })(svgEl));
+      bound++;
+    }
+
+    var zenSel = ".zenuml label.name, .zenuml label.condition, .zenuml label.interface, .zenuml div.title.text-skin-title, .zenuml span.text-skin-lifeline-group-name, .zenuml .message > .name, .zenuml .fragment .header .collapsible-header > label";
+    var zenEls = document.querySelectorAll(zenSel);
+    for (var z = 0; z < zenEls.length; z++) {
+      var ze = zenEls[z];
+      if (ze.dataset && ze.dataset.liveWysiwygClickBound) continue;
+      ze.dataset.liveWysiwygClickBound = "1";
+      ze.style.cursor = "pointer";
+      ze.style.pointerEvents = "auto";
+      ze.addEventListener("click", (function(textEl) {
+        return function(e) {
+          e.stopPropagation();
+          _handleSvgTextClick(textEl.textContent, "");
+        };
+      })(ze));
+      bound++;
+    }
+
+    console.log("[BRIDGE-SEL] Bound click handlers on " + bound + " new elements (" + htmlEls.length + " html + " + svgEls.length + " svg + " + zenEls.length + " zenuml candidates)");
+  }
+
+  function _svgHasContent(svg) {
+    return svg && (svg.querySelector("g.node") || svg.querySelector("text") || svg.querySelector(".root") || svg.querySelector("foreignObject"));
+  }
+
+  function _onSvgLoaded() {
+    console.log("[BRIDGE-SEL] SVG loaded, attaching click handlers");
+    _attachClickHandlers();
+    var container = document.querySelector("#container");
+    if (container) {
+      var observer = new MutationObserver(function() {
+        var svg = container.querySelector("svg");
+        if (_svgHasContent(svg)) {
+          console.log("[BRIDGE-SEL] SVG mutation detected, re-attaching click handlers");
+          _attachClickHandlers();
+        }
+      });
+      observer.observe(container, { childList: true, subtree: true });
+    }
+  }
+
+  function _monitorSvgLoad() {
+    var reloadKey = "live-wysiwyg-reload-count";
+    var reloadCount = 0;
+    try { reloadCount = parseInt(sessionStorage.getItem(reloadKey), 10) || 0; } catch(e) {}
+    var maxPolls = reloadCount < 3 ? 3 : 3 + (reloadCount - 2);
+    var polls = 0;
+    console.log("[BRIDGE-SEL] Starting SVG load monitor (attempt " + (reloadCount + 1) + ", timeout " + (maxPolls * 500) + "ms)");
+    var timer = setInterval(function() {
+      polls++;
+      var svg = document.querySelector("#container svg");
+      if (_svgHasContent(svg)) {
+        console.log("[BRIDGE-SEL] SVG confirmed loaded after " + polls + " poll(s)");
+        clearInterval(timer);
+        try { sessionStorage.removeItem(reloadKey); } catch(e) {}
+        _onSvgLoaded();
+        return;
+      }
+      if (polls >= maxPolls) {
+        console.log("[BRIDGE-SEL] SVG load timeout after " + maxPolls + " polls (attempt " + (reloadCount + 1) + "), reloading");
+        clearInterval(timer);
+        try { sessionStorage.setItem(reloadKey, String(reloadCount + 1)); } catch(e) {}
+        window.location.reload();
+      }
+    }, 500);
+  }
+
+  _monitorSvgLoad();
 })();
 </script>'''
 


### PR DESCRIPTION
Mermaid live editor UI changes
------------------------------

The Mermaid Live Editor UI is updated so that it's a little cleaner for its purpose.

- "Data Security" dialog updated so that changes are disclosed to the user.
- Links (within an acceptable allow list QA purposes) now always open in a new tab outside of the iframe so that users can visit the mermaid JS website.
- Irrelevant elements are completely hidden
  - Including: Some elements of mermaid AI have been removed since they're confusing and do not actually do anything in the vendored software.  This is intended for the mermaid live editor hosted on the web.
  - Sharable links and other links and elements which don't make sense.
  - Actions (paneforge toolbar) menu is removed.
  - Hamburger menu has elements removed.
  - Fullscreen button removed since the editor is already fullscreen and full screen didn't work when clicked (not intended for this purpose).

UI defaults changed
-------------------

- Diagram from WYSIWYG is loaded instead of default diagram.
- Mermaid Text Editor pane is now 50% with the SVG.  The editor was too small to be reasonable by default.
- Sample Diagrams toolbar is collapsed by default.

New Live Editor Feature!
------------------------

Unique to this mkdocs-live-wysiwyg plugin: Clicking on the SVG now selects relevant text in the editor.

Editing diagrams specifically in this version are a lot easier than any other mermaid editor I've tried including the officially hosted one.

All 22 diagram types have been tested and "click to selection" support has been added across all.

Worth noting that not all diagram types are supported by mkdocs Material.  However, full support has been intentionally kept since `techdocs-preview.sh` can be used to edit any markdown files such as project README files.

New design documents
--------------------

- Monaco Subsystem
- Mermaid Diagram Selection Heuristics